### PR TITLE
chore(glyph)!: hyphenate the distributed Wasm filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,10 +145,10 @@ jobs:
         with:
           name: wasm-failure-evidence
           path: |
-            packages/glyph/dist/font_baker.wasm
-            packages/glyph/dist/bitmap_baker.wasm
-            packages/glyph/dist/mtsdf_baker.wasm
-            packages/glyph/dist/slug_baker.wasm
-            packages/glyph/dist/text_shaper.wasm
+            packages/glyph/dist/font-baker.wasm
+            packages/glyph/dist/bitmap-baker.wasm
+            packages/glyph/dist/mtsdf-baker.wasm
+            packages/glyph/dist/slug-baker.wasm
+            packages/glyph/dist/text-shaper.wasm
           if-no-files-found: error
           retention-days: 7

--- a/apps/benchmarks/scripts/generate-paragraph-cjk-contract.mts
+++ b/apps/benchmarks/scripts/generate-paragraph-cjk-contract.mts
@@ -27,7 +27,7 @@ const coverage = Object.values(retained.cases)
   .replace(/[\u{FE00}-\u{FE0F}\u{E0100}-\u{E01EF}]/gu, '');
 const [source, bakerWasm] = await Promise.all([
   readFile(new URL('../fixtures/fonts/noto-sans-cjk-2.004/NotoSansCJKjp-Regular.otf', import.meta.url)),
-  readFile(new URL('../../../packages/glyph/dist/font_baker.wasm', import.meta.url)),
+  readFile(new URL('../../../packages/glyph/dist/font-baker.wasm', import.meta.url)),
 ]);
 const baker = await createFontBaker(bakerWasm);
 const artifact = baker.bake({ source, descriptor: { formatVersion: 0, fontFaceIndex: 0 } }).artifacts[0];

--- a/apps/benchmarks/scripts/measure-package-sizes.mts
+++ b/apps/benchmarks/scripts/measure-package-sizes.mts
@@ -71,11 +71,11 @@ async function bundle(
             name: 'externalize-package-wasm-for-size-measurement',
             transform(code, id) {
               const wasmAssets = [
-                'bitmap_baker.wasm',
-                'font_baker.wasm',
-                'text_shaper.wasm',
-                'mtsdf_baker.wasm',
-                'slug_baker.wasm',
+                'bitmap-baker.wasm',
+                'font-baker.wasm',
+                'text-shaper.wasm',
+                'mtsdf-baker.wasm',
+                'slug-baker.wasm',
               ];
               let transformed = code;
               let changed = false;
@@ -359,7 +359,7 @@ const coreJavaScript = await measureJavaScript(
 const textShaperWasm = await measureWasm(
   'text-shaper-wasm',
   'Shaper Wasm',
-  new URL('../../../packages/glyph/dist/text_shaper.wasm', import.meta.url),
+  new URL('../../../packages/glyph/dist/text-shaper.wasm', import.meta.url),
 );
 const coreSubpath = await measureJavaScript(
   'core-subpath-js',
@@ -494,7 +494,7 @@ const entries: SizeEntry[] = [
   await measureWasm(
     'bitmap-baker-wasm',
     'Bitmap baker Wasm',
-    new URL('../../../packages/glyph/dist/bitmap_baker.wasm', import.meta.url),
+    new URL('../../../packages/glyph/dist/bitmap-baker.wasm', import.meta.url),
   ),
   await measureJavaScript(
     'bitmap-baker-js',
@@ -515,7 +515,7 @@ const entries: SizeEntry[] = [
   await measureWasm(
     'mtsdf-baker-wasm',
     'MTSDF baker Wasm',
-    new URL('../../../packages/glyph/dist/mtsdf_baker.wasm', import.meta.url),
+    new URL('../../../packages/glyph/dist/mtsdf-baker.wasm', import.meta.url),
   ),
   await measureJavaScript(
     'mtsdf-baker-js',
@@ -530,7 +530,7 @@ const entries: SizeEntry[] = [
   await measureWasm(
     'slug-baker-wasm',
     'Slug baker Wasm',
-    new URL('../../../packages/glyph/dist/slug_baker.wasm', import.meta.url),
+    new URL('../../../packages/glyph/dist/slug-baker.wasm', import.meta.url),
   ),
   await measureJavaScript(
     'slug-baker-js',
@@ -551,7 +551,7 @@ const entries: SizeEntry[] = [
   await measureWasm(
     'portable-baker-wasm',
     'Font baker Wasm',
-    new URL('../../../packages/glyph/dist/font_baker.wasm', import.meta.url),
+    new URL('../../../packages/glyph/dist/font-baker.wasm', import.meta.url),
   ),
   await measureJavaScript(
     'unicode-analysis-js',

--- a/apps/benchmarks/scripts/support/paragraph-contract-runtime.mts
+++ b/apps/benchmarks/scripts/support/paragraph-contract-runtime.mts
@@ -33,7 +33,7 @@ export async function createParagraphContractRuntime() {
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../../../packages/glyph/dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../../../packages/glyph/dist/text-shaper.wasm', import.meta.url)),
   });
   return {
     async loadFont(url: URL, coverage?: string) {

--- a/apps/benchmarks/src/generated/package-sizes.json
+++ b/apps/benchmarks/src/generated/package-sizes.json
@@ -10,11 +10,11 @@
       "label": "Renderer-neutral core JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "36b55b752cbf9b1e1dc131b2895877222314514f06711acc84615fab3030160e",
+      "sha256": "359fc27465c1c42d752e72ab83cc472df7f68bc6a6d1b4c8e54e1ae20e3b8de5",
       "rawBytes": 231670,
       "minifiedBytes": 157263,
-      "gzipBytes": 39662,
-      "brotliBytes": 33730
+      "gzipBytes": 39661,
+      "brotliBytes": 33670
     },
     {
       "id": "tsl-subpath-js",
@@ -32,11 +32,11 @@
       "label": "Core JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "057f086615eb2f9c0b52baed72dcf890469390e668395fb0cbda95b46b4217e6",
+      "sha256": "db91a09aaec56dcfd41e86fdbcf4ea80ccd45f62e3f225c49b4dd75498d08e72",
       "rawBytes": 96480,
       "minifiedBytes": 68711,
-      "gzipBytes": 19203,
-      "brotliBytes": 16645
+      "gzipBytes": 19201,
+      "brotliBytes": 16644
     },
     {
       "id": "text-shaper-wasm",
@@ -54,11 +54,11 @@
       "label": "Three.js adapter JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "6b139a3d68eaa5dc364ad2fd45cb466d9c4352509498fe29b85862657b8d3ab3",
+      "sha256": "fd7bc6180c6a9284dcbd2fb81468427fa830729bcdc6ae96d43adbe8b1f9027a",
       "rawBytes": 376899,
       "minifiedBytes": 244764,
-      "gzipBytes": 62850,
-      "brotliBytes": 53023
+      "gzipBytes": 62847,
+      "brotliBytes": 53053
     },
     {
       "id": "font-inter-bitmap-16-32",
@@ -153,11 +153,11 @@
       "label": "Runtime bake Worker JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "aec7b94debde8a0ce9ed6ed751c7775158c0ebc9a806d7f1ee03c88204a08cc7",
+      "sha256": "029914c54dddc8be7a284785c0fc7983979d2b9e751fb180cf170a1b0139be6c",
       "rawBytes": 782444,
       "minifiedBytes": 613617,
       "gzipBytes": 145901,
-      "brotliBytes": 119829
+      "brotliBytes": 119881
     },
     {
       "id": "bitmap-runtime-js",
@@ -274,11 +274,11 @@
       "label": "Slug baker JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "327ce803557f620c5ab33e3c5b5d1ca046acb7f534e4245f610dc0bd427b6df1",
+      "sha256": "6232efefeae5a9eb171ec646c3809292e3a7ec86b205790cdb85267fcc1dd4b4",
       "rawBytes": 18661,
       "minifiedBytes": 12896,
-      "gzipBytes": 4114,
-      "brotliBytes": 3663
+      "gzipBytes": 4113,
+      "brotliBytes": 3662
     },
     {
       "id": "portable-baker-js",

--- a/docs/packages/benchmarks.md
+++ b/docs/packages/benchmarks.md
@@ -5,7 +5,7 @@ description: Provides the shared interactive and automated benchmark product sur
 resource: ../../apps/benchmarks
 workspace_package: '@pmndrs/glyph-benchmarks'
 documentation_type: reference
-source_digest: 'sha256:90e7a0806a43bc572419755bf00abbbcb85e225b72b61424e10c02a98d00f44b'
+source_digest: 'sha256:6572bf5675c8dbcc0284fe88e53b0eb101b06e521e0da33ea6284e7184173c9c'
 tags: [package, benchmarks, react, vite, product-e2e]
 sources:
   - id: manifest

--- a/docs/packages/glyph-example-raster.md
+++ b/docs/packages/glyph-example-raster.md
@@ -5,7 +5,7 @@ description: Proves the published raster and baker extension boundary with a pri
 resource: ../../packages/glyph-example-raster
 workspace_package: '@pmndrs/glyph-example-raster'
 documentation_type: reference
-source_digest: 'sha256:1456a25d26deb2133553f6613d7923ad11e53355da30a65d3feb5285bb434979'
+source_digest: 'sha256:1f9753429ec00bf8bfb91649aa8dbcdea2aa1f485d23192a0151895c71299b46'
 tags: [package, raster, extension-proof, threejs, tsl]
 sources:
   - id: manifest

--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:626c740b47a701883e50169eb1bfe7fbd0a56d36eb3f563ed163315e7ffb205b'
+source_digest: 'sha256:640f9095ab66a8398d8b56a414b419e7ee2551060cc3d05deab79e1096358bb5'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest
@@ -439,7 +439,7 @@ removes its decoded renderer resources. The unchanged eight-warmup/31-sample pub
 run was 19.42/6.59/3.10/14.24 ms median; process-separated samples support no regression and a plausible cold-path
 reduction, not causal attribution.
 
-The canonical direct benchmark loads the packaged `dist/text_shaper.wasm`: Cargo release optimization, LTO, one codegen
+The canonical direct benchmark loads the packaged `dist/text-shaper.wasm`: Cargo release optimization, LTO, one codegen
 unit, default-on `simd128`, stripping, and `wasm-opt -Oz --enable-simd` have already run. On the identical Rust artifact,
 Binaryen `-O3` and `-O4` added 11,976 and 13,661 raw bytes without a demonstrated latency improvement. The
 evidence-backed pipeline is now `--merge-similar-functions -Oz --merge-similar-functions -Oz` (D-244): the merge pass

--- a/docs/planning/core-api.md
+++ b/docs/planning/core-api.md
@@ -64,7 +64,7 @@ interface TextRuntime {
 declare function createTextRuntime(options?: TextRuntimeOptions): Promise<TextRuntime>;
 ```
 
-The default runtime instantiates the packaged `text_shaper.wasm`. Supplying `wasm` is intended for controlled builds,
+The default runtime instantiates the packaged `text-shaper.wasm`. Supplying `wasm` is intended for controlled builds,
 tests, and compile-time SIMD variants. A runtime owns its Rust registration domain and all fonts loaded through it.
 
 ```ts

--- a/docs/planning/wasm-size-reduction.md
+++ b/docs/planning/wasm-size-reduction.md
@@ -32,7 +32,7 @@ D-242, D-243, and D-244 remain the accepted optimizer decisions.
 
 ## Why this note exists
 
-`text_shaper.wasm` is the artifact a consumer downloads to render one line of text. At the
+`text-shaper.wasm` is the artifact a consumer downloads to render one line of text. At the
 measured baseline it is `1,122,345 B` raw, `435,781 B` gzip, `345,445 B` Brotli. Community
 feedback compares that unfavourably against all of Three.js. The comparison is fair, and the
 answer is not a second "minimal" runtime — two runtimes means two correctness surfaces, two
@@ -409,7 +409,7 @@ and should be priced before any upstream HarfRust fork is contemplated.
 
 ## Portable baker
 
-`font_baker.wasm` is `1,081,312 B` raw / `386,725 B` gzip. Its 2.6× step at `285475b4`
+`font-baker.wasm` is `1,081,312 B` raw / `386,725 B` gzip. Its 2.6× step at `285475b4`
 (422,538 → 1,097,702) is fully explained: the Wasm build invocation gained
 `--features subsetting`, where `subsetting = ["std", "dep:skera"]`.
 

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -353,7 +353,7 @@ Item 3.1 is closed. Item 3.2 is active and replaces the injected fallback seam's
 
 - [x] A baked miss dynamically imports `@pmndrs/glyph/runtime-bake`; the initial browser graph contains only the import boundary and cannot construct a Worker or reach the bake wrapper/Wasm.
 - [x] The standard host creates a named module Worker lazily, queues concurrent requests behind one active bake, reuses that instance within the burst, copies only the source transfer buffer needed to preserve loader provenance, and transfers the returned artifact buffer.
-- [x] The Worker imports the exact portable `@pmndrs/glyph/bake` wrapper, lazily instantiates the same optimized `font_baker.wasm`, accepts only the versioned face descriptor, and serializes structured failures.
+- [x] The Worker imports the exact portable `@pmndrs/glyph/bake` wrapper, lazily instantiates the same optimized `font-baker.wasm`, accepts only the versioned face descriptor, and serializes structured failures.
 - [x] The loader routes standard fallback output through the same provenance and hostile-input validator used for baked hits before registration.
 - [x] Canonical Inter integration tests exercise the public host, default loader path, transfer lists, Worker entry, and exact portable-core artifact bytes; package tests prove the runtime host/Worker/Wasm remain outside the static entry graph.
 - [x] Independent size lanes report the runtime host, Worker JavaScript, and portable Wasm separately instead of folding lazy code or Wasm into the initial core.

--- a/packages/glyph-example-raster/tests/glyph-example.test.ts
+++ b/packages/glyph-example-raster/tests/glyph-example.test.ts
@@ -100,7 +100,7 @@ describe('public external raster proof', () => {
     const registry = new FontRegistry();
     const runtime = await createTextRuntime({
       registry,
-      wasm: await readFile(new URL('../../glyph/dist/text_shaper.wasm', import.meta.url)),
+      wasm: await readFile(new URL('../../glyph/dist/text-shaper.wasm', import.meta.url)),
     });
     const font = await runtime.loadFont({
       input: { baked: dataUrl(await readFile(core.file)) },

--- a/packages/glyph-example-raster/tests/runtime-bake-routing.test.ts
+++ b/packages/glyph-example-raster/tests/runtime-bake-routing.test.ts
@@ -11,7 +11,7 @@ import { afterEach, test } from 'vitest';
 import { glyphExample } from '../src/index.js';
 
 const fixtureDirectory = new URL('../../../apps/benchmarks/fixtures/fonts/inter-v4.1/', import.meta.url);
-const shaperWasmUrl = new URL('../../glyph/dist/text_shaper.wasm', import.meta.url);
+const shaperWasmUrl = new URL('../../glyph/dist/text-shaper.wasm', import.meta.url);
 
 const cleanups: (() => Promise<void>)[] = [];
 afterEach(async () => {

--- a/packages/glyph/package.json
+++ b/packages/glyph/package.json
@@ -98,27 +98,27 @@
       "types": "./dist/runtime-bake.d.ts",
       "import": "./dist/runtime-bake.js"
     },
-    "./text-shaper.wasm": "./dist/text_shaper.wasm",
+    "./text-shaper.wasm": "./dist/text-shaper.wasm",
     "./text-shaper-abi": {
       "types": "./dist/text-shaper-abi.d.ts",
       "import": "./dist/text-shaper-abi.js"
     },
-    "./bitmap-baker.wasm": "./dist/bitmap_baker.wasm",
+    "./bitmap-baker.wasm": "./dist/bitmap-baker.wasm",
     "./bitmap-baker-abi": {
       "types": "./dist/bitmap-baker-abi.d.ts",
       "import": "./dist/bitmap-baker-abi.js"
     },
-    "./mtsdf-baker.wasm": "./dist/mtsdf_baker.wasm",
+    "./mtsdf-baker.wasm": "./dist/mtsdf-baker.wasm",
     "./mtsdf-baker-abi": {
       "types": "./dist/mtsdf-baker-abi.d.ts",
       "import": "./dist/mtsdf-baker-abi.js"
     },
-    "./slug-baker.wasm": "./dist/slug_baker.wasm",
+    "./slug-baker.wasm": "./dist/slug-baker.wasm",
     "./slug-baker-abi": {
       "types": "./dist/slug-baker-abi.d.ts",
       "import": "./dist/slug-baker-abi.js"
     },
-    "./font-baker.wasm": "./dist/font_baker.wasm",
+    "./font-baker.wasm": "./dist/font-baker.wasm",
     "./font-baker-abi": {
       "types": "./dist/font-baker-abi.d.ts",
       "import": "./dist/font-baker-abi.js"

--- a/packages/glyph/scripts/benchmark-rust-layout-engine.mjs
+++ b/packages/glyph/scripts/benchmark-rust-layout-engine.mjs
@@ -28,7 +28,7 @@ const fontStackHandle = 1;
 const regionHeight = options.height;
 
 const [wasm, abi, artifact] = await Promise.all([
-  readFile(options.wasm ?? new URL('../dist/text_shaper.wasm', import.meta.url)),
+  readFile(options.wasm ?? new URL('../dist/text-shaper.wasm', import.meta.url)),
   readFile(new URL('../dist/text-shaper-abi-v0.json', import.meta.url), 'utf8').then(JSON.parse),
   loadArtifact(options.technique, options.corpus),
 ]);

--- a/packages/glyph/scripts/build.mjs
+++ b/packages/glyph/scripts/build.mjs
@@ -83,17 +83,17 @@ const wasmOpt = fileURLToPath(new URL(`../node_modules/.bin/${executable}`, impo
 const rustWasm = fileURLToPath(
   new URL('../rust/bitmap-baker/target/wasm32-unknown-unknown/release/pmndrs_glyph_bitmap_baker.wasm', import.meta.url),
 );
-const distributedWasm = fileURLToPath(staged('bitmap_baker.wasm'));
+const distributedWasm = fileURLToPath(staged('bitmap-baker.wasm'));
 const shaperWasm = join(shaperTargetDirectory, 'wasm32-unknown-unknown/release/pmndrs_glyph_shaper.wasm');
-const distributedShaperWasm = fileURLToPath(staged('text_shaper.wasm'));
+const distributedShaperWasm = fileURLToPath(staged('text-shaper.wasm'));
 const mtsdfWasm = join(mtsdfArtifactTargetDirectory, 'wasm32-unknown-unknown/release/pmndrs_glyph_mtsdf_baker.wasm');
-const distributedMtsdfWasm = fileURLToPath(staged('mtsdf_baker.wasm'));
+const distributedMtsdfWasm = fileURLToPath(staged('mtsdf-baker.wasm'));
 const slugWasm = join(slugArtifactTargetDirectory, 'wasm32-unknown-unknown/release/pmndrs_glyph_slug_baker.wasm');
-const distributedSlugWasm = fileURLToPath(staged('slug_baker.wasm'));
+const distributedSlugWasm = fileURLToPath(staged('slug-baker.wasm'));
 const fontBakerWasm = fileURLToPath(
   new URL('../rust/font-baker/target/wasm32-unknown-unknown/release/pmndrs_glyph_font_baker.wasm', import.meta.url),
 );
-const distributedFontBakerWasm = fileURLToPath(staged('font_baker.wasm'));
+const distributedFontBakerWasm = fileURLToPath(staged('font-baker.wasm'));
 
 const [bitmapAbiJson, shaperAbiJson, mtsdfAbiJson, slugAbiJson, fontBakerAbiJson] = await Promise.all([
   runCapture('cargo', [

--- a/packages/glyph/scripts/font-baker/fuzz-validator.mjs
+++ b/packages/glyph/scripts/font-baker/fuzz-validator.mjs
@@ -22,7 +22,7 @@ const runs = positiveInteger(values.runs, 'runs');
 const seed = unsignedInteger(values.seed, 'seed');
 const [source, wasm] = await Promise.all([
   readFile(new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url)),
-  readFile(new URL('../../dist/font_baker.wasm', import.meta.url)),
+  readFile(new URL('../../dist/font-baker.wasm', import.meta.url)),
 ]);
 const baker = await createFontBaker(wasm);
 const artifact = baker.bake({

--- a/packages/glyph/scripts/generate-bitmap-fixture.mjs
+++ b/packages/glyph/scripts/generate-bitmap-fixture.mjs
@@ -10,7 +10,7 @@ import { composeFontBake } from '../dist/internal/compose-bake.js';
 import { bitmapDescriptor, bitmapRasterKey } from '../dist/raster/bitmap-technique.js';
 
 const sourceUrl = new URL('../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url);
-const wasmUrl = new URL('../dist/bitmap_baker.wasm', import.meta.url);
+const wasmUrl = new URL('../dist/bitmap-baker.wasm', import.meta.url);
 const outputUrl = new URL('../tests/fixtures/inter-bitmap-v0.json', import.meta.url);
 const renderingFixtureUrl = new URL(
   '../../../apps/benchmarks/fixtures/rendering/inter-bitmap-16.font.glb',

--- a/packages/glyph/scripts/measure-mtsdf-generator.mjs
+++ b/packages/glyph/scripts/measure-mtsdf-generator.mjs
@@ -15,7 +15,7 @@ import { performance } from 'node:perf_hooks';
 import { createMtsdfGenerator } from '../dist/internal/mtsdf-generator.js';
 import { mtsdfOracleCases } from '../tests/fixtures/mtsdf-oracle-cases.mjs';
 
-const wasm = await readFile(new URL('../dist/mtsdf_baker.wasm', import.meta.url));
+const wasm = await readFile(new URL('../dist/mtsdf-baker.wasm', import.meta.url));
 const compileStart = performance.now();
 const module = await WebAssembly.compile(wasm);
 const compileMilliseconds = performance.now() - compileStart;

--- a/packages/glyph/scripts/profile-mtsdf-baker.mjs
+++ b/packages/glyph/scripts/profile-mtsdf-baker.mjs
@@ -104,7 +104,7 @@ async function runDirectProfile(profileCase, source) {
     import('../dist/internal/msdf-contract.js'),
   ]);
   const instance = await WebAssembly.instantiate(
-    await WebAssembly.compile(await readFile(new URL('../dist/mtsdf_baker.wasm', import.meta.url))),
+    await WebAssembly.compile(await readFile(new URL('../dist/mtsdf-baker.wasm', import.meta.url))),
     {
       env: { pmndrs_glyph_bake_progress() {} },
     },

--- a/packages/glyph/scripts/support/paragraph-benchmark-fixture.mts
+++ b/packages/glyph/scripts/support/paragraph-benchmark-fixture.mts
@@ -33,7 +33,7 @@ export async function loadParagraphBenchmarkFixture(corpus: BenchmarkCorpus = 'l
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('packages/glyph/dist/text_shaper.wasm', workspaceRoot)),
+    wasm: await readFile(new URL('packages/glyph/dist/text-shaper.wasm', workspaceRoot)),
   });
   const bytes = await readFile(
     new URL(`apps/benchmarks/fixtures/rendering/${corpusFixtures[corpus].font}`, workspaceRoot),

--- a/packages/glyph/src/bakers/bitmap.ts
+++ b/packages/glyph/src/bakers/bitmap.ts
@@ -124,7 +124,7 @@ export function bitmapBakerFromCore(
 }
 
 async function loadDefaultBitmapBaker(): Promise<ReturnType<typeof bitmapBakerFromCore>> {
-  const wasmUrl = new URL('../bitmap_baker.wasm', import.meta.url);
+  const wasmUrl = new URL('../bitmap-baker.wasm', import.meta.url);
   let bytes: BufferSource;
   if (wasmUrl.protocol === 'file:') {
     const { readFile } = await import('node:fs/promises');

--- a/packages/glyph/src/bakers/msdf.ts
+++ b/packages/glyph/src/bakers/msdf.ts
@@ -157,7 +157,7 @@ export function msdfBakerFromCore(core: MsdfBakerCore): RasterBakerModule<'msdf'
 }
 
 async function loadDefaultMsdfBaker(): Promise<ReturnType<typeof msdfBakerFromCore>> {
-  const wasmUrl = new URL('../mtsdf_baker.wasm', import.meta.url);
+  const wasmUrl = new URL('../mtsdf-baker.wasm', import.meta.url);
   let bytes: BufferSource;
   if (wasmUrl.protocol === 'file:') {
     const { readFile } = await import('node:fs/promises');

--- a/packages/glyph/src/bakers/slug.ts
+++ b/packages/glyph/src/bakers/slug.ts
@@ -127,7 +127,7 @@ export function slugBakerFromCore(
 }
 
 async function loadDefaultSlugBaker(): Promise<ReturnType<typeof slugBakerFromCore>> {
-  const wasmUrl = new URL('../slug_baker.wasm', import.meta.url);
+  const wasmUrl = new URL('../slug-baker.wasm', import.meta.url);
   let bytes: BufferSource;
   if (wasmUrl.protocol === 'file:') {
     const { readFile } = await import('node:fs/promises');

--- a/packages/glyph/src/font-baker/wasm-url.ts
+++ b/packages/glyph/src/font-baker/wasm-url.ts
@@ -1,2 +1,2 @@
 /** Canonical browser-safe URL for the optimized font baker Wasm artifact. */
-export const fontBakerWasmUrl: string = new URL('../font_baker.wasm', import.meta.url).href;
+export const fontBakerWasmUrl: string = new URL('../font-baker.wasm', import.meta.url).href;

--- a/packages/glyph/src/shaper.ts
+++ b/packages/glyph/src/shaper.ts
@@ -204,7 +204,7 @@ class RuntimeShaperImpl implements RuntimeShaper {
 }
 
 async function fetchDefaultWasm(): Promise<ArrayBuffer> {
-  const response = await fetch(new URL('./text_shaper.wasm', import.meta.url));
+  const response = await fetch(new URL('./text-shaper.wasm', import.meta.url));
   if (!response.ok) {
     throw new Error(`text shaper Wasm request failed with HTTP ${response.status}`);
   }

--- a/packages/glyph/tests/font-baker/e2e/real-font.test.mjs
+++ b/packages/glyph/tests/font-baker/e2e/real-font.test.mjs
@@ -42,7 +42,7 @@ async function shapeReducedFont(t, shapingSfnt, fontFile, shapingCasesDirectory)
 
 test('the canonical Inter fixture bakes deterministically and retains HarfRust shaping', async (t) => {
   const [wasm, source, manifestSource, expectedOracleSource] = await Promise.all([
-    readFile(new URL('../../../dist/font_baker.wasm', import.meta.url)),
+    readFile(new URL('../../../dist/font-baker.wasm', import.meta.url)),
     readFile(new URL('Inter-Regular.ttf', fixtureDirectory)),
     readFile(new URL('manifest.json', fixtureDirectory), 'utf8'),
     readFile(new URL('harfrust.json', shapingDirectory), 'utf8'),
@@ -113,7 +113,7 @@ test('the canonical Amiri fixture preserves exact complex shaping through the GL
   const directory = new URL('../../../../../apps/benchmarks/fixtures/fonts/amiri-1.002/', import.meta.url);
   const casesDirectory = new URL('../../../../../apps/benchmarks/fixtures/shaping/amiri-regular/', import.meta.url);
   const [wasm, source, manifestSource, expectedOracleSource] = await Promise.all([
-    readFile(new URL('../../../dist/font_baker.wasm', import.meta.url)),
+    readFile(new URL('../../../dist/font-baker.wasm', import.meta.url)),
     readFile(new URL('Amiri-Regular.ttf', directory)),
     readFile(new URL('manifest.json', directory), 'utf8'),
     readFile(new URL('harfrust.json', casesDirectory), 'utf8'),
@@ -167,7 +167,7 @@ test('the authenticated Noto CJK fixture retains the closed shaping profile at t
   const directory = new URL('../../../../../apps/benchmarks/fixtures/fonts/noto-sans-cjk-2.004/', import.meta.url);
   const casesDirectory = new URL('../../../../../apps/benchmarks/fixtures/shaping/noto-sans-cjk/', import.meta.url);
   const [wasm, source, manifestSource, expectedOracleSource] = await Promise.all([
-    readFile(new URL('../../../dist/font_baker.wasm', import.meta.url)),
+    readFile(new URL('../../../dist/font-baker.wasm', import.meta.url)),
     readFile(new URL('NotoSansCJKjp-Regular.otf', directory)),
     readFile(new URL('manifest.json', directory), 'utf8'),
     readFile(new URL('harfrust.json', casesDirectory), 'utf8'),

--- a/packages/glyph/tests/font-baker/fuzz/validator-fuzz-smoke.test.mjs
+++ b/packages/glyph/tests/font-baker/fuzz/validator-fuzz-smoke.test.mjs
@@ -9,7 +9,7 @@ import { FONT_ARTIFACT_FUZZ_SEED, mutateFontArtifact } from '../support/font-art
 test('fixed-seed font artifact mutations fail safely and deterministically', async () => {
   const [source, wasm] = await Promise.all([
     readFile(new URL('../../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url)),
-    readFile(new URL('../../../dist/font_baker.wasm', import.meta.url)),
+    readFile(new URL('../../../dist/font-baker.wasm', import.meta.url)),
   ]);
   const baker = await createFontBaker(wasm);
   const artifact = baker.bake({

--- a/packages/glyph/tests/font-baker/integration/validator.test.mjs
+++ b/packages/glyph/tests/font-baker/integration/validator.test.mjs
@@ -16,7 +16,7 @@ let cjkProfileArtifact;
 before(async () => {
   const [source, wasm] = await Promise.all([
     readFile(new URL('../../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url)),
-    readFile(new URL('../../../dist/font_baker.wasm', import.meta.url)),
+    readFile(new URL('../../../dist/font-baker.wasm', import.meta.url)),
   ]);
   const baker = await createFontBaker(wasm);
   artifact = baker.bake({ source, descriptor: { formatVersion: 0, fontFaceIndex: 0 } }).artifacts[0].bytes;
@@ -129,7 +129,7 @@ test('keeps the packaged extension schema byte-identical to the canonical schema
   });
   assert.equal(FONT_BAKER_VERSION, manifest.version);
   assert.equal(FONT_FORMAT_VERSION, 0);
-  assert.equal(fontBakerWasmUrl, new URL('../../../dist/font_baker.wasm', import.meta.url).href);
+  assert.equal(fontBakerWasmUrl, new URL('../../../dist/font-baker.wasm', import.meta.url).href);
   assert.doesNotMatch(coreSource, /(?:ajv|gltf-validator|validator\.js)/);
 
   const property = JSON.parse(

--- a/packages/glyph/tests/font-baker/integration/wasm-package.test.mjs
+++ b/packages/glyph/tests/font-baker/integration/wasm-package.test.mjs
@@ -10,7 +10,7 @@ import {
 } from '../../../dist/font-baker/index.js';
 
 const [wasm, rustReleaseWasm] = await Promise.all([
-  readFile(new URL('../../../dist/font_baker.wasm', import.meta.url)),
+  readFile(new URL('../../../dist/font-baker.wasm', import.meta.url)),
   readFile(
     new URL(
       '../../../rust/font-baker/target/wasm32-unknown-unknown/release/pmndrs_glyph_font_baker.wasm',

--- a/packages/glyph/tests/fuzz/bitmap-validator-fuzz-smoke.test.mjs
+++ b/packages/glyph/tests/fuzz/bitmap-validator-fuzz-smoke.test.mjs
@@ -13,7 +13,7 @@ const shapingHash = '6a96d9c6f9e59fd6aeb51848413bd4dd8711730a5479a7d004979d80f3b
 test('fixed-seed bitmap artifact mutations fail safely and deterministically', async () => {
   const [source, wasm] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url)),
-    readFile(new URL('../../dist/bitmap_baker.wasm', import.meta.url)),
+    readFile(new URL('../../dist/bitmap-baker.wasm', import.meta.url)),
   ]);
   const descriptor = bitmapDescriptor({ strikes: [16] });
   const rasterKey = await bitmapRasterKey({ strikes: [16] });

--- a/packages/glyph/tests/fuzz/engine-wire-fuzz-smoke.test.mjs
+++ b/packages/glyph/tests/fuzz/engine-wire-fuzz-smoke.test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test';
 
 import { copyIntoAllocation, engineUpdateBytes, renderPolicyBytes } from '../support/engine-abi.mjs';
 
-const wasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/text-shaper-abi-v0.json', import.meta.url);
 const mutationCount = 64;
 

--- a/packages/glyph/tests/fuzz/loader-fuzz-smoke.test.mjs
+++ b/packages/glyph/tests/fuzz/loader-fuzz-smoke.test.mjs
@@ -10,7 +10,7 @@ import { ARTIFACT_FUZZ_SEED, mutateArtifact } from '../support/artifact-mutation
 test('fixed-seed loader artifact mutations fail safely, purely, and deterministically', async () => {
   const [source, wasm] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url)),
-    readFile(new URL('../../dist/font_baker.wasm', import.meta.url)),
+    readFile(new URL('../../dist/font-baker.wasm', import.meta.url)),
   ]);
   const baker = await createFontBaker(wasm);
   const artifact = baker.bake({

--- a/packages/glyph/tests/integration/bitmap-baker.test.mjs
+++ b/packages/glyph/tests/integration/bitmap-baker.test.mjs
@@ -11,7 +11,7 @@ import {
 import { bitmap, bitmapDescriptor, bitmapRasterKey } from '@pmndrs/glyph/raster/bitmap';
 import { validateBitmapArtifact } from '@pmndrs/glyph/bakers/bitmap/validate';
 
-const wasmUrl = new URL('../../dist/bitmap_baker.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/bitmap-baker.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/bitmap-baker-abi-v0.json', import.meta.url);
 const fontUrl = new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url);
 const shapingHash = '6a96d9c6f9e59fd6aeb51848413bd4dd8711730a5479a7d004979d80f3b3cd09';

--- a/packages/glyph/tests/integration/bitmap-validator.test.mjs
+++ b/packages/glyph/tests/integration/bitmap-validator.test.mjs
@@ -21,7 +21,7 @@ let sourceBytes;
 
 before(async () => {
   const [wasm, source, goldenBytes] = await Promise.all([
-    readFile(new URL('../../dist/bitmap_baker.wasm', import.meta.url)),
+    readFile(new URL('../../dist/bitmap-baker.wasm', import.meta.url)),
     readFile(new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url)),
     readFile(new URL('../fixtures/inter-bitmap-v0.json', import.meta.url)),
   ]);

--- a/packages/glyph/tests/integration/compose-bake.test.mjs
+++ b/packages/glyph/tests/integration/compose-bake.test.mjs
@@ -19,8 +19,8 @@ let golden;
 before(async () => {
   const [source, fontWasm, bitmapWasm, goldenBytes] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url)),
-    readFile(new URL('../../dist/font_baker.wasm', import.meta.url)),
-    readFile(new URL('../../dist/bitmap_baker.wasm', import.meta.url)),
+    readFile(new URL('../../dist/font-baker.wasm', import.meta.url)),
+    readFile(new URL('../../dist/bitmap-baker.wasm', import.meta.url)),
     readFile(new URL('../fixtures/inter-bitmap-v0.json', import.meta.url)),
   ]);
   golden = JSON.parse(goldenBytes);

--- a/packages/glyph/tests/integration/engine-sequence-property.test.mjs
+++ b/packages/glyph/tests/integration/engine-sequence-property.test.mjs
@@ -22,7 +22,7 @@ import { Text, TextGroup } from '@pmndrs/glyph/three';
 import * as THREE from 'three/webgpu';
 
 const fixtures = new URL('../../../../apps/benchmarks/fixtures/rendering/', import.meta.url);
-const shaperWasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const shaperWasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 
 /** Fonts chosen for shaping behaviour that has broken the engine before. */
 const FONT_FIXTURES = {

--- a/packages/glyph/tests/integration/mtsdf-baker.test.mjs
+++ b/packages/glyph/tests/integration/mtsdf-baker.test.mjs
@@ -19,7 +19,7 @@ import {
   msdfDescriptorRasterKey,
 } from '@pmndrs/glyph/raster/msdf';
 
-const wasmUrl = new URL('../../dist/mtsdf_baker.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/mtsdf-baker.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/mtsdf-baker-abi-v1.json', import.meta.url);
 const fontUrl = new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url);
 const showcaseFontUrl = new URL(

--- a/packages/glyph/tests/integration/mtsdf-generator.test.mjs
+++ b/packages/glyph/tests/integration/mtsdf-generator.test.mjs
@@ -11,7 +11,7 @@ import {
 } from '../../dist/internal/mtsdf-generator.js';
 import { mtsdfOracleCases } from '../fixtures/mtsdf-oracle-cases.mjs';
 
-const wasmUrl = new URL('../../dist/mtsdf_baker.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/mtsdf-baker.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/mtsdf-baker-abi-v1.json', import.meta.url);
 const publishedAbi = JSON.parse(await readFile(abiUrl, 'utf8'));
 const progressImports = { env: { pmndrs_glyph_bake_progress() {} } };

--- a/packages/glyph/tests/integration/react-lease-lifecycle.test.mjs
+++ b/packages/glyph/tests/integration/react-lease-lifecycle.test.mjs
@@ -26,7 +26,7 @@ import '../support/browser-globals.mjs';
 import { Text } from '@pmndrs/glyph/react';
 
 const fontUrl = new URL('../../../../apps/benchmarks/fixtures/rendering/inter-bitmap-16.font.glb', import.meta.url);
-const shaperWasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const shaperWasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 
 const dataUrl = (bytes) => `data:model/gltf-binary;base64,${bytes.toString('base64')}`;
 

--- a/packages/glyph/tests/integration/render-plan-frame-abi.test.mjs
+++ b/packages/glyph/tests/integration/render-plan-frame-abi.test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test';
 
 import { copyIntoAllocation, engineUpdateBytes, renderPolicyBytes } from '../support/engine-abi.mjs';
 
-const wasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/text-shaper-abi-v0.json', import.meta.url);
 const sessionId = 5;
 const policyHandle = 11;

--- a/packages/glyph/tests/integration/render-policy-registration.test.mjs
+++ b/packages/glyph/tests/integration/render-policy-registration.test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test';
 
 import { renderPolicyBytes } from '../support/engine-abi.mjs';
 
-const wasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/text-shaper-abi-v0.json', import.meta.url);
 
 test('registers compiler-mapped render policies as retained typed Wasm state', async () => {

--- a/packages/glyph/tests/integration/runtime-bake.test.mjs
+++ b/packages/glyph/tests/integration/runtime-bake.test.mjs
@@ -319,7 +319,7 @@ test('one TextRuntime source load sends its normalized ranges and complete raste
   );
   const requests = [];
   const runtime = await createTextRuntime({
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   t.after(() => runtime.dispose());
   const runtimeBake = async (request) => {
@@ -393,7 +393,7 @@ test('external techniques bake through their own declared baker, never the Worke
   });
   const requests = [];
   const runtime = await createTextRuntime({
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   t.after(() => runtime.dispose());
   const runtimeBake = async (request) => {

--- a/packages/glyph/tests/integration/shaper-registration.test.mjs
+++ b/packages/glyph/tests/integration/shaper-registration.test.mjs
@@ -9,12 +9,12 @@ import { validateFontArtifact } from '@pmndrs/glyph/bake';
 import { fontBindingBytes, renderPolicyBytes, renderPolicyBytesFromPrograms } from '../support/engine-abi.mjs';
 
 const fixtureDirectory = new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/', import.meta.url);
-const shaperWasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const shaperWasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 const shaperAbiUrl = new URL('../../dist/text-shaper-abi-v0.json', import.meta.url);
 async function fixture() {
   const [source, bakerWasm, shaperWasm] = await Promise.all([
     readFile(new URL('Inter-Regular.ttf', fixtureDirectory)),
-    readFile(new URL('../../dist/font_baker.wasm', import.meta.url)),
+    readFile(new URL('../../dist/font-baker.wasm', import.meta.url)),
     readFile(shaperWasmUrl),
   ]);
   const baker = await createFontBaker(bakerWasm);

--- a/packages/glyph/tests/integration/slug-baker.test.mjs
+++ b/packages/glyph/tests/integration/slug-baker.test.mjs
@@ -12,7 +12,7 @@ import {
 import { validateSlugArtifact } from '../../dist/bakers/slug-validator.js';
 import { SLUG_EXTENSION, slugDescriptor, slugDescriptorRasterKey } from '../../dist/internal/slug-contract.js';
 
-const wasmUrl = new URL('../../dist/slug_baker.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/slug-baker.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/slug-baker-abi-v0.json', import.meta.url);
 const fontUrl = new URL('../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf', import.meta.url);
 const shapingHash = '6a96d9c6f9e59fd6aeb51848413bd4dd8711730a5479a7d004979d80f3b3cd09';

--- a/packages/glyph/tests/integration/text-engine-host.test.mjs
+++ b/packages/glyph/tests/integration/text-engine-host.test.mjs
@@ -8,7 +8,7 @@ import { threeRenderPolicyBytes } from '../../dist/three/render-policy.js';
 import { createRuntimeShaper } from '../../dist/shaper.js';
 import { engineUpdateBytes, renderPolicyBytes } from '../support/engine-abi.mjs';
 
-const wasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 const abiUrl = new URL('../../dist/text-shaper-abi-v0.json', import.meta.url);
 
 test('production text-engine host publishes borrowed A/B plans through the runtime shaper instance', async () => {

--- a/packages/glyph/tests/integration/three-engine-runtime.test.mjs
+++ b/packages/glyph/tests/integration/three-engine-runtime.test.mjs
@@ -26,7 +26,7 @@ import { ThreeTextRenderPlanExecutor } from '../../dist/three/engine-plan-target
 import { defineTextMaterial } from '../../dist/three/material.js';
 
 const fixtureRoot = new URL('../../../../apps/benchmarks/fixtures/rendering/', import.meta.url);
-const wasmUrl = new URL('../../dist/text_shaper.wasm', import.meta.url);
+const wasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 
 test('Three coordinator shares shaping data across technique bindings and reference-counts stack handles', async () => {
   const [bitmapBytes, compressedMsdf, compressedSlug, wasm] = await Promise.all([

--- a/packages/glyph/tests/integration/three-shader.test.mjs
+++ b/packages/glyph/tests/integration/three-shader.test.mjs
@@ -22,7 +22,7 @@ test('a custom Three material composes over the Bitmap shader in the Rust comman
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(fontUrl)) },
@@ -73,7 +73,7 @@ test('Bitmap pixel snapping is an explicit opt-in graph specialization', async (
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(fontUrl)) },

--- a/packages/glyph/tests/integration/three-v1.test.mjs
+++ b/packages/glyph/tests/integration/three-v1.test.mjs
@@ -27,7 +27,7 @@ const multiTechniqueFontUrl = new URL('../../../../apps/r3f-hello-world/assets/i
 
 test('one runtime request registers one font and returns typed resources for every declared technique', async () => {
   const runtime = await createTextRuntime({
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const [bitmapFont, msdfFont, slugFont] = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(multiTechniqueFontUrl)) },
@@ -45,7 +45,7 @@ test('Three Text and TextGroup late-bind, synchronize, reparent, and dispose thr
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(fontUrl)) },
@@ -351,7 +351,7 @@ test('TextGroup drops disposed descendants and reuses their committed transform 
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(fontUrl)) },
@@ -397,7 +397,7 @@ test('Three retires materials bound to a replaced buffer generation', async () =
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(fontUrl)) },
@@ -435,7 +435,7 @@ test('one Rust plan partitions a mixed Bitmap to Slug fallback stack', async () 
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const [latin, icon] = await Promise.all([
     runtime.loadFont({
@@ -686,7 +686,7 @@ test('TextGroup realizes two public Text objects as one indexed Rust draw', asyn
 });
 
 async function createInstrumentedRuntime(registry) {
-  const wasm = await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url));
+  const wasm = await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url));
   const abi = JSON.parse(await readFile(new URL('../../dist/text-shaper-abi-v0.json', import.meta.url), 'utf8'));
   const originalInstantiate = WebAssembly.instantiate;
   let crossings = 0;
@@ -771,7 +771,7 @@ test('Bitmap strike changes fully initialize a replacement indexed batch', async
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(densityFontUrl)) },
@@ -823,7 +823,7 @@ test('Bitmap strike changes fully initialize a replacement indexed batch', async
 
 test('multi-page Bitmap strikes remain one ordered texture-array draw', async () => {
   const runtime = await createTextRuntime({
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(densityFontUrl)) },
@@ -857,7 +857,7 @@ test('Rust ellipsis reshapes only the narrowed unsafe line boundary', async () =
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(amiriFontUrl)) },
@@ -902,7 +902,7 @@ test('TextGroup atomically replaces child paragraphs without multiplying retaine
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(fontUrl)) },
@@ -941,7 +941,7 @@ test('TextGroup grows aggregate glyph storage without reserving one aggregate-si
   const registry = new FontRegistry();
   const runtime = await createTextRuntime({
     registry,
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(fontUrl)) },
@@ -1038,7 +1038,7 @@ test('a standard ligature that absorbs a grapheme publishes and keeps typing', a
   // does not, which is why every existing Latin fixture missed this.
   const runtime = await createTextRuntime({
     registry: new FontRegistry(),
-    wasm: await readFile(new URL('../../dist/text_shaper.wasm', import.meta.url)),
+    wasm: await readFile(new URL('../../dist/text-shaper.wasm', import.meta.url)),
   });
   const font = await runtime.loadFont({
     input: { baked: dataUrl(await readFile(amiriFontUrl)) },

--- a/packages/glyph/tests/package/esm-only.test.mjs
+++ b/packages/glyph/tests/package/esm-only.test.mjs
@@ -76,7 +76,7 @@ test('the public loader graph exposes registration without eager baker or Node h
   ]);
   const initialGraph = `${entry}\n${loader}`;
   assert.match(loader, /import\(["']\.\/runtime-bake\.js["']\)/);
-  assert.doesNotMatch(initialGraph, /(?:from\s+["']\.\/runtime-bake|new Worker|font_baker\.wasm|node:)/);
+  assert.doesNotMatch(initialGraph, /(?:from\s+["']\.\/runtime-bake|new Worker|font-baker\.wasm|node:)/);
   assert.doesNotMatch(initialGraph, /(?:\.\/node\/|\.\/bakers\/)/);
   assert.doesNotMatch(initialGraph, /(?:PMNDRS_font_slug|\.\/raster\/slug|slug-shaders)/);
   assert.doesNotMatch(entry, /(?:three\/|three["'])/, 'core entry must not import Three');
@@ -92,5 +92,5 @@ test('the public loader graph exposes registration without eager baker or Node h
     const source = await readFile(new URL(`../../dist/internal/${helper}`, import.meta.url), 'utf8');
     assert.doesNotMatch(source, /(?:^|\n)\s*(?:import|export\s+\{.*\}\s+from)\s/m);
   }
-  assert.ok((await readFile(new URL('../../dist/font_baker.wasm', import.meta.url))).byteLength > 0);
+  assert.ok((await readFile(new URL('../../dist/font-baker.wasm', import.meta.url))).byteLength > 0);
 });


### PR DESCRIPTION
`dist/` disagreed with itself: `text_shaper.wasm` sat beside
`text-shaper-abi-v0.json`, and every published subpath already used hyphens
while the file it pointed at used underscores. The underscores were never a
choice -- they are cargo's crate-output convention, carried across by the copy
step and never normalized.

The distributed names are now hyphenated, so a subpath and the file it resolves
to read the same, and `dist/` uses one convention throughout.

Cargo artifact paths keep their underscores. `pmndrs_glyph_mtsdf_baker.wasm` is
what the toolchain actually emits, and renaming those references would break the
build rather than tidy it.

Consumers are unaffected: the subpaths did not change, only the files behind
them. Anything reaching into `dist/` by literal path does change, which is
internal to this repository -- the tests, scripts, and CI artifact upload updated
here. That the change is safe at all is a property of the subpath layer having
normalized the name first, not of the file being private.

The size record moves without any byte moving. Underscore to hyphen is one
character for one character, so raw and minified counts are identical and only
the content hashes and compression deltas shift; the filename strings live inside
the emitted JavaScript.

`docs/log.md` keeps the old name where it records a past build race that hid
`bitmap_baker.wasm`. That entry reports what was observed at the time.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>