### PR TITLE
refactor(glyph)!: drop version suffixes from type names

### DIFF
--- a/apps/benchmarks/src/benchmark/autoresearch.ts
+++ b/apps/benchmarks/src/benchmark/autoresearch.ts
@@ -49,9 +49,7 @@ export function assertAutoresearchBaseline(value: unknown): asserts value is Aut
   }
 }
 
-export function assertAutoresearchDisabled(
-  baseline: AutoresearchBaseline,
-): asserts baseline is AutoresearchBaseline & {
+export function assertAutoresearchDisabled(baseline: AutoresearchBaseline): asserts baseline is AutoresearchBaseline & {
   readonly campaign: Extract<AutoresearchCampaign, { readonly state: 'disabled' }>;
 } {
   if (baseline.campaign.state !== 'disabled') {

--- a/apps/benchmarks/src/benchmark/autoresearch.ts
+++ b/apps/benchmarks/src/benchmark/autoresearch.ts
@@ -1,11 +1,11 @@
-export interface AutoresearchEvidenceV0 {
+export interface AutoresearchEvidence {
   readonly id: string;
   readonly path: string;
   readonly sha256: string;
   readonly bytes: number;
 }
 
-export type AutoresearchCampaignV0 =
+export type AutoresearchCampaign =
   | { readonly state: 'disabled'; readonly reason: string }
   | {
       readonly state: 'enabled';
@@ -14,19 +14,19 @@ export type AutoresearchCampaignV0 =
       readonly manifest: string;
     };
 
-export interface AutoresearchBaselineV0 {
+export interface AutoresearchBaseline {
   readonly schemaVersion: 0;
   readonly baseCommit: string;
-  readonly campaign: AutoresearchCampaignV0;
+  readonly campaign: AutoresearchCampaign;
   readonly environment: {
     readonly node: string;
     readonly pnpm: string;
     readonly rust: string;
   };
-  readonly evidence: readonly AutoresearchEvidenceV0[];
+  readonly evidence: readonly AutoresearchEvidence[];
 }
 
-export function assertAutoresearchBaseline(value: unknown): asserts value is AutoresearchBaselineV0 {
+export function assertAutoresearchBaseline(value: unknown): asserts value is AutoresearchBaseline {
   assertPlainObject(value, 'baseline');
   if (value.schemaVersion !== 0) invalid('schemaVersion must be 0');
   if (!isHexDigest(value.baseCommit, 40)) invalid('baseCommit must be a full Git SHA-1');
@@ -50,16 +50,16 @@ export function assertAutoresearchBaseline(value: unknown): asserts value is Aut
 }
 
 export function assertAutoresearchDisabled(
-  baseline: AutoresearchBaselineV0,
-): asserts baseline is AutoresearchBaselineV0 & {
-  readonly campaign: Extract<AutoresearchCampaignV0, { readonly state: 'disabled' }>;
+  baseline: AutoresearchBaseline,
+): asserts baseline is AutoresearchBaseline & {
+  readonly campaign: Extract<AutoresearchCampaign, { readonly state: 'disabled' }>;
 } {
   if (baseline.campaign.state !== 'disabled') {
     throw new Error('autoresearch campaigns require explicit maintainer approval');
   }
 }
 
-function assertCampaign(value: unknown): asserts value is AutoresearchCampaignV0 {
+function assertCampaign(value: unknown): asserts value is AutoresearchCampaign {
   assertPlainObject(value, 'campaign');
   if (value.state === 'disabled') {
     if (!isNonEmptyString(value.reason)) invalid('disabled campaign reason is required');

--- a/docs/packages/benchmarks.md
+++ b/docs/packages/benchmarks.md
@@ -5,7 +5,7 @@ description: Provides the shared interactive and automated benchmark product sur
 resource: ../../apps/benchmarks
 workspace_package: '@pmndrs/glyph-benchmarks'
 documentation_type: reference
-source_digest: 'sha256:6598abc72f281bf3f00e8e28e10ddeb6bb53a7b6e794e087b11ec522d992313b'
+source_digest: 'sha256:6705343933e3e8312d8915c4b15a8cd06b3d87cb37dcb25760dae412bbb8076b'
 tags: [package, benchmarks, react, vite, product-e2e]
 sources:
   - id: manifest

--- a/docs/packages/benchmarks.md
+++ b/docs/packages/benchmarks.md
@@ -5,7 +5,7 @@ description: Provides the shared interactive and automated benchmark product sur
 resource: ../../apps/benchmarks
 workspace_package: '@pmndrs/glyph-benchmarks'
 documentation_type: reference
-source_digest: 'sha256:58f488e40757db856d31896b566d6a4df8f97e88fb0103f116da5a29ad971fef'
+source_digest: 'sha256:6598abc72f281bf3f00e8e28e10ddeb6bb53a7b6e794e087b11ec522d992313b'
 tags: [package, benchmarks, react, vite, product-e2e]
 sources:
   - id: manifest

--- a/docs/packages/glyph-example-raster.md
+++ b/docs/packages/glyph-example-raster.md
@@ -5,7 +5,7 @@ description: Proves the published raster and baker extension boundary with a pri
 resource: ../../packages/glyph-example-raster
 workspace_package: '@pmndrs/glyph-example-raster'
 documentation_type: reference
-source_digest: 'sha256:1f9753429ec00bf8bfb91649aa8dbcdea2aa1f485d23192a0151895c71299b46'
+source_digest: 'sha256:1066b4f07fba9e6aee06191f4d8a04a23bb0962c9f4f1ee441858da7e565311f'
 tags: [package, raster, extension-proof, threejs, tsl]
 sources:
   - id: manifest

--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:2dcf9eaf2fa473aef296c8f08a0799a02605dc2d5e9e4e7edbe0203fcc5c39f3'
+source_digest: 'sha256:03f24285a7c5763345002f8f84a36a0d6c1c348db53f8e13b3f7e4cc1d429414'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/docs/planning/api-shapes.md
+++ b/docs/planning/api-shapes.md
@@ -576,25 +576,25 @@ Every raster module's draw-batch type extends the renderer-neutral `RasterDrawBa
 ## Shared bake core
 
 ```ts
-interface FontBakeRequestV0 {
+interface FontBakeRequest {
   source: Uint8Array;
-  descriptor: FontBakeDescriptorV0;
+  descriptor: FontBakeDescriptor;
 }
 
-interface FontBakeDescriptorV0 {
+interface FontBakeDescriptor {
   formatVersion: 0;
   fontFaceIndex: number;
 }
 
-interface BakeArtifactV0 {
+interface BakeArtifact {
   role: 'font' | 'raster' | 'raster-page';
   id: string;
   bytes: Uint8Array;
   sha256: Sha256Hex;
 }
 
-interface BakeResultV0 {
-  artifacts: readonly BakeArtifactV0[];
+interface BakeResult {
+  artifacts: readonly BakeArtifact[];
   report: FontPayloadReport;
   warnings: readonly BakeWarning[];
 }
@@ -639,7 +639,7 @@ interface FontPayloadReport {
   }[];
   containers: readonly {
     artifactId: string;
-    role: BakeArtifactV0['role'];
+    role: BakeArtifact['role'];
     jsonBytes: number;
     paddingBytes: number;
     totalBytes: number;
@@ -650,7 +650,7 @@ interface FontPayloadReport {
 
 The font bake core owns only shaping data, shared metrics, glyph identity, provenance, and the read-only source-font context offered to raster bakers. It has no raster descriptor union. Bitmap, MSDF, Slug, and external packages each own their options, descriptor schema, generator, artifact schema, writer, validator, and diagnostics.
 
-The Node and Worker hosts orchestrate selected raster baker modules and compose their returned artifacts. `RasterPackagingV0` belongs to that generic composition envelope, not to a raster's internal data schema. `artifact` controls whether the companion raster index is embedded in the core GLB or emitted separately; `pages` controls whether page payloads are embedded in that companion asset or emitted as independently addressable artifacts. Descriptor bodies remain opaque to core. For embedded composition, every integer glTF buffer-view reference in extension JSON is named exactly `bufferView` or ends in `BufferView`; the host range-checks and rebases those fields without interpreting package semantics.
+The Node and Worker hosts orchestrate selected raster baker modules and compose their returned artifacts. `RasterPackaging` belongs to that generic composition envelope, not to a raster's internal data schema. `artifact` controls whether the companion raster index is embedded in the core GLB or emitted separately; `pages` controls whether page payloads are embedded in that companion asset or emitted as independently addressable artifacts. Descriptor bodies remain opaque to core. For embedded composition, every integer glTF buffer-view reference in extension JSON is named exactly `bufferView` or ends in `BufferView`; the host range-checks and rebases those fields without interpreting package semantics.
 
 ## Node host
 
@@ -660,7 +660,7 @@ interface NodeBakeOptions<
 > {
   input: string | URL;
   output: string | URL;
-  font: Omit<FontBakeDescriptorV0, 'formatVersion'>;
+  font: Omit<FontBakeDescriptor, 'formatVersion'>;
   rasters?: Rasters;
   signal?: AbortSignal;
 }
@@ -683,7 +683,7 @@ interface NodeBakeExecutionReport {
     processMaxRssBytes: number;
   };
   outputs: readonly {
-    role: BakeArtifactV0['role'];
+    role: BakeArtifact['role'];
     file: string;
     bytes: number;
     sha256: string;
@@ -779,14 +779,14 @@ Dynamic font URLs remain valid. When discovery cannot establish a local source, 
 ## Worker protocol
 
 ```ts
-interface RuntimeBakeRequestV0 {
+interface RuntimeBakeRequest {
   type: 'bake-font-v0';
   id: number;
   source: ArrayBuffer;
-  font: FontBakeDescriptorV0;
+  font: FontBakeDescriptor;
 }
 
-interface RuntimeBakeSuccessV0 {
+interface RuntimeBakeSuccess {
   type: 'bake-font-result-v0';
   id: number;
   ok: true;
@@ -800,7 +800,7 @@ interface RuntimeBakeSuccessV0 {
   warnings: readonly BakeWarning[];
 }
 
-interface RuntimeBakeFailureV0 {
+interface RuntimeBakeFailure {
   type: 'bake-font-result-v0';
   id: number;
   ok: false;
@@ -1223,12 +1223,12 @@ interface RasterBakeFontContext {
 interface RasterBakeRequest<Descriptor> {
   font: RasterBakeFontContext;
   rasterKey: string;
-  packaging: RasterPackagingV0;
+  packaging: RasterPackaging;
   descriptor: Descriptor;
   signal?: AbortSignal;
 }
 
-interface RasterPackagingV0 {
+interface RasterPackaging {
   artifact: 'embedded' | 'external';
   pages: 'embedded' | 'external';
 }
@@ -1238,7 +1238,7 @@ interface RasterBakeArtifact<Kind extends string = string> {
   kind: Kind;
   extension: string;
   version: number;
-  artifacts: readonly BakeArtifactV0[];
+  artifacts: readonly BakeArtifact[];
   report: RasterPayloadReport;
 }
 
@@ -1248,7 +1248,7 @@ declare function defineRasterBaker<const Kind extends string, Options, Descripto
 
 interface RasterBakePlan<M extends AnyRasterBakerModule> {
   baker: M;
-  packaging: RasterPackagingV0;
+  packaging: RasterPackaging;
   options: RasterBakeOptionsOf<M>;
 }
 ```

--- a/docs/planning/raster-data-contract.md
+++ b/docs/planning/raster-data-contract.md
@@ -87,7 +87,7 @@ A combined GLB may embed at most one raster for a given companion extension name
 Every raster extension root contains the reciprocal binding:
 
 ```ts
-interface RasterBindingV0 {
+interface RasterBinding {
   version: 0;
   rasterKey: string;
   shapingHash: string;
@@ -115,15 +115,15 @@ interface RasterBindingV0 {
 Bitmap and distance-field pages, and losslessly wrapped Slug textures, use the same descriptor:
 
 ```ts
-interface TextureResourceV0 {
+interface TextureResource {
   width: number;
   height: number;
   mipLevelCount: number;
   colorSpace: 'linear' | 'srgb';
-  variants: readonly TextureVariantV0[];
+  variants: readonly TextureVariant[];
 }
 
-type ResourceSourceV0 =
+type ResourceSource =
   | { type: 'bufferView'; bufferView: number }
   | {
       type: 'external';
@@ -132,12 +132,12 @@ type ResourceSourceV0 =
       artifactHash: string;
     };
 
-interface BinaryResourceV0 {
-  source: ResourceSourceV0;
+interface BinaryResource {
+  source: ResourceSource;
 }
 
-interface TextureVariantV0 {
-  source: ResourceSourceV0;
+interface TextureVariant {
+  source: ResourceSource;
   container: 'ktx2';
   gpuFormat:
     | 'r8unorm'
@@ -176,13 +176,13 @@ V0 bitmap raster contains one or more generated strikes. Each strike owns dense 
 The bitmap API accepts a non-empty, duplicate-free tuple of positive integer ppem values. Each public scalar produces a square `(ppemX, ppemY) = (value, value)` strike. Its package-owned descriptor sorts those values in ascending order before key derivation. The extension's `strikes` array MUST use that canonical order and contain exactly those declared pairs; an artifact missing a requested strike, containing a different strike tuple, or carrying a different `rasterKey` does not satisfy the configured bitmap raster. The loader treats it as a baked miss, emits the normal deduplicated development warning, and automatically invokes the bitmap package's runtime baker when source bytes are available. It never silently substitutes a nearby baked strike for one requested by the font token.
 
 ```ts
-interface BitmapStrikeV0 {
+interface BitmapStrike {
   ppemX: number;
   ppemY: number;
   planeUnitsPerEm: number;
   recordBufferView: number;
   recordStride: 20;
-  pages: readonly TextureResourceV0[];
+  pages: readonly TextureResource[];
 }
 ```
 
@@ -224,14 +224,14 @@ For the non-subsetted V0 fixtures, records are 58,740 bytes for the pinned 2,937
 This extension is the serialized resource for the public MSDF raster module. Merged v0 and target v1 support one encoding: MTSDF in linear RGBA8. RGB stores the multi-channel signed-distance field and alpha stores true signed distance. The lossless GPU baseline is already four-channel because WebGPU has no ordinary `rgb8unorm` sampled texture format; discarding alpha would not reduce that baseline's GPU residency.
 
 ```ts
-interface MsdfRasterV0 {
+interface MsdfRaster {
   encoding: 'mtsdf';
   emSize: number;
   pixelRange: number;
   planeUnitsPerEm: number;
   recordBufferView: number;
   recordStride: 20;
-  pages: readonly TextureResourceV0[];
+  pages: readonly TextureResource[];
 }
 ```
 
@@ -315,16 +315,16 @@ Pages expose the curve payload as RGBA16F, headers as R32UI, and references as R
 ### Slug page descriptor
 
 ```ts
-interface SlugPageV0 {
-  curve: TextureResourceV0;
+interface SlugPage {
+  curve: TextureResource;
   headerCount: number;
   headerWidth: number;
   headerHeight: number;
-  headerResource: BinaryResourceV0;
+  headerResource: BinaryResource;
   referenceCount: number;
   referenceWidth: number;
   referenceHeight: number;
-  referenceResource: BinaryResourceV0;
+  referenceResource: BinaryResource;
 }
 ```
 

--- a/docs/planning/shaping-data-contract.md
+++ b/docs/planning/shaping-data-contract.md
@@ -155,7 +155,7 @@ This domain-separated encoding is used identically by the baker, loader, cache, 
 `PMNDRS_font` repeats a small set of values outside the SFNT so the loader can validate and expose them without a JavaScript table walk:
 
 ```ts
-interface FontMetricsV0 {
+interface FontMetrics {
   glyphCount: number;
   glyphIdWidth: 16;
   unitsPerEm: number;
@@ -321,7 +321,7 @@ total shaping bytes = sfnt bytes + font-function bytes
 Every bake report MUST list each retained table independently:
 
 ```ts
-interface ShapingPayloadReportV0 {
+interface ShapingPayloadReport {
   format: 'opentype-sfnt-harfrust-v0';
   sfntDirectoryBytes: number;
   tables: readonly {

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -276,7 +276,7 @@ Item 2.1 is closed. Its analyzer remains internal until item 2.4 exposes the com
 
 ### 2.2 closure checklist
 
-- [x] The portable TypeScript boundary accepts exactly one `FontBakeRequestV0` and returns `FontBakeResultV0`; Node's separate filesystem-oriented `bakeFont(options)` name remains reserved for item 2.4.
+- [x] The portable TypeScript boundary accepts exactly one `FontBakeRequest` and returns `FontBakeResult`; Node's separate filesystem-oriented `bakeFont(options)` name remains reserved for item 2.4.
 - [x] One `no_std + alloc`, zero-import `wasm32-unknown-unknown` core is shared-ready for Node and Worker hosts through the generated direct-memory ABI with no WASI or binding generator.
 - [x] Fontations owns SFNT/TTC parsing and Skrifa owns maintained glyph bounds; fixtures cover invalid bytes, WOFF/WOFF2, required tables, variable/AAT shaping systems, TTC face selection, and out-of-range face indexes.
 - [x] The canonical Inter 4.1 result binds exact source, descriptor, artifact, shaping, table, metric, extent, and byte identities in its immutable fixture manifest.

--- a/packages/glyph-example-raster/src/artifact.ts
+++ b/packages/glyph-example-raster/src/artifact.ts
@@ -1,5 +1,5 @@
 import type {
-  BakeArtifactV0,
+  BakeArtifact,
   RasterBakeArtifact,
   RasterBakeRequest,
   RasterResourceSource,
@@ -19,7 +19,7 @@ const BIN_CHUNK = 0x004e_4942;
 const HEADER = Uint8Array.of(0x47, 0x44, 0x42, GLYPH_EXAMPLE_FORMAT_VERSION);
 const GLTF_WITNESS = new Uint8Array(12);
 
-export interface GlyphExampleExtensionV0 {
+export interface GlyphExampleExtension {
   readonly version: 0;
   readonly rasterKey: string;
   readonly shapingHash: string;
@@ -44,7 +44,7 @@ export async function bakeGlyphExampleArtifact(
   const recordSource: RasterResourceSource = external
     ? { type: 'external', uri: recordId, byteLength: records.byteLength, artifactHash: recordHash }
     : { type: 'bufferView', bufferView: 2 };
-  const extension: GlyphExampleExtensionV0 = {
+  const extension: GlyphExampleExtension = {
     version: GLYPH_EXAMPLE_FORMAT_VERSION,
     rasterKey: request.rasterKey,
     shapingHash: request.font.shapingHash,
@@ -90,7 +90,7 @@ export async function bakeGlyphExampleArtifact(
   };
   const bytes = encodeGlb(document, binary);
   const metadataBytes = HEADER.byteLength + new TextEncoder().encode(JSON.stringify(extension)).byteLength;
-  const artifacts: BakeArtifactV0[] = [
+  const artifacts: BakeArtifact[] = [
     {
       role: 'raster',
       id: `${request.rasterKey}.glyph-example.glb`,

--- a/packages/glyph-example-raster/src/raster.ts
+++ b/packages/glyph-example-raster/src/raster.ts
@@ -10,7 +10,7 @@ import type {
 } from '@pmndrs/glyph';
 import { defineRasterResourceId, defineRasterTechnique } from '@pmndrs/glyph';
 
-import { isGlyphExampleHeader, type GlyphExampleExtensionV0 } from './artifact.js';
+import { isGlyphExampleHeader, type GlyphExampleExtension } from './artifact.js';
 import {
   GLYPH_EXAMPLE_EXTENSION,
   GLYPH_EXAMPLE_FORMAT_VERSION,
@@ -75,7 +75,7 @@ export const glyphExample: RasterTechnique<
 function decodeExtension(
   font: RegisteredFont,
   raster: RegisteredRaster<typeof GLYPH_EXAMPLE_KIND>,
-): GlyphExampleExtensionV0 {
+): GlyphExampleExtension {
   const extension = objectValue(raster.extensionData, 'glyph-example extension');
   if (
     extension.version !== GLYPH_EXAMPLE_FORMAT_VERSION ||

--- a/packages/glyph/src/bake.ts
+++ b/packages/glyph/src/bake.ts
@@ -21,12 +21,12 @@ export interface BakeProgress {
 
 export type BakeProgressListener = (progress: BakeProgress) => void;
 
-export interface RasterPackagingV0 {
+export interface RasterPackaging {
   readonly artifact: 'embedded' | 'external';
   readonly pages: 'embedded' | 'external';
 }
 
-export interface BakeArtifactV0 {
+export interface BakeArtifact {
   readonly role: 'font' | 'raster' | 'raster-page';
   readonly id: string;
   readonly bytes: Uint8Array;
@@ -43,7 +43,7 @@ export interface RasterBakeFontContext {
 export interface RasterBakeRequest<Descriptor extends JsonValue> {
   readonly font: RasterBakeFontContext;
   readonly rasterKey: RasterKey;
-  readonly packaging: RasterPackagingV0;
+  readonly packaging: RasterPackaging;
   readonly descriptor: Descriptor;
   readonly signal?: AbortSignal;
   readonly onProgress?: BakeProgressListener;
@@ -77,7 +77,7 @@ export interface FontPayloadReport {
   }[];
   readonly containers: readonly {
     readonly artifactId: string;
-    readonly role: BakeArtifactV0['role'];
+    readonly role: BakeArtifact['role'];
     readonly jsonBytes: number;
     readonly paddingBytes: number;
     readonly totalBytes: number;
@@ -94,7 +94,7 @@ export interface RasterBakeArtifact<Kind extends string = string> {
   readonly kind: Kind;
   readonly extension: string;
   readonly version: number;
-  readonly artifacts: readonly BakeArtifactV0[];
+  readonly artifacts: readonly BakeArtifact[];
   readonly report: RasterPayloadReport;
 }
 
@@ -122,7 +122,7 @@ export function defineRasterBaker<const Kind extends string, Options, Descriptor
 
 export interface RasterBakePlan<Module extends AnyRasterBakerModule> {
   readonly baker: Module;
-  readonly packaging: RasterPackagingV0;
+  readonly packaging: RasterPackaging;
   readonly options: RasterBakeOptionsOf<Module>;
 }
 

--- a/packages/glyph/src/bakers/bitmap-validator.ts
+++ b/packages/glyph/src/bakers/bitmap-validator.ts
@@ -49,7 +49,7 @@ import {
   BITMAP_FORMAT_VERSION,
   bitmapDescriptorRasterKey,
   canonicalizeBitmapDescriptor,
-  type BitmapDescriptorV0,
+  type BitmapDescriptor,
 } from '../internal/bitmap-contract.js';
 
 const RECORD_STRIDE = 20;
@@ -104,12 +104,12 @@ export interface BitmapArtifactValidationContext {
   readonly shapingHash: Sha256Hex | string;
   readonly glyphCount: number;
   readonly glyphIdWidth: 16;
-  readonly descriptor: BitmapDescriptorV0;
+  readonly descriptor: BitmapDescriptor;
   readonly externalPages?: ReadonlyMap<string, Uint8Array>;
   readonly limits?: Partial<BitmapArtifactValidationLimits>;
 }
 
-export interface ValidatedBitmapPageV0 {
+export interface ValidatedBitmapPage {
   readonly width: number;
   readonly height: number;
   readonly bytes: Uint8Array;
@@ -117,19 +117,19 @@ export interface ValidatedBitmapPageV0 {
   readonly uri?: string;
 }
 
-export interface ValidatedBitmapStrikeV0 {
+export interface ValidatedBitmapStrike {
   readonly ppem: number;
   readonly planeUnitsPerEm: number;
   readonly records: Uint8Array;
-  readonly pages: readonly ValidatedBitmapPageV0[];
+  readonly pages: readonly ValidatedBitmapPage[];
 }
 
-export interface ValidatedBitmapArtifactV0 {
+export interface ValidatedBitmapArtifact {
   readonly document: Readonly<Record<string, unknown>>;
   readonly rasterKey: RasterKey;
   readonly shapingHash: Sha256Hex;
   readonly glyphCount: number;
-  readonly strikes: readonly ValidatedBitmapStrikeV0[];
+  readonly strikes: readonly ValidatedBitmapStrike[];
   readonly khronos: KhronosValidationReport;
 }
 
@@ -150,7 +150,7 @@ export class BitmapArtifactValidationError extends Error {
 export async function validateBitmapArtifact(
   bytes: Uint8Array,
   context: BitmapArtifactValidationContext,
-): Promise<ValidatedBitmapArtifactV0> {
+): Promise<ValidatedBitmapArtifact> {
   try {
     const parsed = parseGlb(bytes);
     const khronos = await validateWithKhronos(bytes, parsed.document);
@@ -168,7 +168,7 @@ async function validateBitmapSemantics(
   parsed: ParsedGlb,
   khronos: KhronosValidationReport,
   context: BitmapArtifactValidationContext,
-): Promise<ValidatedBitmapArtifactV0> {
+): Promise<ValidatedBitmapArtifact> {
   const expectedDescriptor = canonicalizeBitmapDescriptor(context.descriptor.strikes, context.descriptor.coverage);
   if (canonicalJson(context.descriptor) !== canonicalJson(expectedDescriptor)) {
     fail('BITMAP_DESCRIPTOR', 'descriptor is not in canonical bitmap form', '/descriptor');
@@ -264,7 +264,7 @@ async function validateBitmapSemantics(
   }
 
   let gpuBytes = 0;
-  const strikes: ValidatedBitmapStrikeV0[] = [];
+  const strikes: ValidatedBitmapStrike[] = [];
   for (let strikeIndex = 0; strikeIndex < strikeValues.length; strikeIndex += 1) {
     const path = `/extensions/${BITMAP_EXTENSION}/strikes/${strikeIndex}`;
     const strike = requireNonArrayObject(strikeValues[strikeIndex], path);
@@ -283,7 +283,7 @@ async function validateBitmapSemantics(
       fail('RECORD_LENGTH', 'record view must contain exactly glyphCount × 20 bytes', `${path}/recordBufferView`);
     }
     const pageValues = asArray(strike.pages, `${path}/pages`);
-    const pages: ValidatedBitmapPageV0[] = [];
+    const pages: ValidatedBitmapPage[] = [];
     for (let pageIndex = 0; pageIndex < pageValues.length; pageIndex += 1) {
       const pagePath = `${path}/pages/${pageIndex}`;
       const page = requireNonArrayObject(pageValues[pageIndex], pagePath);
@@ -294,7 +294,7 @@ async function validateBitmapSemantics(
       }
       const variants = asArray(page.variants, `${pagePath}/variants`);
       const seenFormats = new Set<string>();
-      let baselinePage: ValidatedBitmapPageV0 | undefined;
+      let baselinePage: ValidatedBitmapPage | undefined;
       for (let variantIndex = 0; variantIndex < variants.length; variantIndex += 1) {
         const variantPath = `${pagePath}/variants/${variantIndex}`;
         const variant = requireNonArrayObject(variants[variantIndex], variantPath);

--- a/packages/glyph/src/bakers/bitmap.ts
+++ b/packages/glyph/src/bakers/bitmap.ts
@@ -13,7 +13,7 @@ import {
   BITMAP_FORMAT_VERSION,
   BITMAP_KIND,
   bitmapDescriptor,
-  type BitmapDescriptorV0,
+  type BitmapDescriptor,
 } from '../internal/bitmap-contract.js';
 import type { RasterCoverage } from '../raster-coverage.js';
 
@@ -24,7 +24,7 @@ export interface BitmapBakerOptions {
   readonly coverage?: RasterCoverage;
 }
 
-export interface BitmapBakerRequestV0 {
+export interface BitmapBakerRequest {
   readonly fontFaceIndex: number;
   readonly glyphCount: number;
   readonly shapingHash: string;
@@ -33,22 +33,22 @@ export interface BitmapBakerRequestV0 {
     readonly artifact: 'embedded' | 'external';
     readonly pages: 'embedded' | 'external';
   };
-  readonly descriptor: BitmapDescriptorV0;
+  readonly descriptor: BitmapDescriptor;
 }
 
-export interface BitmapBakerCoreRequestV0 {
+export interface BitmapBakerCoreRequest {
   readonly source: Uint8Array;
-  readonly request: BitmapBakerRequestV0;
+  readonly request: BitmapBakerRequest;
   readonly onProgress?: BakeProgressListener;
 }
 
 export interface BitmapBakerCore {
-  bake(request: BitmapBakerCoreRequestV0): RasterBakeArtifact<'bitmap'>;
+  bake(request: BitmapBakerCoreRequest): RasterBakeArtifact<'bitmap'>;
 }
 
 export type BitmapBakerWasmSource = BufferSource | WebAssembly.Module;
 
-export type BitmapBakerAbiV0 = BitmapBakerAbi;
+export type { BitmapBakerAbi };
 
 export class BitmapBakeError extends Error {
   readonly code: string;
@@ -85,7 +85,7 @@ export async function createBitmapBaker(source: BitmapBakerWasmSource): Promise<
 }
 
 export function createBitmapBakerFromInstance(instance: WebAssembly.Instance): BitmapBakerCore {
-  return createDirectRasterBakerFromInstance<BitmapBakerRequestV0, 'bitmap'>(instance, bitmapBakerAbi, {
+  return createDirectRasterBakerFromInstance<BitmapBakerRequest, 'bitmap'>(instance, bitmapBakerAbi, {
     label: 'bitmap baker',
     kind: BITMAP_KIND,
     extension: BITMAP_EXTENSION,
@@ -97,13 +97,13 @@ export function createBitmapBakerFromInstance(instance: WebAssembly.Instance): B
 
 export function bitmapBakerFromCore(
   core: BitmapBakerCore,
-): RasterBakerModule<'bitmap', BitmapBakerOptions, BitmapDescriptorV0> {
+): RasterBakerModule<'bitmap', BitmapBakerOptions, BitmapDescriptor> {
   return {
     kind: BITMAP_KIND,
     extension: BITMAP_EXTENSION,
     version: BITMAP_FORMAT_VERSION,
     descriptor: bitmapDescriptor,
-    async bake(request: RasterBakeRequest<BitmapDescriptorV0>) {
+    async bake(request: RasterBakeRequest<BitmapDescriptor>) {
       request.signal?.throwIfAborted();
       const result = core.bake({
         source: request.font.source,
@@ -139,7 +139,7 @@ async function loadDefaultBitmapBaker(): Promise<ReturnType<typeof bitmapBakerFr
 
 const defaultBitmapBaker = cacheSuccessfulPromise(loadDefaultBitmapBaker);
 
-export const bitmapBaker: RasterBakerModule<'bitmap', BitmapBakerOptions, BitmapDescriptorV0> = {
+export const bitmapBaker: RasterBakerModule<'bitmap', BitmapBakerOptions, BitmapDescriptor> = {
   kind: BITMAP_KIND,
   extension: BITMAP_EXTENSION,
   version: BITMAP_FORMAT_VERSION,

--- a/packages/glyph/src/bakers/msdf-validator.ts
+++ b/packages/glyph/src/bakers/msdf-validator.ts
@@ -49,7 +49,7 @@ import {
   msdfDescriptor,
   msdfDescriptorRasterKey,
   type MsdfConfiguration,
-  type MsdfDescriptorV0,
+  type MsdfDescriptor,
 } from '../internal/msdf-contract.js';
 
 const RECORD_STRIDE = 20;
@@ -79,12 +79,12 @@ export interface MsdfArtifactValidationContext {
   readonly shapingHash: Sha256Hex | string;
   readonly glyphCount: number;
   readonly glyphIdWidth: 16;
-  readonly descriptor: MsdfDescriptorV0;
+  readonly descriptor: MsdfDescriptor;
   readonly externalPages?: ReadonlyMap<string, Uint8Array>;
   readonly limits?: Partial<MsdfArtifactValidationLimits>;
 }
 
-export interface ValidatedMsdfPageV0 {
+export interface ValidatedMsdfPage {
   readonly width: number;
   readonly height: number;
   readonly bytes: Uint8Array;
@@ -92,13 +92,13 @@ export interface ValidatedMsdfPageV0 {
   readonly uri?: string;
 }
 
-export interface ValidatedMsdfArtifactV0 {
+export interface ValidatedMsdfArtifact {
   readonly document: Readonly<Record<string, unknown>>;
   readonly rasterKey: RasterKey;
   readonly shapingHash: Sha256Hex;
   readonly glyphCount: number;
   readonly records: Uint8Array;
-  readonly pages: readonly ValidatedMsdfPageV0[];
+  readonly pages: readonly ValidatedMsdfPage[];
   readonly khronos: KhronosValidationReport;
 }
 
@@ -120,7 +120,7 @@ export class MsdfArtifactValidationError extends Error {
 export async function validateMsdfArtifact(
   bytes: Uint8Array,
   context: MsdfArtifactValidationContext,
-): Promise<ValidatedMsdfArtifactV0> {
+): Promise<ValidatedMsdfArtifact> {
   try {
     const parsed = parseGlb(bytes);
     const khronos = await validateWithKhronos(bytes, parsed.document);
@@ -138,7 +138,7 @@ async function validateMsdfSemantics(
   parsed: ParsedGlb,
   khronos: KhronosValidationReport,
   context: MsdfArtifactValidationContext,
-): Promise<ValidatedMsdfArtifactV0> {
+): Promise<ValidatedMsdfArtifact> {
   requireNonArrayObject(context.descriptor, '/descriptor');
   let configuration: MsdfConfiguration;
   try {
@@ -251,7 +251,7 @@ async function validateMsdfSemantics(
 
   let textureArrayWidth = 0;
   let textureArrayHeight = 0;
-  const pages: ValidatedMsdfPageV0[] = [];
+  const pages: ValidatedMsdfPage[] = [];
   const pageValues = asArray(extension.pages, `${extensionPath}/pages`);
   for (let pageIndex = 0; pageIndex < pageValues.length; pageIndex += 1) {
     const pagePath = `${extensionPath}/pages/${pageIndex}`;

--- a/packages/glyph/src/bakers/msdf.ts
+++ b/packages/glyph/src/bakers/msdf.ts
@@ -20,14 +20,14 @@ import {
   MSDF_KIND,
   msdfDescriptor,
   type MsdfOptions,
-  type MsdfDescriptorV0,
+  type MsdfDescriptor,
 } from '../internal/msdf-contract.js';
 
 export { mtsdfBakerAbi as msdfBakerAbi } from '../generated/mtsdf-baker-abi.js';
 
 export type MsdfBakerOptions = MsdfOptions | undefined;
 
-export interface MsdfBakerRequestV0 {
+export interface MsdfBakerRequest {
   readonly fontFaceIndex: number;
   readonly glyphCount: number;
   readonly shapingHash: string;
@@ -36,22 +36,22 @@ export interface MsdfBakerRequestV0 {
     readonly artifact: 'embedded' | 'external';
     readonly pages: 'embedded' | 'external';
   };
-  readonly descriptor: MsdfDescriptorV0;
+  readonly descriptor: MsdfDescriptor;
 }
 
-export interface MsdfBakerCoreRequestV0 {
+export interface MsdfBakerCoreRequest {
   readonly source: Uint8Array;
-  readonly request: MsdfBakerRequestV0;
+  readonly request: MsdfBakerRequest;
   readonly onProgress?: BakeProgressListener;
 }
 
 export interface MsdfBakerCore {
-  bake(request: MsdfBakerCoreRequestV0): RasterBakeArtifact<'msdf'>;
+  bake(request: MsdfBakerCoreRequest): RasterBakeArtifact<'msdf'>;
 }
 
 export type MsdfBakerWasmSource = BufferSource | WebAssembly.Module;
 
-export type MsdfBakerAbiV1 = MsdfBakerAbi;
+export type { MsdfBakerAbi };
 
 export class MsdfBakeError extends Error {
   readonly code: string;
@@ -120,7 +120,7 @@ export function createMsdfBakerFromInstance(instance: WebAssembly.Instance): Msd
       },
     },
   };
-  return createDirectRasterBakerFromInstance<MsdfBakerRequestV0, 'msdf'>(instance, directAbi, {
+  return createDirectRasterBakerFromInstance<MsdfBakerRequest, 'msdf'>(instance, directAbi, {
     label: 'MSDF baker',
     kind: MSDF_KIND,
     extension: MSDF_EXTENSION,
@@ -130,13 +130,13 @@ export function createMsdfBakerFromInstance(instance: WebAssembly.Instance): Msd
   });
 }
 
-export function msdfBakerFromCore(core: MsdfBakerCore): RasterBakerModule<'msdf', MsdfBakerOptions, MsdfDescriptorV0> {
+export function msdfBakerFromCore(core: MsdfBakerCore): RasterBakerModule<'msdf', MsdfBakerOptions, MsdfDescriptor> {
   return {
     kind: MSDF_KIND,
     extension: MSDF_EXTENSION,
     version: MSDF_FORMAT_VERSION,
     descriptor: msdfDescriptor,
-    async bake(request: RasterBakeRequest<MsdfDescriptorV0>) {
+    async bake(request: RasterBakeRequest<MsdfDescriptor>) {
       request.signal?.throwIfAborted();
       const result = core.bake({
         source: request.font.source,
@@ -172,7 +172,7 @@ async function loadDefaultMsdfBaker(): Promise<ReturnType<typeof msdfBakerFromCo
 
 const defaultMsdfBaker = cacheSuccessfulPromise(loadDefaultMsdfBaker);
 
-export const msdfBaker: RasterBakerModule<'msdf', MsdfBakerOptions, MsdfDescriptorV0> = {
+export const msdfBaker: RasterBakerModule<'msdf', MsdfBakerOptions, MsdfDescriptor> = {
   kind: MSDF_KIND,
   extension: MSDF_EXTENSION,
   version: MSDF_FORMAT_VERSION,

--- a/packages/glyph/src/bakers/slug-validator.ts
+++ b/packages/glyph/src/bakers/slug-validator.ts
@@ -48,7 +48,7 @@ import {
   SLUG_GLYPH_RECORD_STRIDE,
   SLUG_PLANE_UNITS_PER_EM,
   slugDescriptorRasterKey,
-  type SlugDescriptorV0,
+  type SlugDescriptor,
 } from '../internal/slug-contract.js';
 
 const CURVE_BYTES_PER_TEXEL = 8;
@@ -81,38 +81,38 @@ export interface SlugArtifactValidationContext {
   readonly shapingHash: Sha256Hex | string;
   readonly glyphCount: number;
   readonly glyphIdWidth: 16;
-  readonly descriptor: SlugDescriptorV0;
+  readonly descriptor: SlugDescriptor;
   readonly externalPages?: ReadonlyMap<string, Uint8Array>;
   readonly limits?: Partial<SlugArtifactValidationLimits>;
 }
 
-export interface ValidatedSlugResourceV0 {
+export interface ValidatedSlugResource {
   readonly bytes: Uint8Array;
   readonly source: 'embedded' | 'external';
   readonly uri?: string;
 }
 
-export interface ValidatedSlugPageV0 {
+export interface ValidatedSlugPage {
   readonly curveWidth: number;
   readonly curveHeight: number;
-  readonly curve: ValidatedSlugResourceV0;
+  readonly curve: ValidatedSlugResource;
   readonly headerCount: number;
   readonly headerWidth: number;
   readonly headerHeight: number;
-  readonly headers: ValidatedSlugResourceV0;
+  readonly headers: ValidatedSlugResource;
   readonly referenceCount: number;
   readonly referenceWidth: number;
   readonly referenceHeight: number;
-  readonly references: ValidatedSlugResourceV0;
+  readonly references: ValidatedSlugResource;
 }
 
-export interface ValidatedSlugArtifactV0 {
+export interface ValidatedSlugArtifact {
   readonly document: Readonly<Record<string, unknown>>;
   readonly rasterKey: RasterKey;
   readonly shapingHash: Sha256Hex;
   readonly glyphCount: number;
   readonly records: Uint8Array;
-  readonly pages: readonly ValidatedSlugPageV0[];
+  readonly pages: readonly ValidatedSlugPage[];
   readonly khronos: KhronosValidationReport;
 }
 
@@ -134,7 +134,7 @@ export class SlugArtifactValidationError extends Error {
 export async function validateSlugArtifact(
   bytes: Uint8Array,
   context: SlugArtifactValidationContext,
-): Promise<ValidatedSlugArtifactV0> {
+): Promise<ValidatedSlugArtifact> {
   try {
     const parsed = parseGlb(bytes);
     const khronos = await validateWithKhronos(bytes, parsed.document);
@@ -152,7 +152,7 @@ async function validateSlugSemantics(
   parsed: ParsedGlb,
   khronos: KhronosValidationReport,
   context: SlugArtifactValidationContext,
-): Promise<ValidatedSlugArtifactV0> {
+): Promise<ValidatedSlugArtifact> {
   await validateContext(context);
   const document = parsed.document;
   const used = stringArray(document.extensionsUsed, '/extensionsUsed');
@@ -229,7 +229,7 @@ async function validateSlugSemantics(
   }
 
   let gpuBytes = 0;
-  const pages: ValidatedSlugPageV0[] = [];
+  const pages: ValidatedSlugPage[] = [];
   const pageValues = asArray(extension.pages, `${extensionPath}/pages`);
   for (let pageIndex = 0; pageIndex < pageValues.length; pageIndex += 1) {
     const pagePath = `${extensionPath}/pages/${pageIndex}`;
@@ -290,7 +290,7 @@ async function validatePage(
   claimedViews: Set<number>,
   externalPages: ReadonlyMap<string, Uint8Array> | undefined,
   limits: SlugArtifactValidationLimits,
-): Promise<ValidatedSlugPageV0> {
+): Promise<ValidatedSlugPage> {
   const curve = requireNonArrayObject(page.curve, `${pagePath}/curve`);
   const curveWidth = asInteger(curve.width, `${pagePath}/curve/width`, 1, limits.maxTextureDimension2D);
   const curveHeight = asInteger(curve.height, `${pagePath}/curve/height`, 1, limits.maxTextureDimension2D);
@@ -418,7 +418,7 @@ function validateIntegerGrid(
 
 function validateSlugRecords(
   records: Uint8Array,
-  pages: readonly ValidatedSlugPageV0[],
+  pages: readonly ValidatedSlugPage[],
   glyphCount: number,
   path: string,
 ): void {
@@ -490,7 +490,7 @@ function validateSlugRecords(
 }
 
 function validateHeaderRange(
-  page: ValidatedSlugPageV0,
+  page: ValidatedSlugPage,
   headerBase: number,
   headerCount: number,
   curveBase: number,
@@ -542,7 +542,7 @@ function recordAbsentPayloadIsZero(records: Uint8Array, offset: number): boolean
   return true;
 }
 
-function pageGpuBytes(page: ValidatedSlugPageV0, path: string): number {
+function pageGpuBytes(page: ValidatedSlugPage, path: string): number {
   const curveBytes = checkedProduct(
     checkedProduct(page.curveWidth, page.curveHeight, path),
     CURVE_BYTES_PER_TEXEL,
@@ -555,7 +555,7 @@ function pageGpuBytes(page: ValidatedSlugPageV0, path: string): number {
   );
 }
 
-function validatedResource(resource: ResolvedRasterPageSource): ValidatedSlugResourceV0 {
+function validatedResource(resource: ResolvedRasterPageSource): ValidatedSlugResource {
   return {
     bytes: resource.bytes,
     source: resource.source,

--- a/packages/glyph/src/bakers/slug.ts
+++ b/packages/glyph/src/bakers/slug.ts
@@ -16,7 +16,7 @@ import {
   SLUG_FORMAT_VERSION,
   SLUG_KIND,
   slugDescriptor,
-  type SlugDescriptorV0,
+  type SlugDescriptor,
 } from '../internal/slug-contract.js';
 import { cacheSuccessfulPromise } from '../internal/successful-promise-cache.js';
 
@@ -24,7 +24,7 @@ export { slugBakerAbi } from '../generated/slug-baker-abi.js';
 
 export type SlugBakerOptions = undefined;
 
-export interface SlugBakerRequestV0 {
+export interface SlugBakerRequest {
   readonly fontFaceIndex: number;
   readonly glyphCount: number;
   readonly shapingHash: string;
@@ -33,21 +33,21 @@ export interface SlugBakerRequestV0 {
     readonly artifact: 'embedded' | 'external';
     readonly pages: 'embedded' | 'external';
   };
-  readonly descriptor: SlugDescriptorV0;
+  readonly descriptor: SlugDescriptor;
 }
 
-export interface SlugBakerCoreRequestV0 {
+export interface SlugBakerCoreRequest {
   readonly source: Uint8Array;
-  readonly request: SlugBakerRequestV0;
+  readonly request: SlugBakerRequest;
   readonly onProgress?: BakeProgressListener;
 }
 
 export interface SlugBakerCore {
-  bake(request: SlugBakerCoreRequestV0): RasterBakeArtifact<typeof SLUG_KIND>;
+  bake(request: SlugBakerCoreRequest): RasterBakeArtifact<typeof SLUG_KIND>;
 }
 
 export type SlugBakerWasmSource = BufferSource | WebAssembly.Module;
-export type SlugBakerAbiV0 = SlugBakerAbi;
+export type { SlugBakerAbi };
 
 export class SlugBakeError extends Error {
   readonly code: string;
@@ -84,7 +84,7 @@ export async function createSlugBaker(source: SlugBakerWasmSource): Promise<Slug
 }
 
 export function createSlugBakerFromInstance(instance: WebAssembly.Instance): SlugBakerCore {
-  return createDirectRasterBakerFromInstance<SlugBakerRequestV0, typeof SLUG_KIND>(
+  return createDirectRasterBakerFromInstance<SlugBakerRequest, typeof SLUG_KIND>(
     instance,
     slugBakerAbi satisfies DirectRasterBakerAbi,
     {
@@ -100,13 +100,13 @@ export function createSlugBakerFromInstance(instance: WebAssembly.Instance): Slu
 
 export function slugBakerFromCore(
   core: SlugBakerCore,
-): RasterBakerModule<typeof SLUG_KIND, SlugBakerOptions, SlugDescriptorV0> {
+): RasterBakerModule<typeof SLUG_KIND, SlugBakerOptions, SlugDescriptor> {
   return {
     kind: SLUG_KIND,
     extension: SLUG_EXTENSION,
     version: SLUG_FORMAT_VERSION,
     descriptor: slugDescriptor,
-    async bake(request: RasterBakeRequest<SlugDescriptorV0>) {
+    async bake(request: RasterBakeRequest<SlugDescriptor>) {
       request.signal?.throwIfAborted();
       const result = core.bake({
         source: request.font.source,
@@ -142,7 +142,7 @@ async function loadDefaultSlugBaker(): Promise<ReturnType<typeof slugBakerFromCo
 
 const defaultSlugBaker = cacheSuccessfulPromise(loadDefaultSlugBaker);
 
-export const slugBaker: RasterBakerModule<typeof SLUG_KIND, SlugBakerOptions, SlugDescriptorV0> = {
+export const slugBaker: RasterBakerModule<typeof SLUG_KIND, SlugBakerOptions, SlugDescriptor> = {
   kind: SLUG_KIND,
   extension: SLUG_EXTENSION,
   version: SLUG_FORMAT_VERSION,

--- a/packages/glyph/src/font-baker/index.ts
+++ b/packages/glyph/src/font-baker/index.ts
@@ -3,33 +3,33 @@ import { fontBakerAbi, type FontBakerAbi } from './generated/font-baker-abi.js';
 export { FONT_BAKER_VERSION, FONT_FORMAT_VERSION } from './contract.js';
 export { fontBakerAbi } from './generated/font-baker-abi.js';
 
-export interface FontBakeDescriptorV0 {
+export interface FontBakeDescriptor {
   readonly formatVersion: 0;
   readonly fontFaceIndex: number;
 }
 
-export interface FontBakeRequestV0 {
+export interface FontBakeRequest {
   readonly source: Uint8Array;
-  readonly descriptor: FontBakeDescriptorV0;
+  readonly descriptor: FontBakeDescriptor;
 }
 
-export type UnicodeRangeV0 = {
+export type UnicodeRange = {
   readonly start: number;
   readonly end: number;
 };
 
-export interface FontSelectionV0 {
+export interface FontBakeSelection {
   readonly formatVersion: 0;
   readonly fontFaceIndex: number;
-  readonly unicodeRanges: readonly UnicodeRangeV0[];
+  readonly unicodeRanges: readonly UnicodeRange[];
 }
 
-export interface FontPrepareRequestV0 {
+export interface FontPrepareRequest {
   readonly source: Uint8Array;
-  readonly selection: FontSelectionV0;
+  readonly selection: FontBakeSelection;
 }
 
-export interface PreparedFontReportV0 {
+export interface PreparedFontReport {
   readonly formatVersion: 0;
   readonly sourceBytes: number;
   readonly preparedBytes: number;
@@ -38,31 +38,31 @@ export interface PreparedFontReportV0 {
   readonly sha256: string;
 }
 
-export interface PreparedFontV0 {
+export interface PreparedFont {
   readonly bytes: Uint8Array;
-  readonly report: PreparedFontReportV0;
+  readonly report: PreparedFontReport;
 }
 
-export interface FontInspectRequestV0 {
+export interface FontInspectRequest {
   readonly source: Uint8Array;
-  readonly descriptor: FontBakeDescriptorV0;
+  readonly descriptor: FontBakeDescriptor;
 }
 
-export interface GlyphInspectionV0 {
+export interface GlyphInspection {
   readonly codePoint: number;
   readonly glyphId: number;
   readonly name?: string;
 }
 
-export interface FontInspectionV0 {
+export interface FontInspection {
   readonly formatVersion: 0;
   readonly fontFaceIndex: number;
   readonly glyphCount: number;
   readonly glyphNameSource: 'post' | 'cff' | 'none';
-  readonly glyphs: readonly GlyphInspectionV0[];
+  readonly glyphs: readonly GlyphInspection[];
 }
 
-export interface BakeArtifactV0 {
+export interface BakeArtifact {
   readonly role: 'font';
   readonly id: string;
   readonly bytes: Uint8Array;
@@ -75,7 +75,7 @@ export interface BakeWarning {
   readonly path?: string;
 }
 
-export interface ShapingPayloadReportV0 {
+export interface ShapingPayloadReport {
   readonly format: 'opentype-sfnt-harfrust-v0';
   readonly sfntDirectoryBytes: number;
   readonly tables: readonly {
@@ -90,9 +90,9 @@ export interface ShapingPayloadReportV0 {
   readonly brotliBytes?: number;
 }
 
-export interface FontPayloadReportV0 {
+export interface FontBakePayloadReport {
   readonly source: { readonly bytes: number };
-  readonly shared: { readonly shaping: ShapingPayloadReportV0 };
+  readonly shared: { readonly shaping: ShapingPayloadReport };
   readonly rasters: readonly unknown[];
   readonly containers: readonly {
     readonly artifactId: string;
@@ -108,9 +108,9 @@ export interface FontPayloadReportV0 {
   }[];
 }
 
-export interface FontBakeResultV0 {
-  readonly artifacts: readonly BakeArtifactV0[];
-  readonly report: FontPayloadReportV0;
+export interface FontBakeResult {
+  readonly artifacts: readonly BakeArtifact[];
+  readonly report: FontBakePayloadReport;
   readonly warnings: readonly BakeWarning[];
 }
 
@@ -133,14 +133,14 @@ export class FontBakeError extends Error {
 }
 
 export interface FontBakeCore {
-  bake(request: FontBakeRequestV0): FontBakeResultV0;
-  prepare(request: FontPrepareRequestV0): PreparedFontV0;
-  inspect(request: FontInspectRequestV0): FontInspectionV0;
+  bake(request: FontBakeRequest): FontBakeResult;
+  prepare(request: FontPrepareRequest): PreparedFont;
+  inspect(request: FontInspectRequest): FontInspection;
 }
 
 export type FontBakerWasmSource = BufferSource | WebAssembly.Module;
 
-export type FontBakerAbiV0 = FontBakerAbi;
+export type { FontBakerAbi };
 
 interface FontArtifactMetadata {
   readonly role: 'font';
@@ -150,7 +150,7 @@ interface FontArtifactMetadata {
 
 interface FontResultMetadata {
   readonly artifacts: readonly FontArtifactMetadata[];
-  readonly report: FontPayloadReportV0;
+  readonly report: FontBakePayloadReport;
   readonly warnings: readonly BakeWarning[];
 }
 
@@ -201,7 +201,7 @@ interface FontBakerExports {
   readonly pmndrs_font_baker_result_len: () => number;
 }
 
-function readExports(exports: WebAssembly.Exports, abi: FontBakerAbiV0): FontBakerExports {
+function readExports(exports: WebAssembly.Exports, abi: FontBakerAbi): FontBakerExports {
   const memory = exports[abi.memory];
   const alloc = exports[abi.functions.allocate.export];
   const dealloc = exports[abi.functions.deallocate.export];
@@ -236,7 +236,7 @@ function invoke<Result>(
   operation: FontBakerOperation,
   source: Uint8Array,
   descriptor: unknown,
-  decode: (bytes: Uint8Array, abi: FontBakerAbiV0) => Result,
+  decode: (bytes: Uint8Array, abi: FontBakerAbi) => Result,
 ): Result {
   const descriptorBytes = textEncoder.encode(JSON.stringify(descriptor));
   let sourcePointer = 0;
@@ -277,7 +277,7 @@ function copyIntoWasm(exports: FontBakerExports, bytes: Uint8Array): number {
   }
 }
 
-function decodeEnvelope(bytes: Uint8Array, abi: FontBakerAbiV0): { metadata: unknown; artifact: Uint8Array } {
+function decodeEnvelope(bytes: Uint8Array, abi: FontBakerAbi): { metadata: unknown; artifact: Uint8Array } {
   const response = abi.response;
   if (
     bytes.byteLength < response.headerByteLength ||
@@ -305,7 +305,7 @@ function decodeEnvelope(bytes: Uint8Array, abi: FontBakerAbiV0): { metadata: unk
   };
 }
 
-function decodeBakeResponse(bytes: Uint8Array, abi: FontBakerAbiV0): FontBakeResultV0 {
+function decodeBakeResponse(bytes: Uint8Array, abi: FontBakerAbi): FontBakeResult {
   const { metadata, artifact: artifactBytes } = decodeEnvelope(bytes, abi);
   assertFontResultMetadata(metadata);
   const result = metadata;
@@ -320,7 +320,7 @@ function decodeBakeResponse(bytes: Uint8Array, abi: FontBakerAbiV0): FontBakeRes
   };
 }
 
-function decodePreparedFont(bytes: Uint8Array, abi: FontBakerAbiV0): PreparedFontV0 {
+function decodePreparedFont(bytes: Uint8Array, abi: FontBakerAbi): PreparedFont {
   const { metadata, artifact } = decodeEnvelope(bytes, abi);
   if (!isPreparedFontReport(metadata) || artifact.byteLength !== metadata.preparedBytes) {
     throw new TypeError('font baker returned invalid prepared font metadata');
@@ -328,7 +328,7 @@ function decodePreparedFont(bytes: Uint8Array, abi: FontBakerAbiV0): PreparedFon
   return { bytes: artifact, report: metadata };
 }
 
-function decodeFontInspection(bytes: Uint8Array, abi: FontBakerAbiV0): FontInspectionV0 {
+function decodeFontInspection(bytes: Uint8Array, abi: FontBakerAbi): FontInspection {
   const { metadata, artifact } = decodeEnvelope(bytes, abi);
   if (!isFontInspection(metadata) || artifact.byteLength !== 0) {
     throw new TypeError('font baker returned invalid font inspection metadata');
@@ -360,7 +360,7 @@ function isFontArtifactMetadata(value: unknown): value is FontArtifactMetadata {
   );
 }
 
-function isFontPayloadReport(value: unknown): value is FontPayloadReportV0 {
+function isFontPayloadReport(value: unknown): value is FontBakePayloadReport {
   if (!isNonArrayObject(value)) return false;
   const { source, shared, containers, transport } = value;
   return (
@@ -376,7 +376,7 @@ function isFontPayloadReport(value: unknown): value is FontPayloadReportV0 {
   );
 }
 
-function isShapingPayloadReport(value: unknown): value is ShapingPayloadReportV0 {
+function isShapingPayloadReport(value: unknown): value is ShapingPayloadReport {
   return (
     isNonArrayObject(value) &&
     value.format === 'opentype-sfnt-harfrust-v0' &&
@@ -429,7 +429,7 @@ function isBakeWarning(value: unknown): value is BakeWarning {
   );
 }
 
-function isPreparedFontReport(value: unknown): value is PreparedFontReportV0 {
+function isPreparedFontReport(value: unknown): value is PreparedFontReport {
   return (
     isNonArrayObject(value) &&
     value.formatVersion === 0 &&
@@ -443,7 +443,7 @@ function isPreparedFontReport(value: unknown): value is PreparedFontReportV0 {
   );
 }
 
-function isFontInspection(value: unknown): value is FontInspectionV0 {
+function isFontInspection(value: unknown): value is FontInspection {
   return (
     isNonArrayObject(value) &&
     value.formatVersion === 0 &&
@@ -455,7 +455,7 @@ function isFontInspection(value: unknown): value is FontInspectionV0 {
   );
 }
 
-function isGlyphInspection(value: unknown): value is GlyphInspectionV0 {
+function isGlyphInspection(value: unknown): value is GlyphInspection {
   return (
     isNonArrayObject(value) &&
     isNonnegativeSafeInteger(value.codePoint) &&

--- a/packages/glyph/src/font-baker/validator.ts
+++ b/packages/glyph/src/font-baker/validator.ts
@@ -43,7 +43,7 @@ export interface KhronosValidationReport {
   readonly info: Readonly<Record<string, unknown>>;
 }
 
-export interface ValidatedFontArtifactV0 {
+export interface ValidatedFontArtifact {
   readonly document: Readonly<Record<string, unknown>>;
   readonly shapingSfnt: Uint8Array;
   readonly glyphExtents: Uint8Array;
@@ -67,7 +67,7 @@ export class FontArtifactValidationError extends Error {
   }
 }
 
-export async function validateFontArtifact(bytes: Uint8Array): Promise<ValidatedFontArtifactV0> {
+export async function validateFontArtifact(bytes: Uint8Array): Promise<ValidatedFontArtifact> {
   const parsed = parseGlb(bytes);
   const khronos = await validateWithKhronos(bytes, parsed.document);
   validateFontExtensionSchema(parsed.document);
@@ -287,7 +287,7 @@ function schemaIssue(error: ErrorObject): FontArtifactValidationIssue {
 async function validateFontSemantics(
   parsed: ParsedGlb,
   khronos: KhronosValidationReport,
-): Promise<ValidatedFontArtifactV0> {
+): Promise<ValidatedFontArtifact> {
   const { document, bin, declaredBinLength } = parsed;
   const extensionsUsed = stringArray(document.extensionsUsed, 'extensionsUsed', '/extensionsUsed');
   const extensionsRequired = stringArray(document.extensionsRequired, 'extensionsRequired', '/extensionsRequired');

--- a/packages/glyph/src/index.ts
+++ b/packages/glyph/src/index.ts
@@ -3,7 +3,7 @@ export type {
   BakeProgressListener,
   BakeProgressPhase,
   AnyRasterBakerModule,
-  BakeArtifactV0,
+  BakeArtifact,
   RasterBakeArtifact,
   RasterBakeDescriptorOf,
   RasterBakeFontContext,
@@ -11,7 +11,7 @@ export type {
   RasterBakePlan,
   RasterBakeRequest,
   RasterBakerModule,
-  RasterPackagingV0,
+  RasterPackaging,
   RasterPagePayloadReport,
   RasterPayloadReport,
   BakeWarning,
@@ -124,7 +124,7 @@ export type {
 } from './raster-technique.js';
 export { defineRasterResourceId, defineRasterTechnique } from './raster-technique.js';
 
-export type { RasterCoverage, RasterCoverageV0, RasterUnicodeRange, RasterUnicodeRangeV0 } from './raster-coverage.js';
+export type { RasterCoverage, RasterUnicodeRange } from './raster-coverage.js';
 export {
   MAX_RASTER_COVERAGE_GLYPH_IDS,
   MAX_RASTER_COVERAGE_RANGES,

--- a/packages/glyph/src/internal/bake-progress-protocol.ts
+++ b/packages/glyph/src/internal/bake-progress-protocol.ts
@@ -25,7 +25,7 @@ export function bakeProgressMessage(
   return { type: 'bake-progress-v0', id, stage, phase, completed, total };
 }
 
-export function isBakeProgressMessageV0(value: unknown): value is BakeProgressMessage {
+export function isBakeProgressMessage(value: unknown): value is BakeProgressMessage {
   if (!isObject(value)) return false;
   return (
     value.type === 'bake-progress-v0' &&

--- a/packages/glyph/src/internal/bake-progress-protocol.ts
+++ b/packages/glyph/src/internal/bake-progress-protocol.ts
@@ -10,7 +10,7 @@ const PHASES = new Set<BakeProgressPhase>([
   'complete',
 ]);
 
-export interface BakeProgressMessageV0 extends BakeProgress {
+export interface BakeProgressMessage extends BakeProgress {
   readonly type: 'bake-progress-v0';
   readonly id: number;
 }
@@ -21,11 +21,11 @@ export function bakeProgressMessage(
   phase: BakeProgressPhase,
   completed: number,
   total: number,
-): BakeProgressMessageV0 {
+): BakeProgressMessage {
   return { type: 'bake-progress-v0', id, stage, phase, completed, total };
 }
 
-export function isBakeProgressMessageV0(value: unknown): value is BakeProgressMessageV0 {
+export function isBakeProgressMessageV0(value: unknown): value is BakeProgressMessage {
   if (!isObject(value)) return false;
   return (
     value.type === 'bake-progress-v0' &&

--- a/packages/glyph/src/internal/bitmap-contract.ts
+++ b/packages/glyph/src/internal/bitmap-contract.ts
@@ -1,6 +1,6 @@
 import type { RasterKey } from '../identity.js';
 import type { JsonValue, StaticNumberTuple } from '../raster.js';
-import { normalizeRasterCoverage, type RasterCoverage, type RasterCoverageV0 } from '../raster-coverage.js';
+import { normalizeRasterCoverage, type RasterCoverage } from '../raster-coverage.js';
 import { deriveRasterKey } from './raster-identity.js';
 
 export const BITMAP_KIND = 'bitmap' as const;
@@ -14,16 +14,16 @@ export interface BitmapOptions<Strikes extends readonly [number, ...number[]]> {
   readonly coverage?: RasterCoverage;
 }
 
-export interface BitmapDescriptorV0 {
+export interface BitmapDescriptor {
   readonly [key: string]: JsonValue;
   readonly generatorVersion: typeof BITMAP_GENERATOR_VERSION;
   readonly strikes: readonly number[];
-  readonly coverage?: RasterCoverageV0;
+  readonly coverage?: RasterCoverage;
 }
 
 export interface NormalizedBitmapOptions {
   readonly strikes: readonly [number, ...number[]];
-  readonly coverage?: RasterCoverageV0;
+  readonly coverage?: RasterCoverage;
 }
 
 function canonicalStrikes(values: readonly number[]): readonly number[] {
@@ -43,7 +43,7 @@ function canonicalStrikes(values: readonly number[]): readonly number[] {
 /** Create the complete payload-changing descriptor owned by the bitmap package. */
 export function bitmapDescriptor<const Strikes extends readonly [number, ...number[]]>(
   options: BitmapOptions<Strikes>,
-): BitmapDescriptorV0 {
+): BitmapDescriptor {
   const normalized = normalizeBitmapOptions(options);
   return canonicalizeBitmapDescriptor(normalized.strikes, normalized.coverage);
 }
@@ -70,7 +70,7 @@ export function normalizeBitmapOptions(value: unknown): NormalizedBitmapOptions 
 }
 
 /** Canonicalize JSON strike data at analyzer and artifact-validation boundaries. */
-export function canonicalizeBitmapDescriptor(strikes: readonly number[], coverage?: unknown): BitmapDescriptorV0 {
+export function canonicalizeBitmapDescriptor(strikes: readonly number[], coverage?: unknown): BitmapDescriptor {
   const normalizedCoverage = normalizeRasterCoverage(coverage);
   return Object.freeze({
     ...(normalizedCoverage === undefined ? {} : { coverage: normalizedCoverage }),
@@ -80,7 +80,7 @@ export function canonicalizeBitmapDescriptor(strikes: readonly number[], coverag
 }
 
 /** Derive a key from a descriptor that has already crossed package-owned validation. */
-export function bitmapDescriptorRasterKey(descriptor: BitmapDescriptorV0): Promise<RasterKey> {
+export function bitmapDescriptorRasterKey(descriptor: BitmapDescriptor): Promise<RasterKey> {
   return deriveRasterKey({
     descriptor,
     extension: BITMAP_EXTENSION,

--- a/packages/glyph/src/internal/compose-bake.ts
+++ b/packages/glyph/src/internal/compose-bake.ts
@@ -1,16 +1,16 @@
-import type { FontBakeResultV0 } from '../font-baker/index.js';
+import type { FontBakeResult } from '../font-baker/index.js';
 import { parseGlb } from '../font-baker/validator.js';
 
-import type { BakeArtifactV0, BakeWarning, FontPayloadReport, RasterBakeArtifact, RasterPackagingV0 } from '../bake.js';
+import type { BakeArtifact, BakeWarning, FontPayloadReport, RasterBakeArtifact, RasterPackaging } from '../bake.js';
 import type { Sha256Hex } from '../identity.js';
 
-export interface RasterCompositionV0 {
+export interface RasterComposition {
   readonly raster: RasterBakeArtifact;
-  readonly packaging: RasterPackagingV0;
+  readonly packaging: RasterPackaging;
 }
 
-export interface ComposedFontBakeResultV0 {
-  readonly artifacts: readonly BakeArtifactV0[];
+export interface ComposedFontBakeResult {
+  readonly artifacts: readonly BakeArtifact[];
   readonly report: FontPayloadReport;
   readonly warnings: readonly BakeWarning[];
 }
@@ -29,9 +29,9 @@ export class BakeCompositionError extends Error {
 
 /** Compose package-owned raster artifacts without interpreting companion semantics. */
 export async function composeFontBake(
-  core: FontBakeResultV0,
-  rasters: readonly RasterCompositionV0[],
-): Promise<ComposedFontBakeResultV0> {
+  core: FontBakeResult,
+  rasters: readonly RasterComposition[],
+): Promise<ComposedFontBakeResult> {
   const coreArtifact = exactlyOne(
     core.artifacts.filter(({ role }) => role === 'font'),
     'CORE_ARTIFACT',
@@ -68,7 +68,7 @@ export async function composeFontBake(
   let binaryLength = parsedCore.declaredBinLength;
   const rasterKeys = new Set<string>();
   const embeddedExtensions = new Set<string>();
-  const outputArtifacts: BakeArtifactV0[] = [];
+  const outputArtifacts: BakeArtifact[] = [];
 
   for (let index = 0; index < rasters.length; index += 1) {
     const { raster, packaging } = rasters[index]!;
@@ -169,7 +169,7 @@ export async function composeFontBake(
   document.extensionsRequired = required;
   requireNonArrayObject(asArray(document.buffers, '/buffers')[0], '/buffers/0').byteLength = binaryLength;
   const combined = encodeGlb(document, concatenate(binaryParts, binaryLength));
-  const fontArtifact: BakeArtifactV0 = {
+  const fontArtifact: BakeArtifact = {
     role: 'font',
     id: coreArtifact.id,
     bytes: combined,
@@ -229,9 +229,9 @@ function rebaseBufferViewReferences(value: unknown, offset: number, count: numbe
 }
 
 function mapReport(
-  core: FontBakeResultV0,
-  rasters: readonly RasterCompositionV0[],
-  artifacts: readonly BakeArtifactV0[],
+  core: FontBakeResult,
+  rasters: readonly RasterComposition[],
+  artifacts: readonly BakeArtifact[],
 ): FontPayloadReport {
   const shaping = core.report.shared.shaping;
   return {
@@ -258,7 +258,7 @@ function mapReport(
   };
 }
 
-function assertUniqueArtifactIds(artifacts: readonly BakeArtifactV0[]): void {
+function assertUniqueArtifactIds(artifacts: readonly BakeArtifact[]): void {
   const ids = new Set<string>();
   for (let index = 0; index < artifacts.length; index += 1) {
     const id = artifacts[index]!.id;
@@ -269,7 +269,7 @@ function assertUniqueArtifactIds(artifacts: readonly BakeArtifactV0[]): void {
   }
 }
 
-function containerReport(artifact: BakeArtifactV0): FontPayloadReport['containers'][number] {
+function containerReport(artifact: BakeArtifact): FontPayloadReport['containers'][number] {
   const jsonChunkBytes = readU32(artifact.bytes, 12);
   const json = artifact.bytes.subarray(20, 20 + jsonChunkBytes);
   let jsonBytes = json.byteLength;
@@ -331,7 +331,7 @@ function asArtifact(artifact: {
   readonly id: string;
   readonly bytes: Uint8Array;
   readonly sha256: string;
-}): BakeArtifactV0 {
+}): BakeArtifact {
   return { ...artifact, sha256: asHash(artifact.sha256, '/artifact/sha256') };
 }
 

--- a/packages/glyph/src/internal/core-bake-policy.ts
+++ b/packages/glyph/src/internal/core-bake-policy.ts
@@ -4,7 +4,7 @@ interface CoreFontArtifact {
   readonly role: 'font';
 }
 
-export function fontBakeDescriptorV0(fontFaceIndex: number): FontBakeDescriptor {
+export function fontBakeDescriptor(fontFaceIndex: number): FontBakeDescriptor {
   return { formatVersion: 0, fontFaceIndex };
 }
 

--- a/packages/glyph/src/internal/core-bake-policy.ts
+++ b/packages/glyph/src/internal/core-bake-policy.ts
@@ -1,10 +1,10 @@
-import type { FontBakeDescriptorV0 } from '../font-baker/index.js';
+import type { FontBakeDescriptor } from '../font-baker/index.js';
 
 interface CoreFontArtifact {
   readonly role: 'font';
 }
 
-export function fontBakeDescriptorV0(fontFaceIndex: number): FontBakeDescriptorV0 {
+export function fontBakeDescriptorV0(fontFaceIndex: number): FontBakeDescriptor {
   return { formatVersion: 0, fontFaceIndex };
 }
 

--- a/packages/glyph/src/internal/font-bake-pipeline.ts
+++ b/packages/glyph/src/internal/font-bake-pipeline.ts
@@ -1,9 +1,9 @@
 import type { BakeProgressListener } from '../bake.js';
-import type { FontBakeCore, PreparedFontReportV0 } from '../font-baker/index.js';
+import type { FontBakeCore, PreparedFontReport } from '../font-baker/index.js';
 import { validateFontArtifact } from '../font-baker/validator.js';
 import type { Sha256Hex } from '../identity.js';
 
-import { composeFontBake, type ComposedFontBakeResultV0 } from './compose-bake.js';
+import { composeFontBake, type ComposedFontBakeResult } from './compose-bake.js';
 import { soleCoreFontArtifact } from './core-bake-policy.js';
 import { normalizeUnicodeRanges } from './font-selection.js';
 import type { ResolvedRasterBakePlan } from './raster-bake-plan.js';
@@ -26,8 +26,8 @@ export interface FontBakePipelineTimings {
 }
 
 export interface FontBakePipelineResult {
-  readonly composed: ComposedFontBakeResultV0;
-  readonly preparation?: PreparedFontReportV0;
+  readonly composed: ComposedFontBakeResult;
+  readonly preparation?: PreparedFontReport;
   readonly timings: FontBakePipelineTimings;
 }
 

--- a/packages/glyph/src/internal/font-selection.ts
+++ b/packages/glyph/src/internal/font-selection.ts
@@ -1,9 +1,9 @@
-import type { UnicodeRangeV0 } from '../font-baker/index.js';
+import type { UnicodeRange } from '../font-baker/index.js';
 
 const MAX_UNICODE_RANGES = 4_096;
 const MAX_UNICODE = 0x10ffff;
 
-export function normalizeUnicodeRanges(ranges: readonly UnicodeRangeV0[]): readonly UnicodeRangeV0[] {
+export function normalizeUnicodeRanges(ranges: readonly UnicodeRange[]): readonly UnicodeRange[] {
   if (!Array.isArray(ranges) || ranges.length === 0) {
     throw new TypeError('font selection requires at least one Unicode range');
   }
@@ -21,7 +21,7 @@ export function normalizeUnicodeRanges(ranges: readonly UnicodeRangeV0[]): reado
     return { start, end };
   });
   normalized.sort((left, right) => left.start - right.start || left.end - right.end);
-  const merged: UnicodeRangeV0[] = [];
+  const merged: UnicodeRange[] = [];
   for (const range of normalized) {
     const previous = merged.at(-1);
     if (previous !== undefined && range.start <= previous.end + 1) {

--- a/packages/glyph/src/internal/frame-transfer-pool.ts
+++ b/packages/glyph/src/internal/frame-transfer-pool.ts
@@ -12,7 +12,7 @@ export interface FrameTransferPoolLimits {
   readonly maximumPooledBytes: number;
 }
 
-export interface FrameTransferPublicationV0 {
+export interface FrameTransferPublication {
   readonly type: typeof FRAME_PUBLICATION_TYPE;
   readonly protocolVersion: typeof FRAME_TRANSFER_PROTOCOL_VERSION;
   readonly transferId: number;
@@ -23,7 +23,7 @@ export interface FrameTransferPublicationV0 {
   readonly buffer: ArrayBuffer;
 }
 
-export interface FrameTransferReturnV0 {
+export interface FrameTransferReturn {
   readonly type: typeof FRAME_RETURN_TYPE;
   readonly protocolVersion: typeof FRAME_TRANSFER_PROTOCOL_VERSION;
   readonly transferId: number;
@@ -49,7 +49,7 @@ export interface FrameTransferPoolStats {
 }
 
 export type FrameTransferResult =
-  | Readonly<{ ok: true; publication: FrameTransferPublicationV0 }>
+  | Readonly<{ ok: true; publication: FrameTransferPublication }>
   | Readonly<{ ok: false; reason: 'backpressure' | 'oversized' | 'transfer-failed'; error?: unknown }>;
 
 export type FrameReturnResult =
@@ -60,7 +60,7 @@ export interface FrameTransferPool {
   transfer(
     bytes: Uint8Array,
     publication: Readonly<{ sessionId: number; planRevision: number }>,
-    send: (message: FrameTransferPublicationV0, transfer: readonly Transferable[]) => void,
+    send: (message: FrameTransferPublication, transfer: readonly Transferable[]) => void,
   ): FrameTransferResult;
   acceptReturn(message: unknown): FrameReturnResult;
   stats(): FrameTransferPoolStats;
@@ -126,7 +126,7 @@ export function createFrameTransferPool(limits: FrameTransferPoolLimits): FrameT
 
       const transferId = nextAvailableTransferId(nextTransferId, outstanding);
       nextTransferId = transferId === 0xffff_ffff ? 1 : transferId + 1;
-      const message: FrameTransferPublicationV0 = {
+      const message: FrameTransferPublication = {
         type: FRAME_PUBLICATION_TYPE,
         protocolVersion: FRAME_TRANSFER_PROTOCOL_VERSION,
         transferId,
@@ -207,14 +207,14 @@ export function createFrameTransferPool(limits: FrameTransferPoolLimits): FrameT
 
 /** Transfer a retired root-owned publication back to its originating worker. */
 export function returnFrameTransfer(
-  publication: FrameTransferPublicationV0,
-  send: (message: FrameTransferReturnV0, transfer: readonly Transferable[]) => void,
+  publication: FrameTransferPublication,
+  send: (message: FrameTransferReturn, transfer: readonly Transferable[]) => void,
 ): void {
   if (!isFrameTransferPublicationV0(publication)) throw new TypeError('invalid frame transfer publication');
   if (publication.buffer.byteLength !== publication.capacity) {
     throw new TypeError('frame transfer is detached or has the wrong capacity');
   }
-  const message: FrameTransferReturnV0 = {
+  const message: FrameTransferReturn = {
     type: FRAME_RETURN_TYPE,
     protocolVersion: FRAME_TRANSFER_PROTOCOL_VERSION,
     transferId: publication.transferId,
@@ -227,7 +227,7 @@ export function returnFrameTransfer(
   }
 }
 
-export function isFrameTransferPublicationV0(value: unknown): value is FrameTransferPublicationV0 {
+export function isFrameTransferPublicationV0(value: unknown): value is FrameTransferPublication {
   if (!isRecord(value) || value.type !== FRAME_PUBLICATION_TYPE || value.protocolVersion !== 0) return false;
   return (
     positiveU32(value.transferId) &&
@@ -240,7 +240,7 @@ export function isFrameTransferPublicationV0(value: unknown): value is FrameTran
   );
 }
 
-export function isFrameTransferReturnV0(value: unknown): value is FrameTransferReturnV0 {
+export function isFrameTransferReturnV0(value: unknown): value is FrameTransferReturn {
   if (!isRecord(value) || value.type !== FRAME_RETURN_TYPE || value.protocolVersion !== 0) return false;
   return positiveU32(value.transferId) && positiveU32(value.capacity) && value.buffer instanceof ArrayBuffer;
 }

--- a/packages/glyph/src/internal/frame-transfer-pool.ts
+++ b/packages/glyph/src/internal/frame-transfer-pool.ts
@@ -165,7 +165,7 @@ export function createFrameTransferPool(limits: FrameTransferPoolLimits): FrameT
     },
 
     acceptReturn(message) {
-      if (!isFrameTransferReturnV0(message)) {
+      if (!isFrameTransferReturn(message)) {
         stats.rejectedReturns += 1;
         return { ok: false, reason: 'invalid-message' };
       }
@@ -210,7 +210,7 @@ export function returnFrameTransfer(
   publication: FrameTransferPublication,
   send: (message: FrameTransferReturn, transfer: readonly Transferable[]) => void,
 ): void {
-  if (!isFrameTransferPublicationV0(publication)) throw new TypeError('invalid frame transfer publication');
+  if (!isFrameTransferPublication(publication)) throw new TypeError('invalid frame transfer publication');
   if (publication.buffer.byteLength !== publication.capacity) {
     throw new TypeError('frame transfer is detached or has the wrong capacity');
   }
@@ -227,7 +227,7 @@ export function returnFrameTransfer(
   }
 }
 
-export function isFrameTransferPublicationV0(value: unknown): value is FrameTransferPublication {
+export function isFrameTransferPublication(value: unknown): value is FrameTransferPublication {
   if (!isRecord(value) || value.type !== FRAME_PUBLICATION_TYPE || value.protocolVersion !== 0) return false;
   return (
     positiveU32(value.transferId) &&
@@ -240,7 +240,7 @@ export function isFrameTransferPublicationV0(value: unknown): value is FrameTran
   );
 }
 
-export function isFrameTransferReturnV0(value: unknown): value is FrameTransferReturn {
+export function isFrameTransferReturn(value: unknown): value is FrameTransferReturn {
   if (!isRecord(value) || value.type !== FRAME_RETURN_TYPE || value.protocolVersion !== 0) return false;
   return positiveU32(value.transferId) && positiveU32(value.capacity) && value.buffer instanceof ArrayBuffer;
 }

--- a/packages/glyph/src/internal/msdf-contract.ts
+++ b/packages/glyph/src/internal/msdf-contract.ts
@@ -1,6 +1,6 @@
 import type { RasterKey } from '../identity.js';
 import type { JsonValue } from '../raster.js';
-import { normalizeRasterCoverage, type RasterCoverage, type RasterCoverageV0 } from '../raster-coverage.js';
+import { normalizeRasterCoverage, type RasterCoverage } from '../raster-coverage.js';
 import { deriveRasterKey } from './raster-identity.js';
 
 export const MSDF_KIND = 'msdf' as const;
@@ -31,28 +31,28 @@ export interface MsdfConfiguration {
   readonly planeUnitsPerEm: number;
 }
 
-export interface DefaultMsdfDescriptorV0 {
+export interface DefaultMsdfDescriptor {
   readonly [key: string]: JsonValue;
   readonly generatorVersion: typeof MSDF_GENERATOR_VERSION;
-  readonly coverage?: RasterCoverageV0;
+  readonly coverage?: RasterCoverage;
 }
 
-export interface ConfiguredMsdfDescriptorV0 {
+export interface ConfiguredMsdfDescriptor {
   readonly [key: string]: JsonValue;
   readonly emSize: number;
   readonly generatorVersion: typeof MSDF_GENERATOR_VERSION;
   readonly pixelRange: number;
-  readonly coverage?: RasterCoverageV0;
+  readonly coverage?: RasterCoverage;
 }
 
-export type MsdfDescriptorV0 = DefaultMsdfDescriptorV0 | ConfiguredMsdfDescriptorV0;
+export type MsdfDescriptor = DefaultMsdfDescriptor | ConfiguredMsdfDescriptor;
 
 const defaultDescriptor = Object.freeze({
   generatorVersion: MSDF_GENERATOR_VERSION,
-}) satisfies DefaultMsdfDescriptorV0;
+}) satisfies DefaultMsdfDescriptor;
 
 /** Return the complete payload-changing MTSDF descriptor. */
-export function msdfDescriptor(options?: MsdfOptions): MsdfDescriptorV0 {
+export function msdfDescriptor(options?: MsdfOptions): MsdfDescriptor {
   const normalized = normalizeMsdfOptions(options);
   if (normalized === undefined) return defaultDescriptor;
   const emSize = normalized.emSize ?? MSDF_EM_SIZE;
@@ -72,7 +72,7 @@ export function msdfDescriptor(options?: MsdfOptions): MsdfDescriptorV0 {
 }
 
 /** Resolve the authenticated generation policy represented by a descriptor. */
-export function msdfDescriptorConfiguration(descriptor: MsdfDescriptorV0): MsdfConfiguration {
+export function msdfDescriptorConfiguration(descriptor: MsdfDescriptor): MsdfConfiguration {
   const keys = Object.keys(descriptor);
   if (
     descriptor.generatorVersion !== MSDF_GENERATOR_VERSION ||
@@ -113,7 +113,7 @@ const defaultConfiguration = Object.freeze({
 }) satisfies MsdfConfiguration;
 
 /** Derive a key from a descriptor that has crossed package-owned validation. */
-export function msdfDescriptorRasterKey(descriptor: MsdfDescriptorV0 = defaultDescriptor): Promise<RasterKey> {
+export function msdfDescriptorRasterKey(descriptor: MsdfDescriptor = defaultDescriptor): Promise<RasterKey> {
   msdfDescriptorConfiguration(descriptor);
   return deriveRasterKey({
     descriptor,

--- a/packages/glyph/src/internal/mtsdf-generator.ts
+++ b/packages/glyph/src/internal/mtsdf-generator.ts
@@ -46,7 +46,7 @@ export interface MtsdfGenerator {
   generate(request: MtsdfGlyphRequest): MtsdfGlyph;
 }
 
-export type MtsdfGeneratorAbiV1 = MtsdfBakerAbi;
+export type MtsdfGeneratorAbi = MtsdfBakerAbi;
 
 export type MtsdfGenerationErrorCode = 'INVALID_REQUEST' | 'INVALID_OUTLINE' | 'GENERATION_FAILED';
 
@@ -120,7 +120,7 @@ export function createMtsdfGeneratorFromInstance(instance: WebAssembly.Instance)
   };
 }
 
-function encodeRequest(request: MtsdfGlyphRequest, abi: MtsdfGeneratorAbiV1): Uint8Array {
+function encodeRequest(request: MtsdfGlyphRequest, abi: MtsdfGeneratorAbi): Uint8Array {
   validateRequest(request);
   const requestLayout = abi.layouts.request;
   const commandLayout = abi.layouts.command;
@@ -213,7 +213,7 @@ function checkedDimension(inner: number, padding: number, label: string): number
   return checkedSum(inner, checkedProduct(padding, 2));
 }
 
-function readExports(wasmExports: WebAssembly.Exports, abi: MtsdfGeneratorAbiV1): MtsdfGeneratorExports {
+function readExports(wasmExports: WebAssembly.Exports, abi: MtsdfGeneratorAbi): MtsdfGeneratorExports {
   const memory = wasmExports[abi.memory];
   const allocate = wasmExports[abi.functions.allocate];
   const deallocate = wasmExports[abi.functions.deallocate];
@@ -240,7 +240,7 @@ function readExports(wasmExports: WebAssembly.Exports, abi: MtsdfGeneratorAbiV1)
   };
 }
 
-function statusCode(status: number, abi: MtsdfGeneratorAbiV1): MtsdfGenerationErrorCode {
+function statusCode(status: number, abi: MtsdfGeneratorAbi): MtsdfGenerationErrorCode {
   if (status === abi.status.invalidRequest) return 'INVALID_REQUEST';
   if (status === abi.status.invalidOutline) return 'INVALID_OUTLINE';
   return 'GENERATION_FAILED';

--- a/packages/glyph/src/internal/raster-artifact-validation.ts
+++ b/packages/glyph/src/internal/raster-artifact-validation.ts
@@ -6,7 +6,7 @@ import {
 } from './raster-ktx.js';
 import { DenseGlyphRecordError, validateDenseGlyphRecordTable, type RasterPageDimensions } from './raster-records.js';
 import { canonicalJson } from './raster-identity.js';
-import { normalizeRasterCoverage, type RasterCoverageV0 } from '../raster-coverage.js';
+import { normalizeRasterCoverage, type RasterCoverage } from '../raster-coverage.js';
 import type { JsonValue } from '../raster.js';
 
 export interface RasterArtifactValidationIssue {
@@ -100,7 +100,7 @@ export function validateDenseRasterRecords(
 export function validateRasterCoverage(
   parsed: ParsedGlb,
   extension: Readonly<Record<string, unknown>>,
-  expectedCoverage: RasterCoverageV0 | undefined,
+  expectedCoverage: RasterCoverage | undefined,
   views: readonly RasterBufferView[],
   claimedViews: Set<number>,
   glyphCount: number,
@@ -118,7 +118,7 @@ export function validateRasterCoverage(
   }
   if (expectedCoverage === undefined) return undefined;
 
-  let actualCoverage: RasterCoverageV0;
+  let actualCoverage: RasterCoverage;
   try {
     actualCoverage = normalizeRasterCoverage(extension.coverage)!;
   } catch {

--- a/packages/glyph/src/internal/raster-bake-worker-entry.ts
+++ b/packages/glyph/src/internal/raster-bake-worker-entry.ts
@@ -4,7 +4,7 @@ import type { RasterBakerModule } from '../bake.js';
 import type { JsonValue } from '../raster.js';
 import { transferableArrayBuffer } from './owned-array-buffer.js';
 import {
-  isRasterBakeWorkerRequestV0,
+  isRasterBakeWorkerRequest,
   type RasterBakeWorkerFailure,
   type RasterBakeWorkerRequest,
   type RasterBakeWorkerSuccess,
@@ -21,7 +21,7 @@ export function startRasterBakeWorker<Kind extends string, Options, Descriptor e
   let pending = Promise.resolve();
   scope.addEventListener('message', (event: MessageEvent<unknown>) => {
     const value = event.data;
-    if (!isRasterBakeWorkerRequestV0(value)) return;
+    if (!isRasterBakeWorkerRequest(value)) return;
     pending = pending.then(() => handleMessage(scope, baker, normalizeOptions, value));
   });
 }

--- a/packages/glyph/src/internal/raster-bake-worker-entry.ts
+++ b/packages/glyph/src/internal/raster-bake-worker-entry.ts
@@ -5,9 +5,9 @@ import type { JsonValue } from '../raster.js';
 import { transferableArrayBuffer } from './owned-array-buffer.js';
 import {
   isRasterBakeWorkerRequestV0,
-  type RasterBakeWorkerFailureV0,
-  type RasterBakeWorkerRequestV0,
-  type RasterBakeWorkerSuccessV0,
+  type RasterBakeWorkerFailure,
+  type RasterBakeWorkerRequest,
+  type RasterBakeWorkerSuccess,
 } from './raster-bake-worker-protocol.js';
 import { bakeProgressMessage } from './bake-progress-protocol.js';
 
@@ -30,7 +30,7 @@ async function handleMessage<Kind extends string, Options, Descriptor extends Js
   scope: DedicatedWorkerGlobalScope,
   baker: RasterBakerModule<Kind, Options, Descriptor>,
   normalizeOptions: OptionsNormalizer<Options>,
-  request: RasterBakeWorkerRequestV0,
+  request: RasterBakeWorkerRequest,
 ): Promise<void> {
   try {
     scope.postMessage(bakeProgressMessage(request.id, 'raster', 'loading', 0, 1));
@@ -52,7 +52,7 @@ async function handleMessage<Kind extends string, Options, Descriptor extends Js
       },
     });
     scope.postMessage(bakeProgressMessage(request.id, 'raster', 'packaging', 0, 1));
-    const artifacts: RasterBakeWorkerSuccessV0['artifacts'] = result.artifacts.map((artifact) => {
+    const artifacts: RasterBakeWorkerSuccess['artifacts'] = result.artifacts.map((artifact) => {
       if (artifact.role === 'font') {
         throw new TypeError(`${result.kind} raster baker returned a core font artifact`);
       }
@@ -63,7 +63,7 @@ async function handleMessage<Kind extends string, Options, Descriptor extends Js
         sha256: artifact.sha256,
       };
     });
-    const response: RasterBakeWorkerSuccessV0 = {
+    const response: RasterBakeWorkerSuccess = {
       type: 'bake-raster-result-v0',
       id: request.id,
       ok: true,
@@ -81,7 +81,7 @@ async function handleMessage<Kind extends string, Options, Descriptor extends Js
       artifacts.map(({ bytes }) => bytes),
     );
   } catch (error) {
-    const response: RasterBakeWorkerFailureV0 = {
+    const response: RasterBakeWorkerFailure = {
       type: 'bake-raster-result-v0',
       id: request.id,
       ok: false,
@@ -91,7 +91,7 @@ async function handleMessage<Kind extends string, Options, Descriptor extends Js
   }
 }
 
-function serializeError(error: unknown): RasterBakeWorkerFailureV0['error'] {
+function serializeError(error: unknown): RasterBakeWorkerFailure['error'] {
   if (error instanceof Error) {
     const value = error as Error & { readonly code?: unknown; readonly path?: unknown };
     return {

--- a/packages/glyph/src/internal/raster-bake-worker-host.ts
+++ b/packages/glyph/src/internal/raster-bake-worker-host.ts
@@ -3,12 +3,12 @@ import type { RasterKey } from '../identity.js';
 import type { RuntimeRasterBakeRequest, RuntimeRasterBakerModule } from '../raster.js';
 import { copyToOwnedArrayBuffer } from './owned-array-buffer.js';
 import {
-  isRasterBakeWorkerResultV0,
+  isRasterBakeWorkerResult,
   type RasterBakeWorkerRequest,
   type RasterBakeWorkerResult,
 } from './raster-bake-worker-protocol.js';
 import { SerialWorkerHost } from './serial-worker-host.js';
-import { isBakeProgressMessageV0, type BakeProgressMessage } from './bake-progress-protocol.js';
+import { isBakeProgressMessage, type BakeProgressMessage } from './bake-progress-protocol.js';
 
 class RuntimeRasterBakeError extends Error {
   readonly code: string;
@@ -52,7 +52,7 @@ export function createRasterBakeWorkerHost<Kind extends string, Options>(options
         transfer: [source],
       };
     },
-    isResponse: isRasterBakeWorkerResultV0,
+    isResponse: isRasterBakeWorkerResult,
     responseId: (response) => response.id,
     resolve(response) {
       if (!response.ok) throw new RuntimeRasterBakeError(response.error);
@@ -72,7 +72,7 @@ export function createRasterBakeWorkerHost<Kind extends string, Options>(options
       };
     },
     progress: {
-      isProgress: isBakeProgressMessageV0,
+      isProgress: isBakeProgressMessage,
       progressId: (progress) => progress.id,
       report: (request, { stage, phase, completed, total }) => request.onProgress?.({ stage, phase, completed, total }),
     },

--- a/packages/glyph/src/internal/raster-bake-worker-host.ts
+++ b/packages/glyph/src/internal/raster-bake-worker-host.ts
@@ -4,11 +4,11 @@ import type { RuntimeRasterBakeRequest, RuntimeRasterBakerModule } from '../rast
 import { copyToOwnedArrayBuffer } from './owned-array-buffer.js';
 import {
   isRasterBakeWorkerResultV0,
-  type RasterBakeWorkerRequestV0,
-  type RasterBakeWorkerResultV0,
+  type RasterBakeWorkerRequest,
+  type RasterBakeWorkerResult,
 } from './raster-bake-worker-protocol.js';
 import { SerialWorkerHost } from './serial-worker-host.js';
-import { isBakeProgressMessageV0, type BakeProgressMessageV0 } from './bake-progress-protocol.js';
+import { isBakeProgressMessageV0, type BakeProgressMessage } from './bake-progress-protocol.js';
 
 class RuntimeRasterBakeError extends Error {
   readonly code: string;
@@ -29,10 +29,10 @@ export function createRasterBakeWorkerHost<Kind extends string, Options>(options
 }): RuntimeRasterBakerModule<Kind, Options> {
   const host = new SerialWorkerHost<
     RuntimeRasterBakeRequest<Options>,
-    RasterBakeWorkerRequestV0,
-    RasterBakeWorkerResultV0,
+    RasterBakeWorkerRequest,
+    RasterBakeWorkerResult,
     RasterBakeArtifact<Kind>,
-    BakeProgressMessageV0
+    BakeProgressMessage
   >({
     name: options.name,
     workerUrl: options.workerUrl,

--- a/packages/glyph/src/internal/raster-bake-worker-protocol.ts
+++ b/packages/glyph/src/internal/raster-bake-worker-protocol.ts
@@ -40,7 +40,7 @@ export interface RasterBakeWorkerFailure {
 
 export type RasterBakeWorkerResult = RasterBakeWorkerSuccess | RasterBakeWorkerFailure;
 
-export function isRasterBakeWorkerRequestV0(value: unknown): value is RasterBakeWorkerRequest {
+export function isRasterBakeWorkerRequest(value: unknown): value is RasterBakeWorkerRequest {
   return (
     isObject(value) &&
     value.type === 'bake-raster-v0' &&
@@ -54,7 +54,7 @@ export function isRasterBakeWorkerRequestV0(value: unknown): value is RasterBake
   );
 }
 
-export function isRasterBakeWorkerResultV0(value: unknown): value is RasterBakeWorkerResult {
+export function isRasterBakeWorkerResult(value: unknown): value is RasterBakeWorkerResult {
   if (
     !isObject(value) ||
     value.type !== 'bake-raster-result-v0' ||

--- a/packages/glyph/src/internal/raster-bake-worker-protocol.ts
+++ b/packages/glyph/src/internal/raster-bake-worker-protocol.ts
@@ -1,7 +1,7 @@
 import type { RasterPayloadReport, SerializedBakeError } from '../bake.js';
 import type { RasterKey, Sha256Hex } from '../identity.js';
 
-export interface RasterBakeWorkerRequestV0 {
+export interface RasterBakeWorkerRequest {
   readonly type: 'bake-raster-v0';
   readonly id: number;
   readonly source: ArrayBuffer;
@@ -12,14 +12,14 @@ export interface RasterBakeWorkerRequestV0 {
   readonly options: unknown;
 }
 
-export interface RasterBakeWorkerArtifactV0 {
+export interface RasterBakeWorkerArtifact {
   readonly role: 'raster' | 'raster-page';
   readonly id: string;
   readonly bytes: ArrayBuffer;
   readonly sha256: Sha256Hex;
 }
 
-export interface RasterBakeWorkerSuccessV0 {
+export interface RasterBakeWorkerSuccess {
   readonly type: 'bake-raster-result-v0';
   readonly id: number;
   readonly ok: true;
@@ -27,20 +27,20 @@ export interface RasterBakeWorkerSuccessV0 {
   readonly kind: string;
   readonly extension: string;
   readonly version: number;
-  readonly artifacts: readonly RasterBakeWorkerArtifactV0[];
+  readonly artifacts: readonly RasterBakeWorkerArtifact[];
   readonly report: RasterPayloadReport;
 }
 
-export interface RasterBakeWorkerFailureV0 {
+export interface RasterBakeWorkerFailure {
   readonly type: 'bake-raster-result-v0';
   readonly id: number;
   readonly ok: false;
   readonly error: SerializedBakeError;
 }
 
-export type RasterBakeWorkerResultV0 = RasterBakeWorkerSuccessV0 | RasterBakeWorkerFailureV0;
+export type RasterBakeWorkerResult = RasterBakeWorkerSuccess | RasterBakeWorkerFailure;
 
-export function isRasterBakeWorkerRequestV0(value: unknown): value is RasterBakeWorkerRequestV0 {
+export function isRasterBakeWorkerRequestV0(value: unknown): value is RasterBakeWorkerRequest {
   return (
     isObject(value) &&
     value.type === 'bake-raster-v0' &&
@@ -54,7 +54,7 @@ export function isRasterBakeWorkerRequestV0(value: unknown): value is RasterBake
   );
 }
 
-export function isRasterBakeWorkerResultV0(value: unknown): value is RasterBakeWorkerResultV0 {
+export function isRasterBakeWorkerResultV0(value: unknown): value is RasterBakeWorkerResult {
   if (
     !isObject(value) ||
     value.type !== 'bake-raster-result-v0' ||
@@ -75,7 +75,7 @@ export function isRasterBakeWorkerResultV0(value: unknown): value is RasterBakeW
   );
 }
 
-function isArtifact(value: unknown): value is RasterBakeWorkerArtifactV0 {
+function isArtifact(value: unknown): value is RasterBakeWorkerArtifact {
   return (
     isObject(value) &&
     (value.role === 'raster' || value.role === 'raster-page') &&

--- a/packages/glyph/src/internal/raster-baker-wasm.ts
+++ b/packages/glyph/src/internal/raster-baker-wasm.ts
@@ -1,5 +1,5 @@
 import type {
-  BakeArtifactV0,
+  BakeArtifact,
   RasterBakeArtifact,
   RasterPagePayloadReport,
   RasterPayloadReport,
@@ -253,7 +253,7 @@ export function decodeSegmentedResponse<Kind extends string>(
   }
   assertResultMetadata(metadata, artifactLength, spec);
   const result = metadata;
-  const artifacts = result.artifacts.map<BakeArtifactV0>((artifact, index) => {
+  const artifacts = result.artifacts.map<BakeArtifact>((artifact, index) => {
     const byteLength = artifactLengths[index];
     if (byteLength === undefined || byteLength !== artifact.byteLength) {
       throw new TypeError(`${spec.label} segmented artifact length does not match its directory`);
@@ -322,7 +322,7 @@ export function decodeResponse<Kind extends string>(
   if (status !== contract.successStatus) throw spec.createError(parseError(metadata, spec.label));
   assertResultMetadata(metadata, artifactLength, spec);
   const result = metadata;
-  const artifacts = result.artifacts.map<BakeArtifactV0>((artifact) => ({
+  const artifacts = result.artifacts.map<BakeArtifact>((artifact) => ({
     role: artifact.role,
     id: artifact.id,
     bytes: response

--- a/packages/glyph/src/internal/raster-coverage-artifact.ts
+++ b/packages/glyph/src/internal/raster-coverage-artifact.ts
@@ -1,10 +1,10 @@
 import type { ParagraphLayout } from '../layout.js';
 import type { JsonValue } from '../raster.js';
-import { normalizeRasterCoverage, RasterCoverageError, type RasterCoverageV0 } from '../raster-coverage.js';
+import { normalizeRasterCoverage, RasterCoverageError, type RasterCoverage } from '../raster-coverage.js';
 import { canonicalJson } from './raster-identity.js';
 
 export interface DecodedRasterCoverage {
-  readonly descriptor: RasterCoverageV0;
+  readonly descriptor: RasterCoverage;
   readonly bits: Uint8Array;
 }
 

--- a/packages/glyph/src/internal/runtime-bake-protocol.ts
+++ b/packages/glyph/src/internal/runtime-bake-protocol.ts
@@ -60,7 +60,7 @@ export interface RuntimeBakeFailure {
 
 export type RuntimeBakeResult = RuntimeBakeSuccess | RuntimeBakeFailure;
 
-export function isRuntimeBakeResultV0(value: unknown): value is RuntimeBakeResult {
+export function isRuntimeBakeResult(value: unknown): value is RuntimeBakeResult {
   if (!isNonArrayObject(value) || value.type !== 'bake-font-result-v0' || !isRequestId(value.id)) {
     return false;
   }
@@ -76,13 +76,13 @@ export function isRuntimeBakeResultV0(value: unknown): value is RuntimeBakeResul
     value.ok === true &&
     Array.isArray(value.artifacts) &&
     value.artifacts.length === 1 &&
-    value.artifacts.every(isRuntimeBakeArtifactV0) &&
+    value.artifacts.every(isRuntimeBakeArtifact) &&
     isNonArrayObject(value.report) &&
     Array.isArray(value.warnings)
   );
 }
 
-export function isRuntimeBakeRequestV0(value: unknown): value is RuntimeBakeRequest {
+export function isRuntimeBakeRequest(value: unknown): value is RuntimeBakeRequest {
   return (
     isNonArrayObject(value) &&
     value.type === 'bake-font-v0' &&
@@ -151,7 +151,7 @@ function isJsonValue(value: unknown, seen = new Set<object>(), depth = 0): value
   return valid;
 }
 
-function isRuntimeBakeArtifactV0(value: unknown): value is RuntimeBakeArtifact {
+function isRuntimeBakeArtifact(value: unknown): value is RuntimeBakeArtifact {
   return (
     isNonArrayObject(value) &&
     value.role === 'font' &&

--- a/packages/glyph/src/internal/runtime-bake-protocol.ts
+++ b/packages/glyph/src/internal/runtime-bake-protocol.ts
@@ -1,8 +1,8 @@
-import type { FontBakeDescriptorV0, SerializedBakeError } from '../font-baker/index.js';
+import type { FontBakeDescriptor, SerializedBakeError } from '../font-baker/index.js';
 import type { RasterKey } from '../identity.js';
 import type { JsonValue } from '../raster.js';
 
-export type RuntimeBakeUnicodeRangeV0 = {
+export type RuntimeBakeUnicodeRange = {
   readonly start: number;
   readonly end: number;
 };
@@ -17,7 +17,7 @@ export type RuntimeBakeUnicodeRangeV0 = {
  */
 export const workerRasterKinds: readonly string[] = Object.freeze(['bitmap', 'msdf', 'slug']);
 
-export type RuntimeBakeRasterV0 = {
+export type RuntimeBakeRaster = {
   readonly kind: string;
   readonly extension: string;
   readonly version: number;
@@ -25,42 +25,42 @@ export type RuntimeBakeRasterV0 = {
   readonly descriptor: JsonValue;
 };
 
-export interface RuntimeBakeRequestV0 {
+export interface RuntimeBakeRequest {
   readonly type: 'bake-font-v0';
   readonly id: number;
   readonly source: ArrayBuffer;
-  readonly font: FontBakeDescriptorV0;
+  readonly font: FontBakeDescriptor;
   readonly cache?: { readonly expiresAt: number };
-  readonly unicodeRanges?: readonly RuntimeBakeUnicodeRangeV0[];
-  readonly rasters?: readonly RuntimeBakeRasterV0[];
+  readonly unicodeRanges?: readonly RuntimeBakeUnicodeRange[];
+  readonly rasters?: readonly RuntimeBakeRaster[];
 }
 
-export interface RuntimeBakeSuccessV0 {
+export interface RuntimeBakeSuccess {
   readonly type: 'bake-font-result-v0';
   readonly id: number;
   readonly ok: true;
-  readonly artifacts: readonly [RuntimeBakeArtifactV0];
+  readonly artifacts: readonly [RuntimeBakeArtifact];
   readonly report: unknown;
   readonly warnings: readonly unknown[];
 }
 
-export interface RuntimeBakeArtifactV0 {
+export interface RuntimeBakeArtifact {
   readonly role: 'font';
   readonly id: string;
   readonly bytes: ArrayBuffer;
   readonly sha256: string;
 }
 
-export interface RuntimeBakeFailureV0 {
+export interface RuntimeBakeFailure {
   readonly type: 'bake-font-result-v0';
   readonly id: number;
   readonly ok: false;
   readonly error: SerializedBakeError;
 }
 
-export type RuntimeBakeResultV0 = RuntimeBakeSuccessV0 | RuntimeBakeFailureV0;
+export type RuntimeBakeResult = RuntimeBakeSuccess | RuntimeBakeFailure;
 
-export function isRuntimeBakeResultV0(value: unknown): value is RuntimeBakeResultV0 {
+export function isRuntimeBakeResultV0(value: unknown): value is RuntimeBakeResult {
   if (!isNonArrayObject(value) || value.type !== 'bake-font-result-v0' || !isRequestId(value.id)) {
     return false;
   }
@@ -82,7 +82,7 @@ export function isRuntimeBakeResultV0(value: unknown): value is RuntimeBakeResul
   );
 }
 
-export function isRuntimeBakeRequestV0(value: unknown): value is RuntimeBakeRequestV0 {
+export function isRuntimeBakeRequestV0(value: unknown): value is RuntimeBakeRequest {
   return (
     isNonArrayObject(value) &&
     value.type === 'bake-font-v0' &&
@@ -102,7 +102,7 @@ export function isRuntimeBakeRequestV0(value: unknown): value is RuntimeBakeRequ
   );
 }
 
-function isUnicodeRanges(value: unknown): value is readonly RuntimeBakeUnicodeRangeV0[] {
+function isUnicodeRanges(value: unknown): value is readonly RuntimeBakeUnicodeRange[] {
   return (
     Array.isArray(value) &&
     value.length > 0 &&
@@ -119,7 +119,7 @@ function isUnicodeRanges(value: unknown): value is readonly RuntimeBakeUnicodeRa
   );
 }
 
-function isRasters(value: unknown): value is readonly RuntimeBakeRasterV0[] {
+function isRasters(value: unknown): value is readonly RuntimeBakeRaster[] {
   return (
     Array.isArray(value) &&
     value.length <= 256 &&
@@ -151,7 +151,7 @@ function isJsonValue(value: unknown, seen = new Set<object>(), depth = 0): value
   return valid;
 }
 
-function isRuntimeBakeArtifactV0(value: unknown): value is RuntimeBakeArtifactV0 {
+function isRuntimeBakeArtifactV0(value: unknown): value is RuntimeBakeArtifact {
   return (
     isNonArrayObject(value) &&
     value.role === 'font' &&

--- a/packages/glyph/src/internal/runtime-font-cache.ts
+++ b/packages/glyph/src/internal/runtime-font-cache.ts
@@ -2,7 +2,7 @@ import { FONT_BAKER_VERSION, FONT_FORMAT_VERSION } from '../font-baker/contract.
 
 import { copyToOwnedArrayBuffer } from './owned-array-buffer.js';
 import { canonicalJson } from './raster-identity.js';
-import type { RuntimeBakeRequestV0 } from './runtime-bake-protocol.js';
+import type { RuntimeBakeRequest } from './runtime-bake-protocol.js';
 
 const CACHE_NAME = `pmndrs-glyph-font-bakes-${FONT_FORMAT_VERSION}-${FONT_BAKER_VERSION}`;
 const CACHE_PATH = '/.pmndrs-glyph/font-bakes/';
@@ -12,7 +12,7 @@ const ARTIFACT_ID_HEADER = 'x-pmndrs-artifact-id';
 const SHA256_HEADER = 'x-pmndrs-sha256';
 
 export interface RuntimeFontCache {
-  key(source: Uint8Array, request: RuntimeBakeRequestV0): Promise<string>;
+  key(source: Uint8Array, request: RuntimeBakeRequest): Promise<string>;
   match(key: string): Promise<CachedFontArtifact | undefined>;
   put(key: string, artifact: CachedFontArtifact, expiresAt: number): Promise<void>;
 }

--- a/packages/glyph/src/internal/slug-contract.ts
+++ b/packages/glyph/src/internal/slug-contract.ts
@@ -10,17 +10,17 @@ export const SLUG_PLANE_UNITS_PER_EM = 2048 as const;
 export const SLUG_DEFAULT_BAND_COUNT = 16 as const;
 export const SLUG_GLYPH_RECORD_STRIDE = 40 as const;
 
-export interface SlugDescriptorV0 {
+export interface SlugDescriptor {
   readonly [key: string]: JsonValue;
   readonly generatorVersion: typeof SLUG_GENERATOR_VERSION;
 }
 
 const descriptor = Object.freeze({
   generatorVersion: SLUG_GENERATOR_VERSION,
-}) satisfies SlugDescriptorV0;
+}) satisfies SlugDescriptor;
 
 /** Return the fixed, quality-preserving Slug V0 payload descriptor. */
-export function slugDescriptor(): SlugDescriptorV0 {
+export function slugDescriptor(): SlugDescriptor {
   return descriptor;
 }
 

--- a/packages/glyph/src/loader.ts
+++ b/packages/glyph/src/loader.ts
@@ -1,4 +1,4 @@
-import type { ParsedGlb, ValidatedFontArtifactV0 } from './font-baker/validator.js';
+import type { ParsedGlb, ValidatedFontArtifact } from './font-baker/validator.js';
 import {
   FONT_BAKER_VERSION as CORE_BAKER_VERSION,
   FONT_FORMAT_VERSION as CORE_FORMAT_VERSION,
@@ -24,7 +24,7 @@ import type {
   RegisteredRaster,
 } from './raster.js';
 import type { BakeProgressListener } from './bake.js';
-import type { RuntimeBakeRasterV0, RuntimeBakeUnicodeRangeV0 } from './internal/runtime-bake-protocol.js';
+import type { RuntimeBakeRaster, RuntimeBakeUnicodeRange } from './internal/runtime-bake-protocol.js';
 
 const DEFAULT_MAX_ARTIFACT_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_BUFFER_VIEWS = 4_096;
@@ -53,8 +53,8 @@ export interface RuntimeFontBakeRequest {
   readonly bakedUrl?: string;
   /** Persistent derived-artifact lifetime inherited from the source response. Omitted means memory-only. */
   readonly cache?: { readonly expiresAt: number };
-  readonly unicodeRanges?: readonly RuntimeBakeUnicodeRangeV0[];
-  readonly rasters?: readonly RuntimeBakeRasterV0[];
+  readonly unicodeRanges?: readonly RuntimeBakeUnicodeRange[];
+  readonly rasters?: readonly RuntimeBakeRaster[];
   readonly signal?: AbortSignal;
   readonly onProgress?: BakeProgressListener;
 }
@@ -146,7 +146,7 @@ export class FontRegistry {
     this.#checkArtifactSize(bytes.byteLength);
     const owned = copyView(bytes);
     const validator = await loadValidator();
-    let validated: ValidatedFontArtifactV0;
+    let validated: ValidatedFontArtifact;
     try {
       validated = await validator.validateFontArtifact(owned);
     } catch (error) {

--- a/packages/glyph/src/node/bake.ts
+++ b/packages/glyph/src/node/bake.ts
@@ -7,10 +7,10 @@ import { brotliCompressSync, constants as zlibConstants, gzipSync } from 'node:z
 
 import {
   createFontBaker,
-  type FontBakeDescriptorV0,
-  type FontInspectionV0,
-  type PreparedFontReportV0,
-  type UnicodeRangeV0,
+  type FontBakeDescriptor,
+  type FontInspection,
+  type PreparedFontReport,
+  type UnicodeRange,
 } from '../font-baker/index.js';
 import { fontBakerWasmUrl } from '../font-baker/wasm-url.js';
 
@@ -20,17 +20,17 @@ export {
   createFontBakerFromInstance,
   fontBakerAbi,
   type FontBakeCore,
-  type FontBakeDescriptorV0,
-  type FontBakeRequestV0,
-  type FontBakeResultV0,
-  type FontBakerAbiV0,
+  type FontBakeDescriptor,
+  type FontBakeRequest,
+  type FontBakeResult,
+  type FontBakerAbi,
   type FontBakerWasmSource,
   type SerializedBakeError,
 } from '../font-baker/index.js';
 export { fontBakerWasmUrl } from '../font-baker/wasm-url.js';
 export * from '../font-baker/validator.js';
 
-import type { AnyRasterBakerModule, BakeArtifactV0, BakeWarning, FontPayloadReport, RasterBakePlan } from '../bake.js';
+import type { AnyRasterBakerModule, BakeArtifact, BakeWarning, FontPayloadReport, RasterBakePlan } from '../bake.js';
 import type {
   DiscoveryDiagnostic,
   DiscoveredFontDefinition,
@@ -47,8 +47,8 @@ export interface NodeBakeOptions<
 > {
   readonly input: string | URL;
   readonly output: string | URL;
-  readonly font: Omit<FontBakeDescriptorV0, 'formatVersion'>;
-  readonly unicodeRanges?: readonly UnicodeRangeV0[];
+  readonly font: Omit<FontBakeDescriptor, 'formatVersion'>;
+  readonly unicodeRanges?: readonly UnicodeRange[];
   readonly rasters?: Rasters;
   readonly signal?: AbortSignal;
 }
@@ -79,7 +79,7 @@ export interface NodeBakeExecutionReport {
     readonly processMaxRssBytes: number;
   };
   readonly outputs: readonly {
-    readonly role: BakeArtifactV0['role'];
+    readonly role: BakeArtifact['role'];
     readonly file: string;
     readonly bytes: number;
     readonly sha256: string;
@@ -87,7 +87,7 @@ export interface NodeBakeExecutionReport {
 }
 
 export interface NodeFontBakeReport extends FontPayloadReport {
-  readonly preparation?: PreparedFontReportV0;
+  readonly preparation?: PreparedFontReport;
   readonly execution: NodeBakeExecutionReport;
 }
 
@@ -139,7 +139,7 @@ export async function bakeFont<const Rasters extends readonly RasterBakePlan<Any
   return bakeFontWithResolvedPlans(options);
 }
 
-export async function inspectFont(options: NodeFontInspectOptions): Promise<FontInspectionV0> {
+export async function inspectFont(options: NodeFontInspectOptions): Promise<FontInspection> {
   const source = new Uint8Array(await readFile(filePath(options.input, 'input')));
   const fontBaker = await defaultFontBaker();
   return fontBaker.inspect({
@@ -356,8 +356,8 @@ function bakedSiblingPath(path: string): string {
 
 function outputTargets(
   fontOutput: string,
-  artifacts: readonly BakeArtifactV0[],
-): readonly { artifact: BakeArtifactV0; file: string }[] {
+  artifacts: readonly BakeArtifact[],
+): readonly { artifact: BakeArtifact; file: string }[] {
   const directory = dirname(fontOutput);
   const targets = artifacts.map((artifact) => {
     if (artifact.role === 'font') return { artifact, file: fontOutput };
@@ -391,7 +391,7 @@ interface StagedArtifactOutput {
 }
 
 async function publishArtifactsWithRollback(
-  outputs: readonly { artifact: BakeArtifactV0; file: string }[],
+  outputs: readonly { artifact: BakeArtifact; file: string }[],
   signal?: AbortSignal,
 ): Promise<void> {
   const staged: StagedArtifactOutput[] = [];
@@ -501,7 +501,7 @@ function isMissing(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
 
-function finalizeTransport(report: FontPayloadReport, artifacts: readonly BakeArtifactV0[]): FontPayloadReport {
+function finalizeTransport(report: FontPayloadReport, artifacts: readonly BakeArtifact[]): FontPayloadReport {
   return {
     ...report,
     transport: artifacts.flatMap(({ id, role, bytes }) => {

--- a/packages/glyph/src/node/bake.ts
+++ b/packages/glyph/src/node/bake.ts
@@ -37,7 +37,7 @@ import type {
   DiscoveryOptions,
   ResolvedRasterBaker,
 } from '../discovery.js';
-import { fontBakeDescriptorV0 } from '../internal/core-bake-policy.js';
+import { fontBakeDescriptor } from '../internal/core-bake-policy.js';
 import { bakeFontPipeline } from '../internal/font-bake-pipeline.js';
 import { resolveRasterBakePlan, type ResolvedRasterBakePlan } from '../internal/raster-bake-plan.js';
 import { cacheSuccessfulPromise } from '../internal/successful-promise-cache.js';
@@ -144,7 +144,7 @@ export async function inspectFont(options: NodeFontInspectOptions): Promise<Font
   const fontBaker = await defaultFontBaker();
   return fontBaker.inspect({
     source,
-    descriptor: fontBakeDescriptorV0(options.fontFaceIndex ?? 0),
+    descriptor: fontBakeDescriptor(options.fontFaceIndex ?? 0),
   });
 }
 

--- a/packages/glyph/src/node/cli.ts
+++ b/packages/glyph/src/node/cli.ts
@@ -6,7 +6,7 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import type { AnyRasterBakerModule, RasterBakePlan } from '../bake.js';
-import type { UnicodeRangeV0 } from '../font-baker/index.js';
+import type { UnicodeRange } from '../font-baker/index.js';
 import { normalizeUnicodeRanges } from '../internal/font-selection.js';
 import {
   bakeFont,
@@ -244,7 +244,7 @@ interface DirectBakeArguments {
   readonly bitmapStrikes?: readonly [number, ...number[]];
   readonly msdf: boolean;
   readonly slug: boolean;
-  readonly unicodeRanges?: readonly UnicodeRangeV0[];
+  readonly unicodeRanges?: readonly UnicodeRange[];
   readonly check: boolean;
 }
 
@@ -260,7 +260,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
   let bitmapStrikes: readonly [number, ...number[]] | undefined;
   let msdf = false;
   let slug = false;
-  let unicodeRanges: readonly UnicodeRangeV0[] | undefined;
+  let unicodeRanges: readonly UnicodeRange[] | undefined;
   let check = false;
   let json = false;
   let help = false;
@@ -363,7 +363,7 @@ function bitmapStrikeList(value: string): readonly [number, ...number[]] {
   return strikes as [number, ...number[]];
 }
 
-function parseUnicodeSet(value: string): readonly UnicodeRangeV0[] {
+function parseUnicodeSet(value: string): readonly UnicodeRange[] {
   const ranges = value.split(',').map((part) => {
     const match = /^U\+([0-9A-Fa-f]{1,6})(?:-U\+?([0-9A-Fa-f]{1,6})|-([0-9A-Fa-f]{1,6}))?$/u.exec(part.trim());
     if (match === null) throw new TypeError('--unicodes requires comma-separated U+XXXX or U+XXXX-YYYY ranges');

--- a/packages/glyph/src/raster-coverage.ts
+++ b/packages/glyph/src/raster-coverage.ts
@@ -1,38 +1,24 @@
-import type { JsonValue } from './raster.js';
-
 export const MAX_RASTER_COVERAGE_RANGES = 1_024 as const;
 export const MAX_RASTER_COVERAGE_SCALARS = 65_536 as const;
 export const MAX_RASTER_COVERAGE_TEXT_CODE_POINTS = 65_536 as const;
 export const MAX_RASTER_COVERAGE_GLYPH_IDS = 65_535 as const;
 
-export interface RasterUnicodeRange {
+export type RasterUnicodeRange = {
   /** Inclusive Unicode scalar value. */
   readonly start: number;
   /** Inclusive Unicode scalar value. */
   readonly end: number;
-}
-
-export interface RasterUnicodeRangeV0 extends RasterUnicodeRange {
-  readonly [key: string]: number;
-}
+};
 
 /**
  * Bounded seeds for a sparse raster artifact. Seeds select nominal font-local glyph IDs only;
  * they do not request source subsetting, glyph remapping, or transitive shaping closure.
  */
-export interface RasterCoverage {
+export type RasterCoverage = {
   readonly unicodeRanges?: readonly RasterUnicodeRange[];
   readonly text?: string;
   readonly glyphIds?: readonly number[];
-}
-
-/** Canonical JSON representation authenticated as part of a raster descriptor. */
-export interface RasterCoverageV0 {
-  readonly [key: string]: JsonValue;
-  readonly unicodeRanges?: readonly RasterUnicodeRangeV0[];
-  readonly text?: string;
-  readonly glyphIds?: readonly number[];
-}
+};
 
 /** A shaped layout references font-local glyphs omitted from its bounded raster artifact. */
 export class RasterCoverageError extends Error {
@@ -48,7 +34,7 @@ export class RasterCoverageError extends Error {
 }
 
 /** Validate, copy, sort, and freeze caller-authored sparse raster coverage. */
-export function normalizeRasterCoverage(value: unknown): RasterCoverageV0 | undefined {
+export function normalizeRasterCoverage(value: unknown): RasterCoverage | undefined {
   if (value === undefined) return undefined;
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new TypeError('raster coverage must be an object');
@@ -75,7 +61,7 @@ export function normalizeRasterCoverage(value: unknown): RasterCoverageV0 | unde
   });
 }
 
-function normalizeUnicodeRanges(value: unknown): readonly RasterUnicodeRangeV0[] | undefined {
+function normalizeUnicodeRanges(value: unknown): readonly RasterUnicodeRange[] | undefined {
   if (!Array.isArray(value)) throw new TypeError('raster coverage unicodeRanges must be an array');
   if (value.length === 0) return undefined;
   if (value.length > MAX_RASTER_COVERAGE_RANGES) {

--- a/packages/glyph/src/raster/bitmap-technique.ts
+++ b/packages/glyph/src/raster/bitmap-technique.ts
@@ -7,7 +7,7 @@ import {
   BITMAP_KIND,
   bitmapDescriptorRasterKey,
   canonicalizeBitmapDescriptor,
-  type BitmapDescriptorV0,
+  type BitmapDescriptor,
 } from '../internal/bitmap-contract.js';
 import { nearestBitmapStrikeIndex } from '../internal/bitmap-strike.js';
 import {
@@ -41,7 +41,7 @@ export {
   bitmapDescriptorRasterKey,
   bitmapRasterKey,
   canonicalizeBitmapDescriptor,
-  type BitmapDescriptorV0,
+  type BitmapDescriptor,
   type BitmapOptions,
 } from '../internal/bitmap-contract.js';
 
@@ -88,7 +88,7 @@ export const bitmap: RasterTechnique<
   RasterTechniqueId & 'pmndrs.bitmap',
   typeof BITMAP_KIND,
   BitmapTechniqueOptions,
-  BitmapDescriptorV0,
+  BitmapDescriptor,
   BitmapData
 > = defineRasterTechnique({
   id: 'pmndrs.bitmap',
@@ -96,7 +96,7 @@ export const bitmap: RasterTechnique<
   extension: BITMAP_EXTENSION,
   version: BITMAP_FORMAT_VERSION,
   runtimeBaker: () => import('../runtime-bakers/bitmap.js'),
-  descriptor(options: BitmapTechniqueOptions): BitmapDescriptorV0 {
+  descriptor(options: BitmapTechniqueOptions): BitmapDescriptor {
     return canonicalizeBitmapDescriptor(options.strikes, options.coverage);
   },
   async decode(font, raster, signal): Promise<BitmapData> {

--- a/packages/glyph/src/raster/msdf.ts
+++ b/packages/glyph/src/raster/msdf.ts
@@ -15,7 +15,7 @@ import {
   MSDF_MAX_PIXEL_RANGE,
   msdfDescriptor,
   msdfRasterKey,
-  type MsdfDescriptorV0,
+  type MsdfDescriptor,
   type MsdfOptions,
 } from '../internal/msdf-contract.js';
 import {
@@ -52,7 +52,7 @@ export {
   msdfDescriptorRasterKey,
   msdfRasterKey,
   type MsdfConfiguration,
-  type MsdfDescriptorV0,
+  type MsdfDescriptor,
   type MsdfOptions,
 } from '../internal/msdf-contract.js';
 export { DENSE_GLYPH_RECORD_STRIDE as MSDF_GLYPH_RECORD_STRIDE } from '../internal/raster-atlas.js';
@@ -86,7 +86,7 @@ export const msdf: RasterTechnique<
   RasterTechniqueId & 'pmndrs.msdf',
   typeof MSDF_KIND,
   MsdfOptions | undefined,
-  MsdfDescriptorV0,
+  MsdfDescriptor,
   MsdfData
 > = defineRasterTechnique({
   id: 'pmndrs.msdf',
@@ -94,7 +94,7 @@ export const msdf: RasterTechnique<
   extension: MSDF_EXTENSION,
   version: MSDF_FORMAT_VERSION,
   runtimeBaker: () => import('../runtime-bakers/msdf.js'),
-  descriptor(options: MsdfOptions | undefined): MsdfDescriptorV0 {
+  descriptor(options: MsdfOptions | undefined): MsdfDescriptor {
     return msdfDescriptor(options);
   },
   async decode(font, raster, signal): Promise<MsdfData> {

--- a/packages/glyph/src/raster/slug-technique.ts
+++ b/packages/glyph/src/raster/slug-technique.ts
@@ -17,7 +17,7 @@ import {
   SLUG_KIND,
   SLUG_PLANE_UNITS_PER_EM,
   slugDescriptor,
-  type SlugDescriptorV0,
+  type SlugDescriptor,
 } from '../internal/slug-contract.js';
 import type { JsonValue, RasterResourceSource, RegisteredRaster } from '../raster.js';
 import {
@@ -38,7 +38,7 @@ export {
   SLUG_PLANE_UNITS_PER_EM,
   slugDescriptor,
   slugDescriptorRasterKey,
-  type SlugDescriptorV0,
+  type SlugDescriptor,
 } from '../internal/slug-contract.js';
 
 const ABSENT_PAGE = 0xffff;
@@ -71,7 +71,7 @@ export const slug: RasterTechnique<
   RasterTechniqueId & 'pmndrs.slug',
   typeof SLUG_KIND,
   undefined,
-  SlugDescriptorV0,
+  SlugDescriptor,
   SlugData
 > = defineRasterTechnique({
   id: 'pmndrs.slug',
@@ -79,7 +79,7 @@ export const slug: RasterTechnique<
   extension: SLUG_EXTENSION,
   version: SLUG_FORMAT_VERSION,
   runtimeBaker: () => import('../runtime-bakers/slug.js'),
-  descriptor(): SlugDescriptorV0 {
+  descriptor(): SlugDescriptor {
     return slugDescriptor();
   },
   async decode(font, raster, signal): Promise<SlugData> {

--- a/packages/glyph/src/runtime-bake-worker.ts
+++ b/packages/glyph/src/runtime-bake-worker.ts
@@ -10,7 +10,7 @@ import type { ResolvedRasterBakePlan } from './internal/raster-bake-plan.js';
 import { deriveRasterKey } from './internal/raster-identity.js';
 import { createRuntimeFontCache, type CachedFontArtifact } from './internal/runtime-font-cache.js';
 import {
-  isRuntimeBakeRequestV0,
+  isRuntimeBakeRequest,
   type RuntimeBakeRaster,
   type RuntimeBakeRequest,
   type RuntimeBakeFailure,
@@ -31,7 +31,7 @@ let pending = Promise.resolve();
 
 scope.addEventListener('message', (event: MessageEvent<unknown>) => {
   const value = event.data;
-  if (!isRuntimeBakeRequestV0(value)) return;
+  if (!isRuntimeBakeRequest(value)) return;
   pending = pending.then(() => handleMessage(value));
 });
 

--- a/packages/glyph/src/runtime-bake-worker.ts
+++ b/packages/glyph/src/runtime-bake-worker.ts
@@ -11,10 +11,10 @@ import { deriveRasterKey } from './internal/raster-identity.js';
 import { createRuntimeFontCache, type CachedFontArtifact } from './internal/runtime-font-cache.js';
 import {
   isRuntimeBakeRequestV0,
-  type RuntimeBakeRasterV0,
-  type RuntimeBakeRequestV0,
-  type RuntimeBakeFailureV0,
-  type RuntimeBakeSuccessV0,
+  type RuntimeBakeRaster,
+  type RuntimeBakeRequest,
+  type RuntimeBakeFailure,
+  type RuntimeBakeSuccess,
 } from './internal/runtime-bake-protocol.js';
 import { cacheSuccessfulPromise } from './internal/successful-promise-cache.js';
 import { bakeProgressMessage } from './internal/bake-progress-protocol.js';
@@ -35,7 +35,7 @@ scope.addEventListener('message', (event: MessageEvent<unknown>) => {
   pending = pending.then(() => handleMessage(value));
 });
 
-async function handleMessage(value: RuntimeBakeRequestV0): Promise<void> {
+async function handleMessage(value: RuntimeBakeRequest): Promise<void> {
   try {
     const source = new Uint8Array(value.source);
     const cache =
@@ -72,7 +72,7 @@ async function handleMessage(value: RuntimeBakeRequestV0): Promise<void> {
     scope.postMessage(bakeProgressMessage(value.id, 'font', 'complete', 1, 1));
     postSuccess(value.id, artifact, result.composed.report, result.composed.warnings);
   } catch (error) {
-    const response: RuntimeBakeFailureV0 = {
+    const response: RuntimeBakeFailure = {
       type: 'bake-font-result-v0',
       id: value.id,
       ok: false,
@@ -83,7 +83,7 @@ async function handleMessage(value: RuntimeBakeRequestV0): Promise<void> {
 }
 
 function postSuccess(id: number, artifact: CachedFontArtifact, report: unknown, warnings: readonly unknown[]): void {
-  const artifacts: RuntimeBakeSuccessV0['artifacts'] = [
+  const artifacts: RuntimeBakeSuccess['artifacts'] = [
     {
       role: 'font',
       id: artifact.id,
@@ -91,7 +91,7 @@ function postSuccess(id: number, artifact: CachedFontArtifact, report: unknown, 
       sha256: artifact.sha256,
     },
   ];
-  const response: RuntimeBakeSuccessV0 = {
+  const response: RuntimeBakeSuccess = {
     type: 'bake-font-result-v0',
     id,
     ok: true,
@@ -105,11 +105,11 @@ function postSuccess(id: number, artifact: CachedFontArtifact, report: unknown, 
   );
 }
 
-async function resolveRasters(rasters: readonly RuntimeBakeRasterV0[]): Promise<readonly ResolvedRasterBakePlan[]> {
+async function resolveRasters(rasters: readonly RuntimeBakeRaster[]): Promise<readonly ResolvedRasterBakePlan[]> {
   return Promise.all(rasters.map(resolveRaster));
 }
 
-async function resolveRaster(raster: RuntimeBakeRasterV0): Promise<ResolvedRasterBakePlan> {
+async function resolveRaster(raster: RuntimeBakeRaster): Promise<ResolvedRasterBakePlan> {
   let baker: AnyRasterBakerModule;
   switch (raster.kind) {
     case 'bitmap':

--- a/packages/glyph/src/runtime-bake.ts
+++ b/packages/glyph/src/runtime-bake.ts
@@ -1,18 +1,18 @@
 import { FontBakeError } from './font-baker/index.js';
 
 import type { RuntimeFontBake, RuntimeFontBakeRequest } from './loader.js';
-import { fontBakeDescriptorV0 } from './internal/core-bake-policy.js';
+import { fontBakeDescriptor } from './internal/core-bake-policy.js';
 import { copyToOwnedArrayBuffer } from './internal/owned-array-buffer.js';
 import { normalizeUnicodeRanges } from './internal/font-selection.js';
 import {
-  isRuntimeBakeResultV0,
+  isRuntimeBakeResult,
   type RuntimeBakeRequest,
   type RuntimeBakeResult,
 } from './internal/runtime-bake-protocol.js';
 
 export { workerRasterKinds } from './internal/runtime-bake-protocol.js';
 import { SerialWorkerHost } from './internal/serial-worker-host.js';
-import { isBakeProgressMessageV0, type BakeProgressMessage } from './internal/bake-progress-protocol.js';
+import { isBakeProgressMessage, type BakeProgressMessage } from './internal/bake-progress-protocol.js';
 
 const host = new SerialWorkerHost<
   RuntimeFontBakeRequest,
@@ -30,7 +30,7 @@ const host = new SerialWorkerHost<
         type: 'bake-font-v0',
         id,
         source,
-        font: fontBakeDescriptorV0(0),
+        font: fontBakeDescriptor(0),
         ...(request.cache === undefined ? {} : { cache: request.cache }),
         ...(request.unicodeRanges === undefined
           ? {}
@@ -40,14 +40,14 @@ const host = new SerialWorkerHost<
       transfer: [source],
     };
   },
-  isResponse: isRuntimeBakeResultV0,
+  isResponse: isRuntimeBakeResult,
   responseId: (response) => response.id,
   resolve(response) {
     if (!response.ok) throw new FontBakeError(response.error);
     return new Uint8Array(response.artifacts[0]!.bytes);
   },
   progress: {
-    isProgress: isBakeProgressMessageV0,
+    isProgress: isBakeProgressMessage,
     progressId: (progress) => progress.id,
     report: (request, { stage, phase, completed, total }) => request.onProgress?.({ stage, phase, completed, total }),
   },

--- a/packages/glyph/src/runtime-bake.ts
+++ b/packages/glyph/src/runtime-bake.ts
@@ -6,20 +6,20 @@ import { copyToOwnedArrayBuffer } from './internal/owned-array-buffer.js';
 import { normalizeUnicodeRanges } from './internal/font-selection.js';
 import {
   isRuntimeBakeResultV0,
-  type RuntimeBakeRequestV0,
-  type RuntimeBakeResultV0,
+  type RuntimeBakeRequest,
+  type RuntimeBakeResult,
 } from './internal/runtime-bake-protocol.js';
 
 export { workerRasterKinds } from './internal/runtime-bake-protocol.js';
 import { SerialWorkerHost } from './internal/serial-worker-host.js';
-import { isBakeProgressMessageV0, type BakeProgressMessageV0 } from './internal/bake-progress-protocol.js';
+import { isBakeProgressMessageV0, type BakeProgressMessage } from './internal/bake-progress-protocol.js';
 
 const host = new SerialWorkerHost<
   RuntimeFontBakeRequest,
-  RuntimeBakeRequestV0,
-  RuntimeBakeResultV0,
+  RuntimeBakeRequest,
+  RuntimeBakeResult,
   Uint8Array,
-  BakeProgressMessageV0
+  BakeProgressMessage
 >({
   name: 'pmndrs-glyph-font-baker',
   workerUrl: new URL('./runtime-bake-worker.js', import.meta.url),

--- a/packages/glyph/src/text-runtime.ts
+++ b/packages/glyph/src/text-runtime.ts
@@ -14,8 +14,8 @@ import { canonicalJson, deriveRasterKey } from './internal/raster-identity.js';
 import { normalizeUnicodeRanges } from './internal/font-selection.js';
 import {
   workerRasterKinds,
-  type RuntimeBakeRasterV0,
-  type RuntimeBakeUnicodeRangeV0,
+  type RuntimeBakeRaster,
+  type RuntimeBakeUnicodeRange,
 } from './internal/runtime-bake-protocol.js';
 import { getRegisteredFontData } from './internal/registered-font.js';
 import type {
@@ -45,7 +45,7 @@ export type LoadedFontInput =
   | {
       readonly source: string | URL;
       readonly runtimeBake: RuntimeFontBake;
-      readonly unicodeRanges?: readonly RuntimeBakeUnicodeRangeV0[];
+      readonly unicodeRanges?: readonly RuntimeBakeUnicodeRange[];
     };
 
 export interface LoadedFontRequest<Technique extends AnyRasterTechnique> {
@@ -430,7 +430,7 @@ class TextRuntimeImpl implements TextRuntime {
   }
 }
 
-async function runtimeBakeRaster(request: RasterTechniqueRequest<AnyRasterTechnique>): Promise<RuntimeBakeRasterV0> {
+async function runtimeBakeRaster(request: RasterTechniqueRequest<AnyRasterTechnique>): Promise<RuntimeBakeRaster> {
   const { technique } = request;
   const descriptor = techniqueOperations(technique).descriptor(
     request.options as RasterOptionsArgument<RasterOptionsOf<AnyRasterTechnique>>,

--- a/packages/glyph/tests/integration/bake-progress-protocol.test.mjs
+++ b/packages/glyph/tests/integration/bake-progress-protocol.test.mjs
@@ -1,16 +1,16 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { bakeProgressMessage, isBakeProgressMessageV0 } from '../../dist/internal/bake-progress-protocol.js';
+import { bakeProgressMessage, isBakeProgressMessage } from '../../dist/internal/bake-progress-protocol.js';
 
 test('bake progress protocol accepts bounded typed progress', () => {
   const progress = bakeProgressMessage(7, 'raster', 'rasterizing', 42, 100);
-  assert.equal(isBakeProgressMessageV0(progress), true);
+  assert.equal(isBakeProgressMessage(progress), true);
 });
 
 test('bake progress protocol rejects impossible and unknown progress', () => {
   assert.equal(
-    isBakeProgressMessageV0({
+    isBakeProgressMessage({
       type: 'bake-progress-v0',
       id: 1,
       stage: 'raster',
@@ -21,7 +21,7 @@ test('bake progress protocol rejects impossible and unknown progress', () => {
     false,
   );
   assert.equal(
-    isBakeProgressMessageV0({
+    isBakeProgressMessage({
       type: 'bake-progress-v0',
       id: 1,
       stage: 'shader',

--- a/packages/glyph/tests/package/core-bake-policy.test.mjs
+++ b/packages/glyph/tests/package/core-bake-policy.test.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { fontBakeDescriptorV0, soleCoreFontArtifact } from '../../dist/internal/core-bake-policy.js';
+import { fontBakeDescriptor, soleCoreFontArtifact } from '../../dist/internal/core-bake-policy.js';
 
 test('constructs the one canonical V0 face descriptor', () => {
-  assert.deepEqual(fontBakeDescriptorV0(17), { formatVersion: 0, fontFaceIndex: 17 });
+  assert.deepEqual(fontBakeDescriptor(17), { formatVersion: 0, fontFaceIndex: 17 });
 });
 
 test('returns only a sole authoritative core font artifact', () => {

--- a/packages/glyph/tests/package/frame-transfer-pool.test.mjs
+++ b/packages/glyph/tests/package/frame-transfer-pool.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import {
   createFrameTransferPool,
-  isFrameTransferPublicationV0,
+  isFrameTransferPublication,
   returnFrameTransfer,
 } from '../../dist/internal/frame-transfer-pool.js';
 
@@ -26,7 +26,7 @@ test('frame transfers copy opaque Wasm bytes once and return the same storage to
 
   assert.equal(first.ok, true);
   assert.equal(first.publication.buffer.byteLength, 0);
-  assert.equal(isFrameTransferPublicationV0(rootPublication), true);
+  assert.equal(isFrameTransferPublication(rootPublication), true);
   assert.equal(rootPublication.capacity, 256);
   assert.deepEqual(new Uint8Array(rootPublication.buffer, 0, rootPublication.byteLength), source);
   assert.deepEqual(pool.stats(), {

--- a/packages/glyph/tests/types/mtsdf-api.test.ts
+++ b/packages/glyph/tests/types/mtsdf-api.test.ts
@@ -2,7 +2,7 @@ import type { RegisteredFont, RegisteredRaster } from '@pmndrs/glyph';
 import {
   validateMsdfArtifact,
   type MsdfArtifactValidationContext,
-  type ValidatedMsdfArtifactV0,
+  type ValidatedMsdfArtifact,
 } from '@pmndrs/glyph/bakers/msdf/validate';
 import {
   MSDF_KIND,
@@ -23,7 +23,7 @@ declare const raster: RegisteredRaster<'msdf'>;
 const data: Promise<MsdfData> = msdf.decode(font, raster);
 declare const artifactBytes: Uint8Array;
 declare const validationContext: MsdfArtifactValidationContext;
-const validation: Promise<ValidatedMsdfArtifactV0> = validateMsdfArtifact(artifactBytes, validationContext);
+const validation: Promise<ValidatedMsdfArtifact> = validateMsdfArtifact(artifactBytes, validationContext);
 
 void descriptor;
 void configuredDescriptor;


### PR DESCRIPTION
Stacked on #98.

## The suffix tracked nothing

No type had a sibling version. Stripping the suffix from all 59 versioned type names produced **zero collisions among themselves** — there was never a `V1` next to a `V0` for the same concept. Meanwhile the generated ABI modules already used unversioned names (`TextShaperAbi`, `FontBakerAbi`), so one package carried two conventions that disagreed.

Three findings while removing it:

**Five were pure aliases.** They existed only to bolt a version onto a generated type that never had one:

```ts
export type BitmapBakerAbi = typeof bitmapBakerAbi;  // generated
export type BitmapBakerAbiV0 = BitmapBakerAbi;       // hand-written, adds nothing
```

They are now re-exports of the generated name.

**Two were not versions at all.** `RasterCoverageV0` and `RasterUnicodeRangeV0` were index-signature twins, written so their base types could satisfy `JsonValue`:

```ts
export interface RasterUnicodeRangeV0 extends RasterUnicodeRange {
  readonly [key: string]: number;   // the entire reason the twin existed
}
```

That is the same interface/index-signature rule #98 addresses. Declaring the bases as type aliases makes the twins unnecessary, and both are deleted.

**Two collided with unrelated types.** `FontPayloadReportV0` and `FontPayloadReport` are different shapes, and `FontSelectionV0` (a bake wire descriptor) is unrelated to `FontSelection<Technique>` (the runtime font-stack type). Stripping the suffix would have fused distinct concepts, so they take the surrounding `FontBake*` vocabulary instead: `FontBakePayloadReport` and `FontBakeSelection`.

Nine runtime guards followed their types in a second pass, since the first sweep matched Type-cased identifiers only.

## What keeps its version, deliberately

Runtime wire tags are untouched — `'bake-font-v0'` and `font.formatVersion`:

```ts
export function isRuntimeBakeRequest(value: unknown): value is RuntimeBakeRequest {
  return isNonArrayObject(value) && value.type === 'bake-font-v0' && ...
}
```

That tag crosses a Worker boundary where the peer can be a **different build** — a cached Worker script, a stale chunk — and the receiver validates it at run time. A type name cannot express that case, because the compiler erases it before anything could compare versions. Version what a peer of unknown vintage checks at run time; do not version what the compiler deletes.

## Breaking

58 of the 59 names are in the public `.d.ts` surface, so this is a breaking rename for any consumer importing them by name. Nothing is published yet at a stable version.

## Evidence

- `tsc -p tsconfig.json --noEmit` clean.
- 144 integration, 66 package, 69 package+fuzz, 20 font-baker integration tests pass.
- `oxlint --deny-warnings`, `oxfmt --check` clean.
- OKF validation clean.
- Zero versioned identifiers remain in source; `'bake-font-v0'` verified still present.
