### PR TITLE
fix(benchmarks): fail runVitexec when a probe throws

### DIFF
--- a/apps/benchmarks/scripts/support/command-cli.mts
+++ b/apps/benchmarks/scripts/support/command-cli.mts
@@ -1,6 +1,8 @@
 import { spawn } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { hasVitexecFailure } from '../workflow-output.mts';
+
 const applicationRoot = fileURLToPath(new URL('../..', import.meta.url));
 
 export function isMainModule(metaUrl: string): boolean {
@@ -13,7 +15,30 @@ export async function runNodeScript(script: string, arguments_: readonly string[
 }
 
 export async function runVitexec(arguments_: readonly string[]): Promise<void> {
-  await runNodeScript('node_modules/vitexec/dist/cli.js', arguments_);
+  const probe = arguments_.find((value) => value.endsWith('.probe.ts')) ?? 'probe';
+  const output = await runCapturing(process.execPath, ['node_modules/vitexec/dist/cli.js', ...arguments_]);
+  // Vitexec exits 0 even when the injected module throws, so the exit status alone passes a probe
+  // that never ran to completion.
+  if (hasVitexecFailure(output)) throw new Error(`${probe} reported a browser error`);
+}
+
+export async function runCapturing(command: string, arguments_: readonly string[]): Promise<string> {
+  return await new Promise<string>((resolveRun, reject) => {
+    const child = spawn(command, arguments_, { cwd: applicationRoot, stdio: ['inherit', 'pipe', 'pipe'] });
+    let output = '';
+    for (const stream of [child.stdout, child.stderr]) {
+      stream.setEncoding('utf8');
+      stream.on('data', (chunk: string) => {
+        output += chunk;
+        process.stdout.write(chunk);
+      });
+    }
+    child.on('error', reject);
+    child.on('close', (code: number | null) => {
+      if (code === 0) resolveRun(output);
+      else reject(new Error(`${command} exited with ${String(code)}`));
+    });
+  });
 }
 
 export async function buildRuntimePackages(): Promise<void> {

--- a/docs/packages/benchmarks.md
+++ b/docs/packages/benchmarks.md
@@ -5,7 +5,7 @@ description: Provides the shared interactive and automated benchmark product sur
 resource: ../../apps/benchmarks
 workspace_package: '@pmndrs/glyph-benchmarks'
 documentation_type: reference
-source_digest: 'sha256:0e16e5ed09fcc6fbd590361406d19e02a615cbceb261b2fe7cd76fd110780c5a'
+source_digest: 'sha256:90e7a0806a43bc572419755bf00abbbcb85e225b72b61424e10c02a98d00f44b'
 tags: [package, benchmarks, react, vite, product-e2e]
 sources:
   - id: manifest


### PR DESCRIPTION
`vitexec` 0.1.17 reports an injected-module failure as an `[error]` browser log and **exits 0**, so a probe that throws passes the gate it exists to enforce.

Proven directly — a probe whose only statement is `throw new Error('BOOM_UNCAUGHT')`:

```
exit=0
logs:
[log] probe-marker-before
[error] BOOM_UNCAUGHT
```

This is not hypothetical. It is why the R3F alpha.3 click regression in #91 stayed invisible: the probe threw `did not settle the bitmap technique` on every run while `live:check` reported success, and the failure was visible only by reading the log.

## Scope

Two of the three vitexec entry points already handled this:

| entry point | before |
|---|---|
| `capture-slug-external-render-parity.mts` | checks the transcript **and** requires its result marker |
| `workflows.mts` | routes through `hasVitexecFailure` |
| `support/command-cli.mts` → `runVitexec` | **exit code only** |

So `run-raster-technique-compare` could throw without failing its lane. `runVitexec` now captures output and reuses the existing `hasVitexecFailure` — whose pattern also matches `[page error]` — rather than adding a second detector beside it.

## Verification

Both directions, against real probes:

```
throwing probe → threw -> ./vitexec/boom.probe.ts reported a browser error
healthy probe  → resolved (no failure detected)
```

`pnpm check` — exit 0, OKF 0 errors / 0 warnings.
