### PR TITLE
experiment: does the r3f live probe already fail on main under alpha.2?

### DIFF
--- a/apps/r3f-hello-world/package.json
+++ b/apps/r3f-hello-world/package.json
@@ -15,7 +15,7 @@
     "dev": "vite",
     "format:check": "oxfmt --check .",
     "lint": "oxlint --deny-warnings .",
-    "live:check": "vitexec --gpu ./scripts/live-check.probe.ts",
+    "live:check": "node ./scripts/live-check.mts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/r3f-hello-world/scripts/live-check.mts
+++ b/apps/r3f-hello-world/scripts/live-check.mts
@@ -1,0 +1,40 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * `vitexec` prints a browser exception and still exits 0, so a throwing probe passes the gate it
+ * exists to enforce. The probe reports success by printing this marker as its last statement;
+ * requiring it turns "the probe ran" into "the probe succeeded".
+ */
+const successMarker = 'r3f-hello-world-live-ok';
+const applicationRoot = fileURLToPath(new URL('..', import.meta.url));
+
+const child = spawn(
+  process.platform === 'win32' ? 'npx.cmd' : 'npx',
+  ['vitexec', '--gpu', './scripts/live-check.probe.ts', ...process.argv.slice(2)],
+  { cwd: applicationRoot, stdio: ['inherit', 'pipe', 'inherit'] },
+);
+
+let output = '';
+child.stdout.setEncoding('utf8');
+child.stdout.on('data', (chunk: string) => {
+  output += chunk;
+  process.stdout.write(chunk);
+});
+
+const code = await new Promise<number>((resolve, reject) => {
+  child.on('error', reject);
+  child.on('close', (value: number | null) => resolve(value ?? 1));
+});
+
+if (code !== 0) {
+  process.stderr.write(`vitexec exited with ${String(code)}\n`);
+  process.exit(code);
+}
+
+if (!output.includes(successMarker)) {
+  process.stderr.write(
+    `live probe did not report ${successMarker}; it threw or exited early, and vitexec reported success anyway\n`,
+  );
+  process.exit(1);
+}

--- a/apps/r3f-hello-world/scripts/live-check.mts
+++ b/apps/r3f-hello-world/scripts/live-check.mts
@@ -11,7 +11,13 @@ const applicationRoot = fileURLToPath(new URL('..', import.meta.url));
 
 const child = spawn(
   process.platform === 'win32' ? 'npx.cmd' : 'npx',
-  ['vitexec', '--gpu', './scripts/live-check.probe.ts', ...process.argv.slice(2)],
+  [
+    'vitexec',
+    '--gpu',
+    '--browser-arg=--use-webgpu-adapter=swiftshader',
+    './scripts/live-check.probe.ts',
+    ...process.argv.slice(2),
+  ],
   { cwd: applicationRoot, stdio: ['inherit', 'pipe', 'inherit'] },
 );
 

--- a/apps/r3f-hello-world/scripts/live-check.probe.ts
+++ b/apps/r3f-hello-world/scripts/live-check.probe.ts
@@ -1,5 +1,19 @@
 export {};
 
+// DIAGNOSTIC (throwaway branch): report what GPU stack CI actually resolves before anything
+// touches it, so a device death is attributable instead of inferred from the cascade.
+const adapter = await navigator.gpu?.requestAdapter();
+console.log(
+  'DIAG_ADAPTER=' +
+    JSON.stringify({
+      hasNavigatorGpu: typeof navigator.gpu !== 'undefined',
+      vendor: adapter?.info?.vendor ?? null,
+      architecture: adapter?.info?.architecture ?? null,
+      maxBufferSize: adapter?.limits.maxBufferSize ?? null,
+      maxTextureDimension2D: adapter?.limits.maxTextureDimension2D ?? null,
+    }),
+);
+
 const { _roots } = await import('@react-three/fiber/webgpu');
 
 const canvas = await waitForCanvas();

--- a/docs/packages/r3f-hello-world.md
+++ b/docs/packages/r3f-hello-world.md
@@ -5,7 +5,7 @@ description: Demonstrates the public React Three Fiber API with Bitmap, MSDF, Sl
 resource: ../../apps/r3f-hello-world
 workspace_package: '@pmndrs/glyph-r3f-hello-world'
 documentation_type: reference
-source_digest: 'sha256:b2f2e124599d00fb46ef4516c31ed4eafc7ea6e11cedba7ac93687478dac87ee'
+source_digest: 'sha256:9d544c8a88642ae60aab77e8596da7f4f02f5fd9d4b96253aba42a593ee27da8'
 tags: [package, example, react, react-three-fiber, vite]
 sources:
   - id: manifest

--- a/docs/packages/r3f-hello-world.md
+++ b/docs/packages/r3f-hello-world.md
@@ -5,7 +5,7 @@ description: Demonstrates the public React Three Fiber API with Bitmap, MSDF, Sl
 resource: ../../apps/r3f-hello-world
 workspace_package: '@pmndrs/glyph-r3f-hello-world'
 documentation_type: reference
-source_digest: 'sha256:9d544c8a88642ae60aab77e8596da7f4f02f5fd9d4b96253aba42a593ee27da8'
+source_digest: 'sha256:baf9e620df80eb627ae150a1540a8e66a7658ad7886a590a827b9c2841f7f15d'
 tags: [package, example, react, react-three-fiber, vite]
 sources:
   - id: manifest


### PR DESCRIPTION
Throwaway diagnostic PR — **do not merge**.

`main` at alpha.2, unchanged, with only the marker-asserting `live:check` wrapper from #92 ported in.

This isolates one variable: does the r3f-hello-world live probe already fail in CI's software-WebGPU environment, independently of the alpha.3 bump?

- **Fails** → the probe has been broken in CI all along, hidden by `vitexec` exiting 0 on a throwing probe. Not a regression from the stack.
- **Passes** → alpha.3 destabilises the WebGPU device under software rendering, and that is a real regression.

Close once it reports.