### PR TITLE
test(glyph): cover the metrics-only run-topology split from #66

### DIFF
--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:f0d02444415a88d11af570a4dd49ef7681316756fd3aa9e3a6f7d7ea09d96c82'
+source_digest: 'sha256:5d9e3d71131a7bc1206842e1be7e9a5799a27ec8e2a64831e78acb158aa4ff96'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/packages/glyph/tests/integration/three-engine-runtime.test.mjs
+++ b/packages/glyph/tests/integration/three-engine-runtime.test.mjs
@@ -1043,6 +1043,131 @@ test('Three coordinator shares shaping data across technique bindings and refere
   decorationTarget.dispose();
   decorationSession.dispose();
 
+  // Regression canary: a colored span whose fontSize animates through value-equality
+  // with its root keeps its style segment (the paint differs) while the shaping-run
+  // table merges across it -- `same_layout_style` compares layout scalars and ignores
+  // paint, and `font_size` is one of those scalars. When the next tick moves the size
+  // off equality the table splits again under metrics-only invalidation. The engine
+  // once retained the merged shape against the rebuilt table and rejected every later
+  // frame with invalidRequest, poisoning the session; `shaping_run_topology_stable`
+  // in engine/state.rs was added to stop that.
+  //
+  // This drives the merge -> split path end to end and asserts the session stays
+  // healthy across it. It does not isolate that one guard: forcing
+  // `shaping_run_topology_stable` to return `true` -- the pre-fix behaviour -- leaves
+  // this green, so a later path absorbs the split as well. Treat it as a canary over
+  // the whole retained-shape path rather than as proof of a single predicate.
+  const topologySession = coordinator.createSession({
+    requestCapacity: 8_192,
+    resultCapacity: 1024 * 1024,
+    textCapacity: 64,
+  });
+  const topologyStyles = (spanSize) => [
+    {
+      opcode: 'upsert',
+      paragraphId: 1,
+      styleId: 1,
+      cascadeOrder: 0,
+      start: 0,
+      end: 24,
+      root: true,
+      value: {
+        fontStackHandle: first.handle,
+        materialId: primaryMaterial.id,
+        fontSize: 16,
+        rasterPixelRatio: 1,
+        foregroundRgba: 0xffff_ffff,
+      },
+    },
+    {
+      opcode: 'upsert',
+      paragraphId: 1,
+      styleId: 2,
+      cascadeOrder: 1,
+      start: 8,
+      end: 16,
+      value: { fontSize: spanSize, foregroundRgba: 0xff44_22ff },
+    },
+  ];
+  const topologyFrame = (previous, spanSize, extra = {}) =>
+    compileTextEngineFrameUpdate({
+      sessionId: topologySession.handle,
+      policyHandle: coordinator.policyHandle,
+      capabilitySet: 1,
+      expectedEngineRevision: previous?.engineRevision ?? 0,
+      consumedPlanRevision: previous?.planRevision ?? 0,
+      acknowledgedPublicationGeneration: previous?.publicationGeneration ?? 0,
+      limits: {
+        maxParagraphs: 1,
+        maxClusters: 32,
+        maxLines: 8,
+        maxRegions: 1,
+        maxExclusions: 1,
+        maxInlineObjects: 1,
+        maxSlotsPerBand: 2,
+        maxOutputBytes: 1024 * 1024,
+      },
+      styleMutations: topologyStyles(spanSize),
+      ...extra,
+    });
+  // Frame 1: the span size equals the root — shaping runs merge across the span.
+  const topologyFirst = topologySession.update(
+    topologyFrame(undefined, 16, {
+      paragraphMutations: [{ opcode: 'upsert', paragraphId: 1, order: 0 }],
+      textMutations: [{ paragraphId: 1, start: 0, deleteCount: 0, insert: 'alpha beta gamma epsilon' }],
+      constraints: [
+        {
+          paragraphId: 1,
+          flowThreadId: 1,
+          geometryRevision: 1,
+          width: 512,
+          height: 128,
+          viewportBlockStart: 0,
+          viewportBlockEnd: 128,
+          resumeBlockOffset: 0,
+          maxLines: 8,
+          regionStart: 0,
+          resumeCluster: 0,
+          regionCount: 1,
+          resumeRegion: 0,
+          widthMode: 'at-most',
+          heightMode: 'at-most',
+          wrap: 'word',
+          align: 'start',
+          overflow: 'visible',
+          blockAlign: 'start',
+        },
+      ],
+      regions: [
+        {
+          id: 1,
+          geometryRevision: 1,
+          shape: 'rectangle',
+          exclusionStart: 0,
+          exclusionCount: 0,
+          writingMode: 'horizontal-tb',
+          textOrientation: 'mixed',
+          inlineStart: 0,
+          blockStart: 0,
+          inlineEnd: 512,
+          blockEnd: 128,
+          clipInlineStart: 0,
+          clipBlockStart: 0,
+          clipInlineEnd: 512,
+          clipBlockEnd: 128,
+        },
+      ],
+    }),
+  );
+  // Frame 2: the span size moves off equality — the run table splits again and the
+  // retained shape must be rebuilt, not reused.
+  const topologySecond = topologySession.update(topologyFrame(topologyFirst, 17.5));
+  assert.equal(topologySecond.engineRevision, topologyFirst.engineRevision + 1);
+  // Frame 3: and the session must remain healthy afterwards.
+  const topologyThird = topologySession.update(topologyFrame(topologySecond, 18.25));
+  assert.equal(topologyThird.engineRevision, topologySecond.engineRevision + 1);
+  topologySession.dispose();
+
   target.dispose();
   session.dispose();
   first.release();


### PR DESCRIPTION
Ports the regression scenario from #66, which targets the pre-rename `packages/text` tree and therefore can never merge. The fix it guards (`shaping_run_topology_stable`) is already on `main` at `packages/glyph/rust/shaper/src/engine/state.rs:1246`; only the test was left behind.

## The scenario

A colored span whose `fontSize` animates through value-equality with its root keeps its style segment (the paint differs) while the shaping-run table merges across it. Runs coalesce on `same_layout_style`, which compares layout scalars and ignores paint:

```rust
// shaping_state.rs:240
&& style_storage.same_layout_style(previous.style, run.style)

// style_state.rs:154 — font_size is a layout scalar
&& self.font_size.to_bits() == other.font_size.to_bits()
```

So frame 1 (span size == root, different color) merges to one run, and frame 2 (17.5) splits back to three under metrics-only invalidation. The engine once retained the merged shape against the rebuilt table and rejected every later frame with `invalidRequest`, poisoning the session.

## What this test does and does not prove

It drives the merge → split path end to end and asserts the session stays healthy across three frames.

It does **not** isolate `shaping_run_topology_stable`. Forcing that function to `return true` — the pre-fix behaviour — and rebuilding the shaper leaves the entire `three-engine-runtime` suite green, including this scenario. Some later path absorbs the split as well; the most likely candidate is the `refresh_scales_from_stream` fallback dropping through to a full rebuild, though that is unverified.

The test therefore lands as a canary over the retained-shape path, and its comment says exactly that rather than claiming a proof it does not deliver.

## Follow-up worth taking separately

`shaping_run_topology_stable` has no other coverage — no Rust test exercises it (the only topology test in the crate covers the unrelated `same_edit_run_topology`). Combined with the result above, it is worth determining whether the guard plus its two call sites are now redundant. That has a size payoff and belongs with the open items from the Wasm size study, not in this PR.

## Verification

- `node --test tests/integration/three-engine-runtime.test.mjs` — 1 test, 1 pass
- `pnpm check` — exit 0, OKF 0 errors / 0 warnings
- `docs/packages/glyph.md` `source_digest` regenerated for the new package source

Closes #66.
