### PR TITLE
refactor(glyph): let the JSON wire types satisfy JsonValue

### DIFF
--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:ff2e1cdf7690dda73fc33ab38d5e6819f644d2dd87f11ca84eb4c90e029227cf'
+source_digest: 'sha256:2dcf9eaf2fa473aef296c8f08a0799a02605dc2d5e9e4e7edbe0203fcc5c39f3'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/packages/glyph/src/font-baker/index.ts
+++ b/packages/glyph/src/font-baker/index.ts
@@ -13,10 +13,10 @@ export interface FontBakeRequestV0 {
   readonly descriptor: FontBakeDescriptorV0;
 }
 
-export interface UnicodeRangeV0 {
+export type UnicodeRangeV0 = {
   readonly start: number;
   readonly end: number;
-}
+};
 
 export interface FontSelectionV0 {
   readonly formatVersion: 0;

--- a/packages/glyph/src/internal/runtime-bake-protocol.ts
+++ b/packages/glyph/src/internal/runtime-bake-protocol.ts
@@ -2,10 +2,10 @@ import type { FontBakeDescriptorV0, SerializedBakeError } from '../font-baker/in
 import type { RasterKey } from '../identity.js';
 import type { JsonValue } from '../raster.js';
 
-export interface RuntimeBakeUnicodeRangeV0 {
+export type RuntimeBakeUnicodeRangeV0 = {
   readonly start: number;
   readonly end: number;
-}
+};
 
 /**
  * The raster kinds the runtime bake Worker embeds bakers for. This set is the
@@ -17,13 +17,13 @@ export interface RuntimeBakeUnicodeRangeV0 {
  */
 export const workerRasterKinds: readonly string[] = Object.freeze(['bitmap', 'msdf', 'slug']);
 
-export interface RuntimeBakeRasterV0 {
+export type RuntimeBakeRasterV0 = {
   readonly kind: string;
   readonly extension: string;
   readonly version: number;
   readonly rasterKey: RasterKey;
   readonly descriptor: JsonValue;
-}
+};
 
 export interface RuntimeBakeRequestV0 {
   readonly type: 'bake-font-v0';

--- a/packages/glyph/src/internal/runtime-font-cache.ts
+++ b/packages/glyph/src/internal/runtime-font-cache.ts
@@ -1,5 +1,4 @@
 import { FONT_BAKER_VERSION, FONT_FORMAT_VERSION } from '../font-baker/contract.js';
-import type { JsonValue } from '../raster.js';
 
 import { copyToOwnedArrayBuffer } from './owned-array-buffer.js';
 import { canonicalJson } from './raster-identity.js';
@@ -45,7 +44,7 @@ export function createCache(storage: CacheStorage, origin: string, now: () => nu
         rasters: request.rasters ?? [],
         sourceHash,
         unicodeRanges: request.unicodeRanges ?? null,
-      } as unknown as JsonValue);
+      });
       return sha256(new TextEncoder().encode(identity));
     },
     async match(key) {

--- a/packages/glyph/src/text-runtime.ts
+++ b/packages/glyph/src/text-runtime.ts
@@ -252,7 +252,7 @@ class TextRuntimeImpl implements TextRuntime {
     const planKey = canonicalJson({
       rasters,
       unicodeRanges: unicodeRanges ?? null,
-    } as unknown as import('./raster.js').JsonValue);
+    });
     let loaders = this.#sourceLoaders.get(input.runtimeBake);
     if (loaders === undefined) {
       loaders = new Map();


### PR DESCRIPTION
Removes two `as unknown as JsonValue` assertions by making the claim provable instead of asserted.

## Why the assertions existed

`JsonValue`'s object arm is an index signature:

```ts
export type JsonValue = null | boolean | number | string | readonly JsonValue[] | { readonly [key: string]: JsonValue };
```

TypeScript grants *implicit* index signatures to type aliases but withholds them from `interface`, because an interface is open to declaration merging and TypeScript cannot prove nobody will merge in a non-JSON property. Minimal repro:

```ts
interface AsInterface { readonly kind: string; readonly version: number }
type      AsAlias   = { readonly kind: string; readonly version: number };

const fromInterface: JsonValue = a; // error TS2322: Index signature for type 'string' is missing
const fromAlias:     JsonValue = b; // ok
```

Every field of `RuntimeBakeRasterV0` is JSON-shaped, yet it could never satisfy `JsonValue`. The assertions were papering over that rule, not over a real defect — `tsc` passes with the payloads unchanged.

## The change

Three declarations become type aliases. These are closed wire shapes with no merge point, so nothing is given up:

- `RuntimeBakeUnicodeRangeV0`
- `RuntimeBakeRasterV0`
- `UnicodeRangeV0`

The two assertions then delete themselves, and `canonicalize` still validates at runtime and throws on anything non-JSON — so the proof now exists at compile time *and* runtime rather than at neither.

## Evidence

- `tsc -p tsconfig.json --noEmit` clean with both assertions removed and no payload changes.
- 66 package tests, 144 integration tests pass — includes the runtime font-cache key and bake-protocol paths these types feed.
- `oxlint --deny-warnings`, `oxfmt --check` clean.
- OKF validation clean.

## Not addressed here

`raster-artifact-validation.ts:128` still has `canonicalJson(extension.coverage as JsonValue)`. That is a different problem: `extension` is `Readonly<Record<string, unknown>>`, so the value is genuinely untrusted parsed artifact data rather than a closed type the compiler could prove. It needs a validating entry point, not a declaration change, and is left for separate work.
