### PR TITLE
chore: establish project license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Poimandres
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/packages/font-baker.md
+++ b/docs/packages/font-baker.md
@@ -5,7 +5,7 @@ description: Implements the internal portable Rust/Wasm shaping-resource bake co
 resource: ../../packages/font-baker
 workspace_package: '@pmndrs/text-font-baker'
 documentation_type: reference
-source_digest: 'sha256:afbed02ebea19c3d25813c0d85a503913d387b9ab37a7d049f7cbc9332cf9c5d'
+source_digest: 'sha256:eee9ea57d7a9c47bc3483963aa2dd206c66647d3d72422cd534a4c12d185728e'
 tags: [package, rust, wasm, baking, internal]
 sources:
   - id: manifest

--- a/docs/packages/text.md
+++ b/docs/packages/text.md
@@ -5,7 +5,7 @@ description: Implements public font loading, shaping, paragraph measurement, sta
 resource: ../../packages/text
 workspace_package: '@pmndrs/text'
 documentation_type: reference
-source_digest: 'sha256:fbc1471ca2fd4d9f8cffe116697ed47fb46f7fe5b2cfe6938acca811ab910de8'
+source_digest: 'sha256:c9885dd54360150754b6592d705d7822feae8a603537d64aaf62308c6d2a084a'
 tags: [package, public-api, typescript, contracts]
 sources:
   - id: manifest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "pmndrs-text-workspace",
   "private": true,
+  "license": "MIT",
+  "author": "Justin Walsh (https://github.com/thejustinwalsh)",
   "type": "module",
   "scripts": {
     "build": "pnpm --filter './packages/*' build && pnpm --filter './apps/*' build",

--- a/packages/font-baker/LICENSE
+++ b/packages/font-baker/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Poimandres
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/font-baker/package.json
+++ b/packages/font-baker/package.json
@@ -2,6 +2,8 @@
   "name": "@pmndrs/text-font-baker",
   "version": "0.0.0",
   "private": true,
+  "license": "MIT",
+  "author": "Justin Walsh (https://github.com/thejustinwalsh)",
   "files": [
     "dist"
   ],

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -2,6 +2,8 @@
   "name": "@pmndrs/text",
   "version": "0.0.0",
   "private": true,
+  "license": "MIT",
+  "author": "Justin Walsh (https://github.com/thejustinwalsh)",
   "bin": {
     "pmndrs-text-bake": "./dist/node/cli.js"
   },

--- a/packages/text/tests/package/packed-package.test.mjs
+++ b/packages/text/tests/package/packed-package.test.mjs
@@ -32,7 +32,15 @@ test('the packed package exposes every ESM subpath and no CommonJS entry', async
   assert.equal(packedFiles.includes('dist/mtsdf-baker-abi-v1.json'), true);
   assert.equal(packedFiles.includes('dist/slug-baker-abi-v1.json'), false);
   assert.equal(packedFiles.includes('dist/slug-baker-abi-v0.json'), true);
-  assert.deepEqual([...new Set(packedFiles.map((path) => path.split('/')[0]))].sort(), ['dist', 'package.json']);
+  assert.deepEqual([...new Set(packedFiles.map((path) => path.split('/')[0]))].sort(), [
+    'LICENSE',
+    'dist',
+    'package.json',
+  ]);
+  assert.equal(
+    await readFile(join(installedDirectory, 'LICENSE'), 'utf8'),
+    await readFile(join(packageDirectory, '..', '..', 'LICENSE'), 'utf8'),
+  );
   const consumerEntry = pathToFileURL(join(temporaryDirectory, 'consumer', 'entry.mjs')).href;
   const moduleSubpaths = Object.entries(manifest.exports)
     .filter(([, target]) => typeof target === 'object' && target !== null)


### PR DESCRIPTION
## Summary

- add the Poimandres MIT license at the repository root
- record Justin Walsh as the original author in workspace package metadata
- ship the project license from the core and font-baker package tarballs
- require the packed core license to match the repository license exactly
- preserve the independent Khronos schema notice

## Verification

- focused Oxfmt check passes
- OKF validation passes with refreshed package digests
- package dry-runs include the project LICENSE
- root and font-baker project license texts are byte-identical