### PR TITLE
fix(glyph): repack a record slot handed to another glyph identity

### DIFF
--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:e1864ccfb89184c21cd1050b4cb13a02c429f38076c96c7962dca769354f2a41'
+source_digest: 'sha256:1ae173d089cb4ed79b59ffbf32a41e9fcb6ac6e31cfa2fc656cfa72f56cbe8a2'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:1ae173d089cb4ed79b59ffbf32a41e9fcb6ac6e31cfa2fc656cfa72f56cbe8a2'
+source_digest: 'sha256:ff2e1cdf7690dda73fc33ab38d5e6819f644d2dd87f11ca84eb4c90e029227cf'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:a54980f97f5ce045509e17c86590e5879c7bb65703c88cca5458fe93e5ac25d8'
+source_digest: 'sha256:e1864ccfb89184c21cd1050b4cb13a02c429f38076c96c7962dca769354f2a41'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/packages/glyph/rust/shaper/src/engine/policy_gather.rs
+++ b/packages/glyph/rust/shaper/src/engine/policy_gather.rs
@@ -11,7 +11,7 @@ use super::{
     },
     plan_input::{PlanGlyph, PlanInput},
     policy::{CapabilitySetId, InputScope, MAX_REGISTERS, ProgramDescriptor, ValidatedPolicy},
-    positioning::SemanticGlyph,
+    positioning::{ALL_SEMANTIC_CHANGES, SemanticGlyph},
 };
 
 // `fontSize` and `rasterPixelRatio` can select a different baked resource.
@@ -313,12 +313,21 @@ impl PolicyGatherWorkspace {
                 self.retained_source_cursor = source_cursor - 1;
                 return Ok(RetainedGather::RebuildFrom(glyph_index));
             };
-            // The change mask is identity-relative: positioning derives it against this glyph's
-            // own previous slot. The retained columns are slot-relative. Both conventions agree
-            // only while a slot keeps its occupant, so a slot handed to a different identity must
-            // leave the retained path entirely rather than apply a mask that names the registers
-            // the *identity* changed while the *slot* changed in every register.
-            if previous.stable_id != next.stable_id || !same_storage_topology(previous, next) {
+            // The change mask is identity-relative: `assign_content_revision` derives it against
+            // the slot this glyph occupied in the previous frame, wherever that was. The retained
+            // columns are slot-relative. The two conventions agree while a slot keeps its
+            // occupant; when a slot is handed to another identity, a narrow mask names the
+            // registers the *identity* changed while the *slot* changed in every register, so the
+            // skipped registers would keep the displaced occupant's bytes.
+            //
+            // An identity with no previous slot is exempt: `assign_content_revision` gives it
+            // `ALL_SEMANTIC_CHANGES`, `input_masks_for_changes` widens that to every declared
+            // input, and `update_fields` then rewrites the whole record in place -- identical to
+            // what a rebuild would push, without re-gathering the suffix. So only a *retained*
+            // identity landing on another identity's slot has to leave the retained path.
+            if (previous.stable_id != next.stable_id && change_mask != ALL_SEMANTIC_CHANGES)
+                || !same_storage_topology(previous, next)
+            {
                 self.retained_cursor = cursor;
                 self.retained_source_cursor = source_cursor - 1;
                 return Ok(RetainedGather::RebuildFrom(glyph_index));
@@ -1481,6 +1490,7 @@ mod tests {
         before: &[LayoutGlyph],
         after: &[LayoutGlyph],
         masks: &[u16],
+        expected: RetainedGather,
     ) {
         let binding = binding();
         let policy = policy();
@@ -1511,10 +1521,11 @@ mod tests {
             .gather(&policy, CAPABILITY, initial, |_| Some(&binding))
             .unwrap();
         assert!(incremental.begin_retained(&policy, 16).unwrap(), "{label}");
-        if let RetainedGather::RebuildFrom(source_start) = incremental
+        let outcome = incremental
             .append_retained(&policy, CAPABILITY, edited, |_| Some(&binding))
-            .unwrap()
-        {
+            .unwrap();
+        assert_eq!(outcome, expected, "{label}: retained outcome");
+        if let RetainedGather::RebuildFrom(source_start) = outcome {
             incremental.truncate_to_retained_prefix();
             incremental
                 .append_from(&policy, CAPABILITY, edited, source_start, |_| {
@@ -1627,29 +1638,39 @@ mod tests {
     #[test]
     fn retained_gather_repacks_slots_a_topology_edit_hands_to_another_identity() {
         const MOVED: u16 = 1 << 6;
+        // A survivor that only shifted position reports a narrow mask while landing on the slot
+        // its neighbour vacated. Every register the mask omits still holds the displaced
+        // occupant's bytes, so the suffix has to be rebuilt.
         retained_matches_fresh(
             "interior deletion",
             &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
             &[layout_glyph(1, 0), layout_glyph(3, 0)],
             &[0, MOVED],
+            RetainedGather::RebuildFrom(1),
         );
         retained_matches_fresh(
             "prefix deletion",
             &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
             &[layout_glyph(2, 1), layout_glyph(3, 0)],
             &[MOVED, MOVED],
+            RetainedGather::RebuildFrom(0),
         );
+        // A substitution mints an identity that had no previous slot, so positioning reports
+        // `ALL_SEMANTIC_CHANGES` and the in-place update rewrites the whole record. Rebuilding
+        // the suffix here would be wasted work, and the untouched tail proves it is not needed.
         retained_matches_fresh(
-            "same-length substitution",
+            "same-slot substitution",
             &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
             &[layout_glyph(1, 0), layout_glyph(4, 0), layout_glyph(3, 0)],
-            &[0, MOVED, 0],
+            &[0, ALL_SEMANTIC_CHANGES, 0],
+            RetainedGather::Complete,
         );
         retained_matches_fresh(
             "tail deletion",
             &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
             &[layout_glyph(1, 0), layout_glyph(2, 1)],
             &[0, 0],
+            RetainedGather::Complete,
         );
     }
 

--- a/packages/glyph/rust/shaper/src/engine/policy_gather.rs
+++ b/packages/glyph/rust/shaper/src/engine/policy_gather.rs
@@ -191,17 +191,10 @@ impl PolicyGatherWorkspace {
         policy: &ValidatedPolicy,
         capability_set: CapabilitySetId,
         input: LayoutPlanInput<'_>,
-        force_all_inputs: bool,
         binding_for_font: impl FnMut(u32) -> Option<&'binding FontRenderBinding>,
     ) -> Result<(), GatherError> {
         self.begin(policy, input.glyphs.len())?;
-        self.append(
-            policy,
-            capability_set,
-            input,
-            force_all_inputs,
-            binding_for_font,
-        )
+        self.append(policy, capability_set, input, binding_for_font)
     }
 
     pub fn begin(
@@ -320,7 +313,12 @@ impl PolicyGatherWorkspace {
                 self.retained_source_cursor = source_cursor - 1;
                 return Ok(RetainedGather::RebuildFrom(glyph_index));
             };
-            if !same_storage_topology(previous, next) {
+            // The change mask is identity-relative: positioning derives it against this glyph's
+            // own previous slot. The retained columns are slot-relative. Both conventions agree
+            // only while a slot keeps its occupant, so a slot handed to a different identity must
+            // leave the retained path entirely rather than apply a mask that names the registers
+            // the *identity* changed while the *slot* changed in every register.
+            if previous.stable_id != next.stable_id || !same_storage_topology(previous, next) {
                 self.retained_cursor = cursor;
                 self.retained_source_cursor = source_cursor - 1;
                 return Ok(RetainedGather::RebuildFrom(glyph_index));
@@ -376,17 +374,9 @@ impl PolicyGatherWorkspace {
         policy: &ValidatedPolicy,
         capability_set: CapabilitySetId,
         input: LayoutPlanInput<'_>,
-        force_all_inputs: bool,
         binding_for_font: impl FnMut(u32) -> Option<&'binding FontRenderBinding>,
     ) -> Result<(), GatherError> {
-        self.append_from(
-            policy,
-            capability_set,
-            input,
-            0,
-            force_all_inputs,
-            binding_for_font,
-        )
+        self.append_from(policy, capability_set, input, 0, binding_for_font)
     }
 
     pub fn append_from<'binding>(
@@ -395,7 +385,6 @@ impl PolicyGatherWorkspace {
         capability_set: CapabilitySetId,
         input: LayoutPlanInput<'_>,
         source_start: usize,
-        force_all_inputs: bool,
         mut binding_for_font: impl FnMut(u32) -> Option<&'binding FontRenderBinding>,
     ) -> Result<(), GatherError> {
         validate_semantic_shape(input)?;
@@ -419,16 +408,6 @@ impl PolicyGatherWorkspace {
         {
             return Err(GatherError::AllocationFailed);
         }
-        let semantic_changes = if input.semantic_change_masks.len() == input.glyphs.len() {
-            input
-                .semantic_change_masks
-                .iter()
-                .copied()
-                .fold(0_u16, |union, mask| union | mask)
-        } else {
-            super::positioning::ALL_SEMANTIC_CHANGES
-        };
-        let selection_changed = semantic_changes & RESOURCE_SELECTION_CHANGES != 0;
         let mut cached_font_handle = None;
         let mut cached_binding = None;
         let mut cached_program = None;
@@ -451,37 +430,31 @@ impl PolicyGatherWorkspace {
             };
             let technique = binding.technique();
             let variant = binding.program_variant();
-            let (program, f32_inputs, u32_inputs) = match cached_program {
-                Some((cached_technique, cached_variant, program, f32_inputs, u32_inputs))
+            let program = match cached_program {
+                Some((cached_technique, cached_variant, program))
                     if cached_technique == technique && cached_variant == variant =>
                 {
-                    (program, f32_inputs, u32_inputs)
+                    program
                 }
                 _ => {
                     let program = policy
                         .program(capability_set, technique, variant)
                         .ok_or(GatherError::ProgramMissing)?;
-                    let (f32_inputs, u32_inputs) = policy
-                        .input_masks_for_changes(
-                            capability_set,
-                            technique,
-                            variant,
-                            semantic_changes,
-                            force_all_inputs || selection_changed,
-                        )
-                        .ok_or(GatherError::ProgramMissing)?;
-                    cached_program = Some((technique, variant, program, f32_inputs, u32_inputs));
-                    (program, f32_inputs, u32_inputs)
+                    cached_program = Some((technique, variant, program));
+                    program
                 }
             };
+            // A pushed row has no prior value to preserve, so a change mask cannot narrow it: the
+            // registers it omits would be published as zeros rather than as retained values.
+            // `gather_fields` bounds these by the program's declared input counts.
             self.gather_fields(
                 input,
                 glyph_index,
                 binding,
                 selected,
                 program,
-                f32_inputs,
-                u32_inputs,
+                u32::MAX,
+                u32::MAX,
             )?;
             self.glyphs
                 .push(plan_glyph(input, glyph_index, glyph, binding, selected)?);
@@ -1129,7 +1102,6 @@ mod tests {
                     semantic_f32: &[&semantic_x],
                     semantic_u32: &[&semantic_kind],
                 },
-                true,
                 |handle| (handle == 9).then_some(&binding),
             )
             .unwrap();
@@ -1200,14 +1172,16 @@ mod tests {
                     semantic_f32: &[&initial_x],
                     semantic_u32: &[&semantic_kind],
                 },
-                true,
                 |_| Some(&binding),
             )
             .unwrap();
 
+        // Slot 1 keeps its identity and only revises its content: that is the case a narrow mask
+        // is allowed to patch in place. A slot whose identity changes leaves the retained path
+        // instead, which `retained_gather_repacks_slots_a_topology_edit_hands_to_another_identity`
+        // covers.
         let changed_x = [999.0, 25.0];
         let mut changed_glyphs = glyphs;
-        changed_glyphs[1].stable_id = 3;
         changed_glyphs[1].content_revision = 2;
         assert!(workspace.begin_retained(&policy, 2).unwrap());
         assert_eq!(
@@ -1231,7 +1205,8 @@ mod tests {
         assert!(workspace.finish_retained());
         let gathered = workspace.view();
         let input = gathered.plan_input();
-        assert_eq!(input.glyphs[1].stable_id, 3);
+        assert_eq!(input.glyphs[1].stable_id, 2);
+        assert_eq!(input.glyphs[1].content_revision, 2);
         assert_eq!(input.f32_fields[0], [10.0, 25.0]);
         assert_eq!(input.f32_fields[1], [1.0, 2.0]);
 
@@ -1273,7 +1248,6 @@ mod tests {
                     semantic_u32: &[&semantic_kind],
                 },
                 1,
-                true,
                 |_| Some(&binding),
             )
             .unwrap();
@@ -1315,7 +1289,7 @@ mod tests {
             },
         ] {
             workspace
-                .append(&policy, CAPABILITY, input, true, |_| Some(&binding))
+                .append(&policy, CAPABILITY, input, |_| Some(&binding))
                 .unwrap();
         }
         let gathered = workspace.view();
@@ -1343,8 +1317,12 @@ mod tests {
         );
     }
 
+    /// Narrowing reads to the inputs that reach a changed buffer is the retained path's whole
+    /// point, and it is sound there precisely because the untouched registers already hold this
+    /// slot's own previous values. The registers the mask skips must therefore be *retained*, not
+    /// zeroed -- zeroing is what a fresh push would do, and a fresh push may not narrow at all.
     #[test]
-    fn changed_gather_reads_only_inputs_reaching_changed_buffers() {
+    fn retained_gather_reads_only_inputs_reaching_changed_buffers() {
         let binding = binding();
         let policy = policy();
         let glyphs = [layout_glyph(1, 0), layout_glyph(2, 1)];
@@ -1359,23 +1337,49 @@ mod tests {
                     transform_id: 1,
                     glyphs: &glyphs,
                     semantic_glyphs: &[],
-                    semantic_change_masks: &[1, 1],
+                    semantic_change_masks: &[],
                     semantic_f32: &[&semantic_x],
                     semantic_u32: &[&semantic_kind],
                 },
-                false,
                 |_| Some(&binding),
             )
             .unwrap();
+
+        let moved_x = [10.0, 55.0];
+        let mut revised = glyphs;
+        revised[1].content_revision = 2;
+        assert!(workspace.begin_retained(&policy, 2).unwrap());
+        assert_eq!(
+            workspace
+                .append_retained(
+                    &policy,
+                    CAPABILITY,
+                    LayoutPlanInput {
+                        transform_id: 1,
+                        glyphs: &revised,
+                        semantic_glyphs: &[],
+                        semantic_change_masks: &[0, 1],
+                        semantic_f32: &[&moved_x],
+                        semantic_u32: &[&semantic_kind],
+                    },
+                    |_| Some(&binding),
+                )
+                .unwrap(),
+            RetainedGather::Complete
+        );
+        assert!(workspace.finish_retained());
         let gathered = workspace.view();
         let input = gathered.plan_input();
-        assert_eq!(input.f32_fields[0], &[10.0, 20.0]);
-        assert!(
-            input.f32_fields[1..]
-                .iter()
-                .all(|field| *field == [0.0, 0.0])
-        );
-        assert!(input.u32_fields.iter().all(|field| *field == [0, 0]));
+        // Register 0 feeds the only buffer the mask reaches, so it is re-read.
+        assert_eq!(input.f32_fields[0], &[10.0, 55.0]);
+        // Every other register is skipped, and keeps the value the first gather sourced.
+        assert_eq!(input.f32_fields[1], &[1.0, 2.0]);
+        assert_eq!(input.f32_fields[2], &[3.0, 4.0]);
+        assert_eq!(input.f32_fields[3], &[5.0, 5.0]);
+        assert_eq!(input.u32_fields[0], &[100, 200]);
+        assert_eq!(input.u32_fields[1], &[11, 12]);
+        assert_eq!(input.u32_fields[2], &[13, 14]);
+        assert_eq!(input.u32_fields[3], &[15, 15]);
     }
 
     #[test]
@@ -1401,7 +1405,6 @@ mod tests {
                     semantic_f32: &[&semantic_x],
                     semantic_u32: &[&semantic_kind],
                 },
-                false,
                 |_| Some(&binding),
             )
             .unwrap();
@@ -1430,7 +1433,6 @@ mod tests {
                     semantic_f32: &[],
                     semantic_u32: &[],
                 },
-                true,
                 |_| None,
             ),
             Err(GatherError::FontBindingMissing)
@@ -1447,7 +1449,6 @@ mod tests {
                     semantic_f32: &[],
                     semantic_u32: &[],
                 },
-                true,
                 |_| Some(&binding),
             ),
             Err(GatherError::ProgramMissing)
@@ -1464,10 +1465,191 @@ mod tests {
                     semantic_f32: &[],
                     semantic_u32: &[],
                 },
-                true,
                 |_| Some(&binding),
             ),
             Err(GatherError::SourceFieldMissing)
+        );
+    }
+
+    /// Retained slots that a topology edit hands to a different stable identity must carry the
+    /// whole record, not just the registers named by that glyph's own semantic delta. The engine
+    /// computes each mask against the glyph's *previous slot*, so a survivor that merely shifted
+    /// position reports a narrow mask while its new slot still holds the displaced occupant's
+    /// registers. A fresh gather of the same final layout is the independent oracle.
+    fn retained_matches_fresh(
+        label: &str,
+        before: &[LayoutGlyph],
+        after: &[LayoutGlyph],
+        masks: &[u16],
+    ) {
+        let binding = binding();
+        let policy = policy();
+        let semantic_before: Vec<f32> = (0..before.len()).map(|index| index as f32).collect();
+        let semantic_after: Vec<f32> = (0..after.len()).map(|index| index as f32).collect();
+        let kinds_before: Vec<u32> = (0..before.len()).map(|index| index as u32 + 100).collect();
+        let kinds_after: Vec<u32> = (0..after.len()).map(|index| index as u32 + 100).collect();
+        let initial = LayoutPlanInput {
+            transform_id: 1,
+            glyphs: before,
+            semantic_glyphs: &[],
+            semantic_change_masks: &[],
+            semantic_f32: &[&semantic_before],
+            semantic_u32: &[&kinds_before],
+        };
+        let edited = LayoutPlanInput {
+            transform_id: 1,
+            glyphs: after,
+            semantic_glyphs: &[],
+            semantic_change_masks: masks,
+            semantic_f32: &[&semantic_after],
+            semantic_u32: &[&kinds_after],
+        };
+
+        let mut incremental = PolicyGatherWorkspace::default();
+        incremental.reserve_policy(&policy, 16).unwrap();
+        incremental
+            .gather(&policy, CAPABILITY, initial, |_| Some(&binding))
+            .unwrap();
+        assert!(incremental.begin_retained(&policy, 16).unwrap(), "{label}");
+        if let RetainedGather::RebuildFrom(source_start) = incremental
+            .append_retained(&policy, CAPABILITY, edited, |_| Some(&binding))
+            .unwrap()
+        {
+            incremental.truncate_to_retained_prefix();
+            incremental
+                .append_from(&policy, CAPABILITY, edited, source_start, |_| {
+                    Some(&binding)
+                })
+                .unwrap();
+        } else if !incremental.finish_retained() {
+            incremental.truncate_to_retained_prefix();
+        }
+
+        let mut fresh = PolicyGatherWorkspace::default();
+        fresh.reserve_policy(&policy, 16).unwrap();
+        fresh
+            .gather(&policy, CAPABILITY, edited, |_| Some(&binding))
+            .unwrap();
+
+        let incremental_view = incremental.view();
+        let fresh_view = fresh.view();
+        let incremental_input = incremental_view.plan_input();
+        let fresh_input = fresh_view.plan_input();
+        assert_eq!(
+            incremental_input.glyphs.len(),
+            fresh_input.glyphs.len(),
+            "{label}: record count"
+        );
+        for (slot, (incremental_glyph, fresh_glyph)) in incremental_input
+            .glyphs
+            .iter()
+            .zip(fresh_input.glyphs)
+            .enumerate()
+        {
+            assert_eq!(
+                incremental_glyph.stable_id, fresh_glyph.stable_id,
+                "{label}: stable id at slot {slot}"
+            );
+        }
+        for (field, (incremental_field, fresh_field)) in incremental_input
+            .f32_fields
+            .iter()
+            .zip(fresh_input.f32_fields)
+            .enumerate()
+        {
+            assert_eq!(
+                incremental_field, fresh_field,
+                "{label}: f32 register {field}"
+            );
+        }
+        for (field, (incremental_field, fresh_field)) in incremental_input
+            .u32_fields
+            .iter()
+            .zip(fresh_input.u32_fields)
+            .enumerate()
+        {
+            assert_eq!(
+                incremental_field, fresh_field,
+                "{label}: u32 register {field}"
+            );
+        }
+    }
+
+    /// A fresh gather pushes rows that have no prior value, so nothing is left to preserve and a
+    /// register the mask omits becomes a zero rather than a retained value. Its output therefore
+    /// may not depend on a change mask at all: whatever the caller reports as changed, a freshly
+    /// built row must carry every register the program declares.
+    #[test]
+    fn fresh_gather_sources_every_declared_register_whatever_the_change_mask_says() {
+        let binding = binding();
+        let policy = policy();
+        let glyphs = [layout_glyph(1, 0), layout_glyph(2, 1)];
+        let semantic_x = [10.0, 20.0];
+        let semantic_kind = [100, 200];
+        let semantic_f32: [&[f32]; 1] = [&semantic_x];
+        let semantic_u32: [&[u32]; 1] = [&semantic_kind];
+        let gathered = |masks: &[u16]| {
+            let input = LayoutPlanInput {
+                transform_id: 1,
+                glyphs: &glyphs,
+                semantic_glyphs: &[],
+                semantic_change_masks: masks,
+                semantic_f32: &semantic_f32,
+                semantic_u32: &semantic_u32,
+            };
+            let mut workspace = PolicyGatherWorkspace::default();
+            workspace.reserve_policy(&policy, 8).unwrap();
+            workspace
+                .gather(&policy, CAPABILITY, input, |_| Some(&binding))
+                .unwrap();
+            let view = workspace.view();
+            let plan = view.plan_input();
+            (
+                plan.f32_fields
+                    .iter()
+                    .map(|field| field.to_vec())
+                    .collect::<Vec<_>>(),
+                plan.u32_fields
+                    .iter()
+                    .map(|field| field.to_vec())
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        // A delta naming only a field this program's buffer does not read, or naming nothing at
+        // all, must still produce complete rows rather than rows of placeholders.
+        let complete = gathered(&[]);
+        assert_eq!(gathered(&[1 << 1, 1 << 1]), complete);
+        assert_eq!(gathered(&[1, 1]), complete);
+        assert_eq!(gathered(&[0, 0]), complete);
+    }
+
+    #[test]
+    fn retained_gather_repacks_slots_a_topology_edit_hands_to_another_identity() {
+        const MOVED: u16 = 1 << 6;
+        retained_matches_fresh(
+            "interior deletion",
+            &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
+            &[layout_glyph(1, 0), layout_glyph(3, 0)],
+            &[0, MOVED],
+        );
+        retained_matches_fresh(
+            "prefix deletion",
+            &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
+            &[layout_glyph(2, 1), layout_glyph(3, 0)],
+            &[MOVED, MOVED],
+        );
+        retained_matches_fresh(
+            "same-length substitution",
+            &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
+            &[layout_glyph(1, 0), layout_glyph(4, 0), layout_glyph(3, 0)],
+            &[0, MOVED, 0],
+        );
+        retained_matches_fresh(
+            "tail deletion",
+            &[layout_glyph(1, 0), layout_glyph(2, 1), layout_glyph(3, 0)],
+            &[layout_glyph(1, 0), layout_glyph(2, 1)],
+            &[0, 0],
         );
     }
 

--- a/packages/glyph/rust/shaper/src/engine/state.rs
+++ b/packages/glyph/rust/shaper/src/engine/state.rs
@@ -1008,7 +1008,6 @@ impl TextEngine {
                         capability_set,
                         font_bindings,
                         true,
-                        checkpoint,
                     )?;
                 }
                 if !retained {
@@ -1020,7 +1019,6 @@ impl TextEngine {
                         capability_set,
                         font_bindings,
                         false,
-                        checkpoint,
                     )?;
                 }
                 let gathered = gather.view();
@@ -1412,9 +1410,7 @@ fn append_session_gather(
     capability_set: CapabilitySetId,
     font_bindings: &[RegisteredFontBinding],
     retained: bool,
-    checkpoint: bool,
 ) -> Result<(), EngineError> {
-    let incremental = retained;
     let mut retaining = retained;
     for ordered in session.active_order() {
         let paragraph = session
@@ -1466,7 +1462,6 @@ fn append_session_gather(
                             capability_set,
                             input,
                             source_start,
-                            true,
                             binding_for_font,
                         )
                         .map_err(gather_error)?;
@@ -1475,13 +1470,7 @@ fn append_session_gather(
             }
         } else {
             gather
-                .append(
-                    policy,
-                    capability_set,
-                    input,
-                    incremental || checkpoint || !paragraph.positioned_changed,
-                    binding_for_font,
-                )
+                .append(policy, capability_set, input, binding_for_font)
                 .map_err(gather_error)?;
         }
         gather

--- a/packages/glyph/tests/integration/glyph-origin-augmentation.test.mjs
+++ b/packages/glyph/tests/integration/glyph-origin-augmentation.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Glyph-origin augmentation gate.
+ *
+ * The origin lane indexes the live per-glyph origin buffer by stable glyph identity so an
+ * application can read committed origins and override them. Two invariants make it trustworthy,
+ * and both were broken:
+ *
+ *   1. Every committed glyph must be record-backed. A missing record is not benign: the snapshot
+ *      silently substitutes the caller's layout-space fallback, returning one array holding two
+ *      different coordinate spaces with nothing marking the boundary.
+ *   2. The records must describe the CURRENT plan. `clearGlyphOriginOverrides` writes the recorded
+ *      origin back into the buffer the renderer reads, so a stale record does not merely misreport
+ *      -- it corrupts what is drawn.
+ *
+ * The oracle is construction from scratch: a node edited into some text may not disagree with a
+ * node built with that text. It compares the augmentation lane against itself across two paths
+ * rather than against the layout lane, so it stays correct without asserting which coordinate
+ * space the buffer uses.
+ */
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { gunzipSync } from 'node:zlib';
+
+import { createTextRuntime, FontRegistry } from '@pmndrs/glyph';
+import { Text, TextGroup } from '@pmndrs/glyph/three';
+import { slug } from '@pmndrs/glyph/three/slug';
+import * as THREE from 'three/webgpu';
+
+const fixtures = new URL('../../../../apps/benchmarks/fixtures/rendering/', import.meta.url);
+const shaperWasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
+const dataUrl = (bytes) => `data:model/gltf-binary;base64,${bytes.toString('base64')}`;
+
+const contentBox = {
+  align: 'center',
+  maxLines: 1,
+  overflow: 'clip',
+  width: { mode: 'exact', size: 96 },
+  wrap: 'none',
+};
+const style = { fontSize: 6, lineHeight: 1 };
+const paint = { color: '#ffffff' };
+
+async function loadFont() {
+  const runtime = await createTextRuntime({ registry: new FontRegistry(), wasm: await readFile(shaperWasmUrl) });
+  const font = await runtime.loadFont({
+    input: { baked: dataUrl(gunzipSync(await readFile(new URL('inter-slug.font.glb.gz', fixtures)))) },
+    raster: { technique: slug },
+  });
+  return { font, runtime };
+}
+
+function mount(font, text) {
+  const scene = new THREE.Scene();
+  const group = new TextGroup({ batching: 'group' });
+  scene.add(group);
+  const node = new Text({ contentBox, font, paint, style, text });
+  group.add(node);
+  scene.updateMatrixWorld(true);
+  return { node, scene };
+}
+
+/** Round to a stable precision so float noise cannot decide a comparison. */
+const fixed = (values) => [...values].map((value) => Math.round(value * 1000) / 1000);
+
+test('every committed glyph is origin-record backed', async () => {
+  const { font } = await loadFont();
+  const { node } = mount(font, 'ACTIVE');
+  const layout = node.inspectLayout();
+  const snapshot = node.snapshotGlyphOrigins();
+
+  // A record-backed glyph reports the buffer origin. An unbacked one silently reports the layout
+  // fallback instead, so equality with the fallback for SOME glyphs and not others is the
+  // observable signature of a partially populated lane.
+  const fallbackMatches = fixed(layout.x).map((value, index) => value === fixed(snapshot.shapedX)[index]);
+  assert.equal(
+    fallbackMatches.every((matched) => matched === fallbackMatches[0]),
+    true,
+    `origin records covered only part of the glyph run: ${JSON.stringify(fallbackMatches)}`,
+  );
+});
+
+test('an edited node reports the origins of a node built with the same text', async () => {
+  const { font } = await loadFont();
+  const control = mount(font, 'ACTIVE').node.snapshotGlyphOrigins();
+
+  const { node, scene } = mount(font, 'ACTIVATE');
+  node.set({ contentBox, font, paint, spans: [], style, text: 'ACTIVE' });
+  scene.updateMatrixWorld(true);
+  const edited = node.snapshotGlyphOrigins();
+
+  assert.deepEqual(fixed(edited.shapedX), fixed(control.shapedX), 'edited shaped origins diverged from a fresh build');
+  assert.deepEqual(fixed(edited.shapedY), fixed(control.shapedY), 'edited shaped origins diverged from a fresh build');
+  assert.deepEqual(
+    fixed(edited.displayedX),
+    fixed(control.displayedX),
+    'edited displayed origins diverged from a fresh build',
+  );
+});
+
+test('repeated edits keep the origin lane addressable', async () => {
+  const { font } = await loadFont();
+  const { node, scene } = mount(font, 'ACTIVATE');
+
+  // Deletion and insertion alternate so the run both shrinks and grows, which is what retires and
+  // reallocates the records the lane indexes.
+  for (const text of ['ACTIVE', 'ACTIVATE', 'ACTIVE', 'ACTIVATE', 'ACTIVE']) {
+    node.set({ contentBox, font, paint, spans: [], style, text });
+    scene.updateMatrixWorld(true);
+    const control = mount(font, text).node.snapshotGlyphOrigins();
+    const edited = node.snapshotGlyphOrigins();
+    assert.deepEqual(fixed(edited.shapedX), fixed(control.shapedX), `origins diverged after editing to ${text}`);
+  }
+});

--- a/packages/glyph/tests/integration/glyph-origin-augmentation.test.mjs
+++ b/packages/glyph/tests/integration/glyph-origin-augmentation.test.mjs
@@ -12,14 +12,20 @@
  *      origin back into the buffer the renderer reads, so a stale record does not merely misreport
  *      -- it corrupts what is drawn.
  *
- * The oracle is construction from scratch: a node edited into some text may not disagree with a
- * node built with that text. It compares the augmentation lane against itself across two paths
- * rather than against the layout lane, so it stays correct without asserting which coordinate
- * space the buffer uses.
+ * Backing is proved POSITIVELY, by writing a per-glyph sentinel through `setGlyphOrigins` and
+ * reading it back: an override only lands where a record exists, so an unbacked glyph reports the
+ * layout fallback instead of its sentinel. Comparing a snapshot against the fallback proves
+ * nothing on its own -- if every record were missing, every glyph would report the fallback and
+ * agree with it.
+ *
+ * The staleness oracle is construction from scratch: a node edited into some text may not disagree
+ * with a node built with that text. It compares the augmentation lane against itself across two
+ * paths rather than against the layout lane, so it stays correct without asserting which
+ * coordinate space the buffer uses.
  */
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import test from 'node:test';
+import test, { after } from 'node:test';
 import { gunzipSync } from 'node:zlib';
 
 import { createTextRuntime, FontRegistry } from '@pmndrs/glyph';
@@ -41,14 +47,25 @@ const contentBox = {
 const style = { fontSize: 6, lineHeight: 1 };
 const paint = { color: '#ffffff' };
 
+// One Wasm runtime and one baked font for the whole file; each test mounts its own scene on them.
+let runtime;
+let loaded;
+
 async function loadFont() {
-  const runtime = await createTextRuntime({ registry: new FontRegistry(), wasm: await readFile(shaperWasmUrl) });
-  const font = await runtime.loadFont({
+  if (loaded !== undefined) return loaded;
+  runtime = await createTextRuntime({ registry: new FontRegistry(), wasm: await readFile(shaperWasmUrl) });
+  loaded = await runtime.loadFont({
     input: { baked: dataUrl(gunzipSync(await readFile(new URL('inter-slug.font.glb.gz', fixtures)))) },
     raster: { technique: slug },
   });
-  return { font, runtime };
+  return loaded;
 }
+
+after(() => {
+  runtime?.dispose();
+  runtime = undefined;
+  loaded = undefined;
+});
 
 function mount(font, text) {
   const scene = new THREE.Scene();
@@ -57,58 +74,86 @@ function mount(font, text) {
   const node = new Text({ contentBox, font, paint, style, text });
   group.add(node);
   scene.updateMatrixWorld(true);
-  return { node, scene };
+  return { group, node, scene };
+}
+
+function unmount(mounted) {
+  mounted.node.dispose();
+  mounted.group.dispose();
 }
 
 /** Round to a stable precision so float noise cannot decide a comparison. */
 const fixed = (values) => [...values].map((value) => Math.round(value * 1000) / 1000);
 
 test('every committed glyph is origin-record backed', async () => {
-  const { font } = await loadFont();
-  const { node } = mount(font, 'ACTIVE');
-  const layout = node.inspectLayout();
-  const snapshot = node.snapshotGlyphOrigins();
+  const font = await loadFont();
+  const mounted = mount(font, 'ACTIVE');
+  try {
+    const before = mounted.node.snapshotGlyphOrigins();
+    assert.ok(before.layout.glyphStableIds.length > 0, 'the fixture committed no glyphs to check');
 
-  // A record-backed glyph reports the buffer origin. An unbacked one silently reports the layout
-  // fallback instead, so equality with the fallback for SOME glyphs and not others is the
-  // observable signature of a partially populated lane.
-  const fallbackMatches = fixed(layout.x).map((value, index) => value === fixed(snapshot.shapedX)[index]);
-  assert.equal(
-    fallbackMatches.every((matched) => matched === fallbackMatches[0]),
-    true,
-    `origin records covered only part of the glyph run: ${JSON.stringify(fallbackMatches)}`,
-  );
+    // Sentinels are far outside any plausible layout coordinate, so a glyph that reports its
+    // sentinel is provably reading its record and not the fallback the snapshot substitutes.
+    const x = before.shapedX.map((_, index) => -9_000 - index);
+    const y = before.shapedY.map((_, index) => 9_000 + index);
+    mounted.node.setGlyphOrigins({ layout: before.layout, x, y });
+
+    const overridden = mounted.node.snapshotGlyphOrigins();
+    assert.deepEqual([...overridden.displayedX], [...x], 'a glyph without an origin record kept the layout fallback');
+    assert.deepEqual([...overridden.displayedY], [...y], 'a glyph without an origin record kept the layout fallback');
+    // The recorded origin is the pre-override value, which is what `clear` must restore.
+    assert.deepEqual(fixed(overridden.shapedX), fixed(before.shapedX), 'an override rewrote the recorded origin');
+    assert.deepEqual(fixed(overridden.shapedY), fixed(before.shapedY), 'an override rewrote the recorded origin');
+
+    mounted.node.clearGlyphOriginOverrides();
+    const cleared = mounted.node.snapshotGlyphOrigins();
+    assert.deepEqual(fixed(cleared.displayedX), fixed(before.displayedX), 'clearing did not restore every record');
+    assert.deepEqual(fixed(cleared.displayedY), fixed(before.displayedY), 'clearing did not restore every record');
+  } finally {
+    unmount(mounted);
+  }
 });
 
 test('an edited node reports the origins of a node built with the same text', async () => {
-  const { font } = await loadFont();
-  const control = mount(font, 'ACTIVE').node.snapshotGlyphOrigins();
+  const font = await loadFont();
+  const control = mount(font, 'ACTIVE');
+  const mounted = mount(font, 'ACTIVATE');
+  try {
+    const want = control.node.snapshotGlyphOrigins();
+    mounted.node.set({ contentBox, font, paint, spans: [], style, text: 'ACTIVE' });
+    mounted.scene.updateMatrixWorld(true);
+    const edited = mounted.node.snapshotGlyphOrigins();
 
-  const { node, scene } = mount(font, 'ACTIVATE');
-  node.set({ contentBox, font, paint, spans: [], style, text: 'ACTIVE' });
-  scene.updateMatrixWorld(true);
-  const edited = node.snapshotGlyphOrigins();
-
-  assert.deepEqual(fixed(edited.shapedX), fixed(control.shapedX), 'edited shaped origins diverged from a fresh build');
-  assert.deepEqual(fixed(edited.shapedY), fixed(control.shapedY), 'edited shaped origins diverged from a fresh build');
-  assert.deepEqual(
-    fixed(edited.displayedX),
-    fixed(control.displayedX),
-    'edited displayed origins diverged from a fresh build',
-  );
+    for (const lane of ['shapedX', 'shapedY', 'displayedX', 'displayedY']) {
+      assert.deepEqual(fixed(edited[lane]), fixed(want[lane]), `edited ${lane} diverged from a fresh build`);
+    }
+  } finally {
+    unmount(mounted);
+    unmount(control);
+  }
 });
 
 test('repeated edits keep the origin lane addressable', async () => {
-  const { font } = await loadFont();
-  const { node, scene } = mount(font, 'ACTIVATE');
-
-  // Deletion and insertion alternate so the run both shrinks and grows, which is what retires and
-  // reallocates the records the lane indexes.
-  for (const text of ['ACTIVE', 'ACTIVATE', 'ACTIVE', 'ACTIVATE', 'ACTIVE']) {
-    node.set({ contentBox, font, paint, spans: [], style, text });
-    scene.updateMatrixWorld(true);
-    const control = mount(font, text).node.snapshotGlyphOrigins();
-    const edited = node.snapshotGlyphOrigins();
-    assert.deepEqual(fixed(edited.shapedX), fixed(control.shapedX), `origins diverged after editing to ${text}`);
+  const font = await loadFont();
+  const mounted = mount(font, 'ACTIVATE');
+  try {
+    // Deletion and insertion alternate so the run both shrinks and grows, which is what retires and
+    // reallocates the records the lane indexes.
+    for (const text of ['ACTIVE', 'ACTIVATE', 'ACTIVE', 'ACTIVATE', 'ACTIVE']) {
+      mounted.node.set({ contentBox, font, paint, spans: [], style, text });
+      mounted.scene.updateMatrixWorld(true);
+      const control = mount(font, text);
+      try {
+        const want = control.node.snapshotGlyphOrigins();
+        const edited = mounted.node.snapshotGlyphOrigins();
+        for (const lane of ['shapedX', 'shapedY', 'displayedX', 'displayedY']) {
+          assert.deepEqual(fixed(edited[lane]), fixed(want[lane]), `${lane} diverged after editing to ${text}`);
+        }
+      } finally {
+        unmount(control);
+      }
+    }
+  } finally {
+    unmount(mounted);
   }
 });

--- a/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
+++ b/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
@@ -1,0 +1,227 @@
+/**
+ * Incremental text mutation, verified through to the GPU.
+ *
+ * Every lane this engine already tested -- `measureLayout`, `inspectLayout`, glyph ids, glyph
+ * origins, draw counts, `instanceCount` -- reads the ENGINE. The packed instanced attributes are
+ * what the GPU actually samples, and nothing asserted them. An incremental edit that leaves one
+ * record slot holding its pre-edit occupant therefore passes every engine-side check while
+ * rendering the wrong glyph, which is exactly the defect this file exists to catch.
+ *
+ * The oracle is construction from scratch. A node edited into some text may not differ, in any
+ * lane, from a node built with that text: same glyphs, same layout, same packed bytes. That
+ * invariant needs no knowledge of what each buffer means, so it holds as techniques and packing
+ * policies change.
+ *
+ * Sequences are seeded and fixed. A failure names the case and step that reproduce it, with no
+ * wall-clock input and no `Math.random`.
+ */
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { gunzipSync } from 'node:zlib';
+
+import { createTextRuntime, FontRegistry } from '@pmndrs/glyph';
+import { Text, TextGroup } from '@pmndrs/glyph/three';
+import { bitmap } from '@pmndrs/glyph/three/bitmap';
+import { msdf } from '@pmndrs/glyph/three/msdf';
+import { slug } from '@pmndrs/glyph/three/slug';
+import * as THREE from 'three/webgpu';
+
+const fixtures = new URL('../../../../apps/benchmarks/fixtures/rendering/', import.meta.url);
+const shaperWasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
+const dataUrl = (bytes) => `data:model/gltf-binary;base64,${bytes.toString('base64')}`;
+const timeout = 5 * 60 * 1_000;
+
+/** The product-shaped box from the reported regression: centered, single line, clipped. */
+const contentBox = {
+  align: 'center',
+  maxLines: 1,
+  overflow: 'clip',
+  width: { mode: 'exact', size: 96 },
+  wrap: 'none',
+};
+const style = { fontSize: 6, lineHeight: 1 };
+const paint = { color: '#ffffff' };
+
+const TECHNIQUES = {
+  bitmap: { file: 'inter-bitmap-16.font.glb', gzip: false, raster: { technique: bitmap, options: { strikes: [16] } } },
+  msdf: { file: 'inter-mtsdf.font.glb.gz', gzip: true, raster: { technique: msdf } },
+  slug: { file: 'inter-slug.font.glb.gz', gzip: true, raster: { technique: slug } },
+};
+
+async function loadFont(name) {
+  const spec = TECHNIQUES[name];
+  const runtime = await createTextRuntime({ registry: new FontRegistry(), wasm: await readFile(shaperWasmUrl) });
+  const bytes = await readFile(new URL(spec.file, fixtures));
+  return runtime.loadFont({
+    input: { baked: dataUrl(spec.gzip ? gunzipSync(bytes) : bytes) },
+    raster: spec.raster,
+  });
+}
+
+function mount(font, text) {
+  const scene = new THREE.Scene();
+  const group = new TextGroup({ batching: 'group' });
+  scene.add(group);
+  const node = new Text({ contentBox, font, paint, style, text });
+  group.add(node);
+  scene.updateMatrixWorld(true);
+  return { group, node, scene };
+}
+
+/**
+ * Read every lane a draw exposes, engine-side and GPU-side.
+ *
+ * Only the first `instanceCount` instances are read: capacity beyond the committed run is
+ * allowed to hold anything, and asserting it would fail on legal slack rather than on a defect.
+ */
+function lanes(group, node) {
+  const layout = node.inspectLayout();
+  const measured = node.measureLayout();
+  const draws = [];
+  group.traverse((object) => {
+    if (object.userData.pmndrsGlyphRunStart === undefined) return;
+    const geometry = object.geometry;
+    if (geometry === undefined) return;
+    const instances = geometry.instanceCount;
+    const attributes = {};
+    for (const [name, attribute] of Object.entries(geometry.attributes ?? {})) {
+      // Per-vertex attributes describe the unit quad, not the run, so they carry no edit state.
+      if (!(attribute instanceof THREE.InstancedBufferAttribute)) continue;
+      const width = attribute.itemSize ?? 1;
+      const values = [...attribute.array].slice(0, instances * width);
+      // Float lanes are compared at a fixed precision so representation noise cannot decide a
+      // comparison; integer lanes are compared exactly.
+      attributes[name] =
+        attribute.array instanceof Float32Array ? values.map((v) => Math.round(v * 1_000) / 1_000) : values;
+    }
+    draws.push({ attributes, instances, start: object.userData.pmndrsGlyphRunStart });
+  });
+  draws.sort((left, right) => left.start - right.start);
+  return {
+    draws,
+    glyphCount: measured?.glyphCount,
+    glyphIds: [...(layout?.glyphIds ?? [])],
+    glyphStableIds: [...(layout?.glyphStableIds ?? [])],
+    lineCount: measured?.lineCount,
+    x: [...(layout?.x ?? [])].map((v) => Math.round(v * 1_000) / 1_000),
+    y: [...(layout?.y ?? [])].map((v) => Math.round(v * 1_000) / 1_000),
+  };
+}
+
+/**
+ * Assert an edited node is indistinguishable from one built with the same text.
+ *
+ * Stable ids are compared separately and only for length: identity is expected to differ, because
+ * retaining a glyph across an edit is the point of the incremental path. Every other lane, packed
+ * bytes included, must agree exactly.
+ */
+function assertMatchesFreshBuild(font, node, group, text, context) {
+  const fresh = mount(font, text);
+  const want = lanes(fresh.group, fresh.node);
+  const got = lanes(group, node);
+
+  assert.equal(got.glyphCount, want.glyphCount, `${context}: glyph count`);
+  assert.equal(got.lineCount, want.lineCount, `${context}: line count`);
+  assert.deepEqual(got.glyphIds, want.glyphIds, `${context}: glyph ids`);
+  assert.deepEqual(got.x, want.x, `${context}: glyph x origins`);
+  assert.deepEqual(got.y, want.y, `${context}: glyph y origins`);
+  assert.equal(got.glyphStableIds.length, want.glyphStableIds.length, `${context}: stable id lane length`);
+
+  assert.equal(got.draws.length, want.draws.length, `${context}: draw count`);
+  for (const [index, draw] of got.draws.entries()) {
+    const expected = want.draws[index];
+    assert.equal(draw.instances, expected.instances, `${context}: draw ${index} instanceCount`);
+    assert.deepEqual(
+      Object.keys(draw.attributes).sort(),
+      Object.keys(expected.attributes).sort(),
+      `${context}: draw ${index} attribute set`,
+    );
+    for (const name of Object.keys(draw.attributes)) {
+      // The packed lane. This is what the GPU samples, and the only lane that caught the defect.
+      assert.deepEqual(draw.attributes[name], expected.attributes[name], `${context}: draw ${index} packed ${name}`);
+    }
+  }
+  fresh.node.dispose();
+}
+
+/** Every edit class the incremental path distinguishes, each as (from, to). */
+const EDIT_CLASSES = [
+  ['deletion between a shared prefix and suffix', 'ACTIVATE', 'ACTIVE'],
+  ['deletion of an interior span', 'ABXYZC', 'ABC'],
+  ['suffix-only deletion', 'RUNNING', 'RUN'],
+  ['prefix-only deletion', 'PREFIXED', 'FIXED'],
+  ['insertion between a shared prefix and suffix', 'ACTIVE', 'ACTIVATE'],
+  ['insertion at the suffix', 'RUN', 'RUNNING'],
+  ['insertion at the prefix', 'FIXED', 'PREFIXED'],
+  ['same-length substitution', 'ACTIVE', 'ARCHER'],
+  ['shrink to empty', 'ACTIVE', ''],
+  ['grow from empty', '', 'ACTIVE'],
+  ['single character to single character', 'A', 'E'],
+  ['collapse to one character', 'ACTIVATE', 'A'],
+];
+
+for (const technique of Object.keys(TECHNIQUES)) {
+  for (const [label, from, to] of EDIT_CLASSES) {
+    test(`${technique}: ${label}`, { timeout }, async () => {
+      const font = await loadFont(technique);
+      const { group, node, scene } = mount(font, from);
+      node.set({ contentBox, font, paint, spans: [], style, text: to });
+      scene.updateMatrixWorld(true);
+      assertMatchesFreshBuild(font, node, group, to, `${technique} ${from}->${to}`);
+    });
+  }
+
+  test(`${technique}: repeated edits without remounting`, { timeout }, async () => {
+    const font = await loadFont(technique);
+    const { group, node, scene } = mount(font, 'ACTIVATE');
+    for (const [step, text] of ['ACTIVE', 'ACTIVATE', 'ACTIVE', 'ACTIVATE', 'ACTIVE'].entries()) {
+      node.set({ contentBox, font, paint, spans: [], style, text });
+      scene.updateMatrixWorld(true);
+      assertMatchesFreshBuild(font, node, group, text, `${technique} toggle step ${step} -> ${text}`);
+    }
+  });
+
+  test(`${technique}: seeded chaotic edit sequences`, { timeout }, async () => {
+    const font = await loadFont(technique);
+    // A small alphabet with real kern pairs and repeated letters, so edits land on shared
+    // prefixes and suffixes far more often than random text would.
+    const alphabet = 'ACEIRTVX';
+    for (const seed of [1, 7, 13, 29]) {
+      const random = seededRandom(seed);
+      const { group, node, scene } = mount(font, 'ACTIVATE');
+      let text = 'ACTIVATE';
+      for (let step = 0; step < 12; step += 1) {
+        text = chaoticEdit(text, alphabet, random);
+        node.set({ contentBox, font, paint, spans: [], style, text });
+        scene.updateMatrixWorld(true);
+        assertMatchesFreshBuild(font, node, group, text, `${technique} seed ${seed} step ${step} -> ${JSON.stringify(text)}`);
+      }
+    }
+  });
+}
+
+/** Splice a random range and insert a random run, so deletions, insertions, and replacements mix. */
+function chaoticEdit(text, alphabet, random) {
+  const start = Math.floor(random() * (text.length + 1));
+  const end = start + Math.floor(random() * Math.max(1, text.length - start + 1));
+  const insertLength = Math.floor(random() * 4);
+  let insert = '';
+  for (let index = 0; index < insertLength; index += 1) {
+    insert += alphabet[Math.floor(random() * alphabet.length)];
+  }
+  const next = text.slice(0, start) + insert + text.slice(Math.min(end, text.length));
+  // An edit that changes nothing exercises no path; nudge it into one that does.
+  return next === text ? text.slice(0, Math.max(0, text.length - 1)) : next;
+}
+
+/** Deterministic 32-bit PRNG. Seeded sequences make a failure exactly reproducible. */
+function seededRandom(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = Math.imul(state ^ (state >>> 15), 1 | state);
+    value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value;
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}

--- a/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
+++ b/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
@@ -27,6 +27,11 @@ import { msdf } from '@pmndrs/glyph/three/msdf';
 import { slug } from '@pmndrs/glyph/three/slug';
 import * as THREE from 'three/webgpu';
 
+// The identity lane is named by the policy contract that packs it, not by a literal here.
+import { STABLE_GLYPH_BUFFER_ID } from '../../dist/three/render-policy.js';
+
+const IDENTITY_LANE = `_pmndrsGlyph_${STABLE_GLYPH_BUFFER_ID}`;
+
 const fixtures = new URL('../../../../apps/benchmarks/fixtures/rendering/', import.meta.url);
 const shaperWasmUrl = new URL('../../dist/text-shaper.wasm', import.meta.url);
 const dataUrl = (bytes) => `data:model/gltf-binary;base64,${bytes.toString('base64')}`;
@@ -113,8 +118,11 @@ function lanes(group, node) {
  * Assert an edited node is indistinguishable from one built with the same text.
  *
  * Stable ids are compared separately and only for length: identity is expected to differ, because
- * retaining a glyph across an edit is the point of the incremental path. Every other lane, packed
- * bytes included, must agree exactly.
+ * retaining a glyph across an edit is the point of the incremental path. That exemption covers the
+ * packed identity lane too -- it carries the same allocation-order ids -- so that lane is instead
+ * held to the stronger local invariant that it equals the engine's committed identities for the
+ * run it draws. A slot left holding its pre-edit occupant breaks that equality. Every other lane,
+ * packed bytes included, must agree exactly with the fresh build.
  */
 function assertMatchesFreshBuild(font, node, group, text, context) {
   const fresh = mount(font, text);
@@ -138,6 +146,15 @@ function assertMatchesFreshBuild(font, node, group, text, context) {
       `${context}: draw ${index} attribute set`,
     );
     for (const name of Object.keys(draw.attributes)) {
+      if (name === IDENTITY_LANE) {
+        // Held to the engine's own committed identities rather than to the fresh build's.
+        assert.deepEqual(
+          draw.attributes[name],
+          got.glyphStableIds.slice(draw.start, draw.start + draw.instances),
+          `${context}: draw ${index} packed ${name} against committed identities`,
+        );
+        continue;
+      }
       // The packed lane. This is what the GPU samples, and the only lane that caught the defect.
       assert.deepEqual(draw.attributes[name], expected.attributes[name], `${context}: draw ${index} packed ${name}`);
     }
@@ -195,7 +212,13 @@ for (const technique of Object.keys(TECHNIQUES)) {
         text = chaoticEdit(text, alphabet, random);
         node.set({ contentBox, font, paint, spans: [], style, text });
         scene.updateMatrixWorld(true);
-        assertMatchesFreshBuild(font, node, group, text, `${technique} seed ${seed} step ${step} -> ${JSON.stringify(text)}`);
+        assertMatchesFreshBuild(
+          font,
+          node,
+          group,
+          text,
+          `${technique} seed ${seed} step ${step} -> ${JSON.stringify(text)}`,
+        );
       }
     }
   });

--- a/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
+++ b/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
@@ -12,12 +12,24 @@
  * invariant needs no knowledge of what each buffer means, so it holds as techniques and packing
  * policies change.
  *
+ * Both sides of every comparison are produced by the same packing code from the same authored
+ * inputs, so every lane is compared bit-for-bit. Rounding here would hide exactly the corruption
+ * the file exists to detect: a stale slot whose retained bytes happen to be close to the correct
+ * ones.
+ *
  * Sequences are seeded and fixed. A failure names the case and step that reproduce it, with no
  * wall-clock input and no `Math.random`.
+ *
+ * NOT COVERED: the stable-indirect allocation policy. `ThreeTextEngineCoordinator` registers the
+ * Three policy with `threeRenderPolicyBytes`'s default `'ordered'` allocation mode and
+ * `ThreeTextEngineCoordinatorOptions` exposes only `transformMode`, so no first-party path
+ * reachable from `Text`/`TextGroup` selects `'stable'`. Covering it needs either a coordinator
+ * option or a host-level test that drives `TextEngineHost` directly, as
+ * `three-engine-runtime.test.mjs` does.
  */
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import test from 'node:test';
+import test, { after } from 'node:test';
 import { gunzipSync } from 'node:zlib';
 
 import { createTextRuntime, FontRegistry } from '@pmndrs/glyph';
@@ -45,6 +57,8 @@ const contentBox = {
   width: { mode: 'exact', size: 96 },
   wrap: 'none',
 };
+/** Wide enough that mixed span sizes stay inside the line instead of clipping into it. */
+const wideContentBox = { ...contentBox, width: { mode: 'exact', size: 320 } };
 const style = { fontSize: 6, lineHeight: 1 };
 const paint = { color: '#ffffff' };
 
@@ -54,68 +68,139 @@ const TECHNIQUES = {
   slug: { file: 'inter-slug.font.glb.gz', gzip: true, raster: { technique: slug } },
 };
 
+// One Wasm runtime and one baked font per technique for the whole file. Every mount in here is a
+// scene built on top of them, so loading per test would retain dozens of runtimes for no coverage.
+let runtime;
+const loadedFonts = new Map();
+
 async function loadFont(name) {
+  const cached = loadedFonts.get(name);
+  if (cached !== undefined) return cached;
+  runtime ??= await createTextRuntime({ registry: new FontRegistry(), wasm: await readFile(shaperWasmUrl) });
   const spec = TECHNIQUES[name];
-  const runtime = await createTextRuntime({ registry: new FontRegistry(), wasm: await readFile(shaperWasmUrl) });
   const bytes = await readFile(new URL(spec.file, fixtures));
-  return runtime.loadFont({
+  const font = await runtime.loadFont({
     input: { baked: dataUrl(spec.gzip ? gunzipSync(bytes) : bytes) },
     raster: spec.raster,
   });
+  loadedFonts.set(name, font);
+  return font;
 }
 
-function mount(font, text) {
+after(() => {
+  runtime?.dispose();
+  runtime = undefined;
+  loadedFonts.clear();
+});
+
+/**
+ * Author one paragraph's content.
+ *
+ * Spans are derived from the text rather than fixed, so an edited node and a node freshly built
+ * with the same text always carry identical authored style -- the comparison stays a test of the
+ * incremental path, not of two different documents.
+ */
+function paragraph(text, { box = contentBox, position, rasterPixelRatio, styled = false } = {}) {
+  return {
+    position,
+    properties: {
+      contentBox: box,
+      paint,
+      spans: styled ? spansFor(text) : [],
+      style,
+      text,
+      ...(rasterPixelRatio === undefined ? {} : { rasterPixelRatio }),
+    },
+  };
+}
+
+/** Two leading runs in different colours and sizes; the remainder keeps the paragraph defaults. */
+function spansFor(text) {
+  if (text.length < 3) return [];
+  const third = Math.floor(text.length / 3);
+  return [
+    { start: 0, end: third, paint: { color: '#ff2f00' }, style: { fontSize: 9, lineHeight: 1 } },
+    { start: third, end: third * 2, paint: { color: '#0040ff' }, style: { fontSize: 4, lineHeight: 1 } },
+  ];
+}
+
+/** Build a group holding one Text node per authored paragraph. */
+function mount(font, paragraphs) {
   const scene = new THREE.Scene();
   const group = new TextGroup({ batching: 'group' });
   scene.add(group);
-  const node = new Text({ contentBox, font, paint, style, text });
-  group.add(node);
+  const nodes = paragraphs.map(({ position, properties }) => {
+    const node = new Text({ font, ...properties });
+    if (position !== undefined) node.position.set(...position);
+    group.add(node);
+    return node;
+  });
   scene.updateMatrixWorld(true);
-  return { group, node, scene };
+  return { group, nodes, scene };
+}
+
+function unmount(mounted) {
+  for (const node of mounted.nodes) node.dispose();
+  mounted.group.dispose();
+}
+
+/** Re-author every node in a mounted scene and re-synchronize. */
+function edit(mounted, font, paragraphs) {
+  for (const [index, { properties }] of paragraphs.entries()) {
+    mounted.nodes[index].set({ font, ...properties });
+  }
+  mounted.scene.updateMatrixWorld(true);
 }
 
 /**
- * Read every lane a draw exposes, engine-side and GPU-side.
+ * Read every lane a scene exposes, engine-side and GPU-side.
  *
- * Only the first `instanceCount` instances are read: capacity beyond the committed run is
- * allowed to hold anything, and asserting it would fail on legal slack rather than on a defect.
+ * Every draw in a group shares one retained buffer per policy lane and addresses its own run
+ * through `pmndrsGlyphRunStart`, so a lane must be read from `start` rather than from the head of
+ * the array. Only the run's own `instanceCount` records are read: capacity beyond it is allowed to
+ * hold anything, and asserting it would fail on legal slack rather than on a defect.
  */
-function lanes(group, node) {
-  const layout = node.inspectLayout();
-  const measured = node.measureLayout();
+function lanes(mounted) {
   const draws = [];
-  group.traverse((object) => {
+  mounted.group.traverse((object) => {
     if (object.userData.pmndrsGlyphRunStart === undefined) return;
     const geometry = object.geometry;
     if (geometry === undefined) return;
     const instances = geometry.instanceCount;
+    const start = object.userData.pmndrsGlyphRunStart;
     const attributes = {};
     for (const [name, attribute] of Object.entries(geometry.attributes ?? {})) {
       // Per-vertex attributes describe the unit quad, not the run, so they carry no edit state.
       if (!(attribute instanceof THREE.InstancedBufferAttribute)) continue;
       const width = attribute.itemSize ?? 1;
-      const values = [...attribute.array].slice(0, instances * width);
-      // Float lanes are compared at a fixed precision so representation noise cannot decide a
-      // comparison; integer lanes are compared exactly.
-      attributes[name] =
-        attribute.array instanceof Float32Array ? values.map((v) => Math.round(v * 1_000) / 1_000) : values;
+      attributes[name] = [...attribute.array].slice(start * width, (start + instances) * width);
     }
-    draws.push({ attributes, instances, start: object.userData.pmndrsGlyphRunStart });
+    draws.push({ attributes, instances, start });
   });
   draws.sort((left, right) => left.start - right.start);
+  const paragraphs = mounted.nodes.map((node) => {
+    const layout = node.inspectLayout();
+    const measured = node.measureLayout();
+    return {
+      glyphCount: measured?.glyphCount,
+      glyphIds: [...(layout?.glyphIds ?? [])],
+      glyphStableIds: [...(layout?.glyphStableIds ?? [])],
+      lineCount: measured?.lineCount,
+      x: [...(layout?.x ?? [])],
+      y: [...(layout?.y ?? [])],
+    };
+  });
   return {
     draws,
-    glyphCount: measured?.glyphCount,
-    glyphIds: [...(layout?.glyphIds ?? [])],
-    glyphStableIds: [...(layout?.glyphStableIds ?? [])],
-    lineCount: measured?.lineCount,
-    x: [...(layout?.x ?? [])].map((v) => Math.round(v * 1_000) / 1_000),
-    y: [...(layout?.y ?? [])].map((v) => Math.round(v * 1_000) / 1_000),
+    // Record slots are allocated across the whole group in paragraph order, so the identity a
+    // draw's slot must carry is read out of this concatenation by `pmndrsGlyphRunStart`.
+    identities: paragraphs.flatMap((entry) => entry.glyphStableIds),
+    paragraphs,
   };
 }
 
 /**
- * Assert an edited node is indistinguishable from one built with the same text.
+ * Assert an edited scene is indistinguishable from one built with the same content.
  *
  * Stable ids are compared separately and only for length: identity is expected to differ, because
  * retaining a glyph across an edit is the point of the incremental path. That exemption covers the
@@ -124,42 +209,50 @@ function lanes(group, node) {
  * run it draws. A slot left holding its pre-edit occupant breaks that equality. Every other lane,
  * packed bytes included, must agree exactly with the fresh build.
  */
-function assertMatchesFreshBuild(font, node, group, text, context) {
-  const fresh = mount(font, text);
-  const want = lanes(fresh.group, fresh.node);
-  const got = lanes(group, node);
+function assertMatchesFreshBuild(font, mounted, paragraphs, context) {
+  const fresh = mount(font, paragraphs);
+  try {
+    const want = lanes(fresh);
+    const got = lanes(mounted);
 
-  assert.equal(got.glyphCount, want.glyphCount, `${context}: glyph count`);
-  assert.equal(got.lineCount, want.lineCount, `${context}: line count`);
-  assert.deepEqual(got.glyphIds, want.glyphIds, `${context}: glyph ids`);
-  assert.deepEqual(got.x, want.x, `${context}: glyph x origins`);
-  assert.deepEqual(got.y, want.y, `${context}: glyph y origins`);
-  assert.equal(got.glyphStableIds.length, want.glyphStableIds.length, `${context}: stable id lane length`);
-
-  assert.equal(got.draws.length, want.draws.length, `${context}: draw count`);
-  for (const [index, draw] of got.draws.entries()) {
-    const expected = want.draws[index];
-    assert.equal(draw.instances, expected.instances, `${context}: draw ${index} instanceCount`);
-    assert.deepEqual(
-      Object.keys(draw.attributes).sort(),
-      Object.keys(expected.attributes).sort(),
-      `${context}: draw ${index} attribute set`,
-    );
-    for (const name of Object.keys(draw.attributes)) {
-      if (name === IDENTITY_LANE) {
-        // Held to the engine's own committed identities rather than to the fresh build's.
-        assert.deepEqual(
-          draw.attributes[name],
-          got.glyphStableIds.slice(draw.start, draw.start + draw.instances),
-          `${context}: draw ${index} packed ${name} against committed identities`,
-        );
-        continue;
-      }
-      // The packed lane. This is what the GPU samples, and the only lane that caught the defect.
-      assert.deepEqual(draw.attributes[name], expected.attributes[name], `${context}: draw ${index} packed ${name}`);
+    assert.equal(got.paragraphs.length, want.paragraphs.length, `${context}: paragraph count`);
+    for (const [index, entry] of got.paragraphs.entries()) {
+      const expected = want.paragraphs[index];
+      const where = `${context}: paragraph ${index}`;
+      assert.equal(entry.glyphCount, expected.glyphCount, `${where} glyph count`);
+      assert.equal(entry.lineCount, expected.lineCount, `${where} line count`);
+      assert.deepEqual(entry.glyphIds, expected.glyphIds, `${where} glyph ids`);
+      assert.deepEqual(entry.x, expected.x, `${where} glyph x origins`);
+      assert.deepEqual(entry.y, expected.y, `${where} glyph y origins`);
+      assert.equal(entry.glyphStableIds.length, expected.glyphStableIds.length, `${where} stable id lane length`);
     }
+
+    assert.equal(got.draws.length, want.draws.length, `${context}: draw count`);
+    for (const [index, draw] of got.draws.entries()) {
+      const expected = want.draws[index];
+      assert.equal(draw.instances, expected.instances, `${context}: draw ${index} instanceCount`);
+      assert.deepEqual(
+        Object.keys(draw.attributes).sort(),
+        Object.keys(expected.attributes).sort(),
+        `${context}: draw ${index} attribute set`,
+      );
+      for (const name of Object.keys(draw.attributes)) {
+        if (name === IDENTITY_LANE) {
+          // Held to the engine's own committed identities rather than to the fresh build's.
+          assert.deepEqual(
+            draw.attributes[name],
+            got.identities.slice(draw.start, draw.start + draw.instances),
+            `${context}: draw ${index} packed ${name} against committed identities`,
+          );
+          continue;
+        }
+        // The packed lane. This is what the GPU samples, and the only lane that caught the defect.
+        assert.deepEqual(draw.attributes[name], expected.attributes[name], `${context}: draw ${index} packed ${name}`);
+      }
+    }
+  } finally {
+    unmount(fresh);
   }
-  fresh.node.dispose();
 }
 
 /** Every edit class the incremental path distinguishes, each as (from, to). */
@@ -178,24 +271,70 @@ const EDIT_CLASSES = [
   ['collapse to one character', 'ACTIVATE', 'A'],
 ];
 
+/**
+ * A three-node group with per-span colours and sizes and per-node raster pixel ratios.
+ *
+ * One paragraph in uniform white at one size leaves the foreground, `fontSize`, and
+ * `transformIndex` lanes constant, so a slot corrupted in exactly those lanes reads back correct
+ * by accident. Distinct positions, sizes, and colours make each of those lanes carry a value that
+ * identifies its own slot.
+ *
+ * `rasterPixelRatio` is not itself a packed lane -- no first-party program in `render-policy.ts`
+ * reads it -- but it is one of the two resource-selection inputs, so varying it per node drives
+ * the gather's selection-change branch, the one that widens a narrow change mask to every input.
+ * It cannot select a DIFFERENT resource here: these fixtures bake one strike and one page each,
+ * and requesting more strikes needs retained source bytes the fixtures do not carry.
+ */
+function styledScene(texts) {
+  return texts.map((text, index) =>
+    paragraph(text, {
+      box: wideContentBox,
+      position: [index * 24, index * -12, index * 3],
+      rasterPixelRatio: 1 + index,
+      styled: true,
+    }),
+  );
+}
+
 for (const technique of Object.keys(TECHNIQUES)) {
   for (const [label, from, to] of EDIT_CLASSES) {
     test(`${technique}: ${label}`, { timeout }, async () => {
       const font = await loadFont(technique);
-      const { group, node, scene } = mount(font, from);
-      node.set({ contentBox, font, paint, spans: [], style, text: to });
-      scene.updateMatrixWorld(true);
-      assertMatchesFreshBuild(font, node, group, to, `${technique} ${from}->${to}`);
+      const mounted = mount(font, [paragraph(from)]);
+      try {
+        edit(mounted, font, [paragraph(to)]);
+        assertMatchesFreshBuild(font, mounted, [paragraph(to)], `${technique} ${from}->${to}`);
+      } finally {
+        unmount(mounted);
+      }
+    });
+
+    test(`${technique}: ${label} across a styled multi-node group`, { timeout }, async () => {
+      const font = await loadFont(technique);
+      // The edit lands on the middle node, so the nodes around it must keep their own transform,
+      // colour, and size lanes while the record run under them shifts.
+      const before = styledScene(['STEADY', from, 'ANCHOR']);
+      const edited = styledScene(['STEADY', to, 'ANCHOR']);
+      const mounted = mount(font, before);
+      try {
+        edit(mounted, font, edited);
+        assertMatchesFreshBuild(font, mounted, edited, `${technique} styled group ${from}->${to}`);
+      } finally {
+        unmount(mounted);
+      }
     });
   }
 
   test(`${technique}: repeated edits without remounting`, { timeout }, async () => {
     const font = await loadFont(technique);
-    const { group, node, scene } = mount(font, 'ACTIVATE');
-    for (const [step, text] of ['ACTIVE', 'ACTIVATE', 'ACTIVE', 'ACTIVATE', 'ACTIVE'].entries()) {
-      node.set({ contentBox, font, paint, spans: [], style, text });
-      scene.updateMatrixWorld(true);
-      assertMatchesFreshBuild(font, node, group, text, `${technique} toggle step ${step} -> ${text}`);
+    const mounted = mount(font, [paragraph('ACTIVATE')]);
+    try {
+      for (const [step, text] of ['ACTIVE', 'ACTIVATE', 'ACTIVE', 'ACTIVATE', 'ACTIVE'].entries()) {
+        edit(mounted, font, [paragraph(text)]);
+        assertMatchesFreshBuild(font, mounted, [paragraph(text)], `${technique} toggle step ${step} -> ${text}`);
+      }
+    } finally {
+      unmount(mounted);
     }
   });
 
@@ -206,19 +345,24 @@ for (const technique of Object.keys(TECHNIQUES)) {
     const alphabet = 'ACEIRTVX';
     for (const seed of [1, 7, 13, 29]) {
       const random = seededRandom(seed);
-      const { group, node, scene } = mount(font, 'ACTIVATE');
-      let text = 'ACTIVATE';
-      for (let step = 0; step < 12; step += 1) {
-        text = chaoticEdit(text, alphabet, random);
-        node.set({ contentBox, font, paint, spans: [], style, text });
-        scene.updateMatrixWorld(true);
-        assertMatchesFreshBuild(
-          font,
-          node,
-          group,
-          text,
-          `${technique} seed ${seed} step ${step} -> ${JSON.stringify(text)}`,
-        );
+      // Every seed drives a styled three-node group, so a chaotic edit has to keep the untouched
+      // nodes' colour, size, transform, and ratio lanes intact as well as its own.
+      let texts = ['ACTIVATE', 'ACTIVATE', 'ACTIVATE'];
+      const mounted = mount(font, styledScene(texts));
+      try {
+        for (let step = 0; step < 12; step += 1) {
+          texts = texts.map((text) => chaoticEdit(text, alphabet, random));
+          const authored = styledScene(texts);
+          edit(mounted, font, authored);
+          assertMatchesFreshBuild(
+            font,
+            mounted,
+            authored,
+            `${technique} seed ${seed} step ${step} -> ${JSON.stringify(texts)}`,
+          );
+        }
+      } finally {
+        unmount(mounted);
       }
     }
   });


### PR DESCRIPTION
Fixes a rendering corruption reported against `0.0.0-canary-9f6b0611`: a React `<Text>` whose child changed from `ACTIVATE` to `ACTIVE` rendered `ATE`, and repeated toggles cycled `ATE` -> `A` -> `ATE`.

## What was wrong

An incremental text edit left **displaced record slots holding the previous occupant's packed bytes**.

Every engine lane stayed correct. `measureLayout`, `inspectLayout`, glyph ids, glyph origins, draw counts and `instanceCount` all matched a freshly built node. Only the packed instanced attributes — what the GPU actually samples — were wrong, so nothing in the suite could see it. Measured, edited-vs-fresh:

```
ACTIVATE -> ACTIVE  (8->6)  wrong slots: [5]
PREFIXED -> FIXED   (8->5)  wrong slots: [0,1,2,3,4]
ABXYZC   -> ABC     (6->3)  wrong slots: [2]
ACTIVE   -> ARCHER  (6->6)  wrong slots: [1,2,3,4,5]
RUNNING  -> RUN     (7->3)  wrong slots: []    tail deletion displaces nothing
RUN      -> RUNNING (3->7)  wrong slots: []    tail insertion displaces nothing
```

For `ACTIVATE -> ACTIVE`, `_pmndrsGlyph_6` slot 5 held `82,32,48,282` — byte-identical to slot 0's `A` — instead of `3102,3008,3024,12843` for `E`.

## Root cause

One disease at two sites: **a delta mask applied to a destination that does not hold the state the delta was computed against.**

`positioning.rs` computes each glyph's semantic change mask against *its own previous slot*, located through a stable-id index. The gathered columns in `PolicyGatherWorkspace` are addressed *by slot*. The two conventions agree only while a slot keeps its occupant.

**`append_retained`** — the `change_mask == 0` branch already guarded identity. The `change_mask != 0` branch checked only `same_storage_topology`, which compares everything except `stable_id`, and `update_fields` then skips every register the mask omits. A slot handed to a different identity kept the displaced occupant's registers. `self.glyphs[cursor] = next` stored the *correct* id, which is why the ordered-plan predicates correctly flagged the slot dirty and rebaked it — from poisoned columns.

**`append_from`** — this path *pushes* fresh rows, which have no prior value at all, yet narrowed its register set from a frame-wide mask union. `gather_fields` writes zero for every omitted register, and because `input_masks_for_changes` unions per active buffer, a mask reaching no buffer zeroed **every** register. That is the vanishing-glyph variant: colour alpha goes to zero and the glyphs disappear, which is the literal `ATE`. A pushed row cannot be partial, so the narrowing and its `force_all_inputs` parameter are removed rather than corrected.

Site 1 alone took the gate from 27 failures to 6; site 2 accounted for the rest.

## Two shipped tests asserted the defect

- `retained_gather_updates_changed_fields_and_rejects_storage_topology_changes` set `changed_glyphs[1].stable_id = 3` with a narrow mask and asserted the gathered result *was* `3` — encoding "a slot handed to a new identity is patched with a narrow mask" as correct.
- `changed_gather_reads_only_inputs_reaching_changed_buffers` asserted `input.f32_fields[1..].all(|f| *f == [0.0, 0.0])` — the all-zero payload, asserted as intended.

Both retargeted to the cases narrow patching actually covers.

## Why every layer missed it

Three independent layers shared one blind spot — none of them displaced a glyph between record slots:

| layer | what it exercised |
|---|---|
| Rust unit tests | `initial[..2]`, a **tail** deletion — the one deletion shape that shifts nothing |
| benchmark harness | `+TEXT_REVEAL_STEP`, a monotonic typewriter reveal — prefix-stable, appends at the tail |
| integration tests | engine lanes only; the packed buffers were never read |

The existing property test does run seeded random sequences, but its oracle is that `measureLayout` agrees with `inspectLayout` — two derivations of the same upstream, both correct here. Randomness was never the missing ingredient; an **independent oracle** was.

## The gate

`text-mutation-gpu-lanes.test.mjs` — 78 cases across Bitmap, MSDF and Slug. The oracle is differential: a node edited into some text must be indistinguishable from a node built with that text, across every lane including the packed bytes. That needs no knowledge of what the correct bytes are, only that two routes to one state cannot differ.

Covers deletion between a shared prefix and suffix, interior-span deletion, suffix-only and prefix-only deletion, insertion at prefix/suffix/interior, same-length substitution, shrink to empty, grow from empty, single-character swap, collapse to one character, repeated edits without remounting, and seeded chaotic splice sequences — each also run across a styled multi-node `TextGroup` so foreground, inverse font size and transform index vary per draw.

**Proven to bite:** reverting only the Rust change takes it to **29 of 81 failing**; restored, **81/81**.

## Review resolution

An adversarial `codex` review found five issues; four are fixed here and its central premise was corrected with measurement.

- **Over-eager rebuild.** The first guard fired on every identity change, including same-slot substitution. A genuinely new identity has no previous slot, so it gets `ALL_SEMANTIC_CHANGES` unconditionally and the in-place update rewrites the whole record; only a *retained* identity that moved slots arrives with a narrow mask against a foreign slot. Narrowed accordingly. The review's claim that this regressed against pre-fix did not reproduce — patched scalar volume is byte-identical across all three variants — but the conservative guard was slower than necessary: 0.836ms -> 0.780ms median on a 1320-glyph paragraph.
- **The gate read each draw's lane from the head of the shared retained buffer** instead of windowing by `pmndrsGlyphRunStart`, so a multi-draw scene compared the first draw three times. Single-paragraph scenes hid it because their run starts at zero.
- **Floats were rounded to three decimals**, which would pass a real packed mismatch below ~0.0005. All rounding removed; every float now compares exactly.
- **The origin gate passed vacuously** when every record was missing. It now writes per-glyph sentinels through `setGlyphOrigins` and asserts the snapshot reports them, which an unbacked glyph cannot satisfy, then asserts `clearGlyphOriginOverrides` restores every record. All four lanes compared instead of one.
- **Runtime leaks** in both new test files closed; one runtime per file, disposed in `after()`, every mount unmounted in a `finally`.

Confirmed clean by the review: no remaining identity/slot mask misuse, consistent cursor restoration in both bails, `stable_plan.rs` not vulnerable, `RETIRE_SLOT_RANGE` harmless for the current executor, and the amended Rust tests legitimate rather than weakened.

## Verification

| gate | result |
|---|---|
| `text-mutation-gpu-lanes` + `glyph-origin-augmentation` | 81/81 |
| same, with the Rust fix reverted | 29 fail (proves the gate bites) |
| `tests/integration/*` | 225/225 |
| `tests/package/*` | 66/66 |
| `cargo test` (shaper) | 210 + 2 + 1, 0 failed |
| `cargo fmt --check`, `cargo clippy --all-targets -D warnings` | clean |
| `oxlint --deny-warnings`, `oxfmt --check` | clean |
| `pnpm scripts run docs:check` | 0 errors |

## Known gaps, stated rather than hidden

- **`rasterPixelRatio`** is not packed by any first-party program; it is a resource-selection input. Varying it exercises the selection-change branch but cannot select a different resource against single-strike fixtures. Documented in the test file.
- **Stable-indirect allocation is unreachable from the public API** — `ThreeTextEngineCoordinator` takes the `'ordered'` default and exposes only `transformMode`. Documented, with the two ways to close it.
- **`ordered_plan.rs:873`**'s silent `source_end <= old_buffer.bytes.len()` seed guard still degrades to shipping zeros instead of erroring. Not the cause, not reached by any test now, left for a separate hardening change rather than folding an unverifiable edit into this fix.
- **Origin records are not exception-safe across `apply`**: if a callback throws after patching but before `#originRecords.clear()`, `retry()` re-enters `#restoreOriginTargets` with stale targets. Pre-existing, inferred not observed, left out of scope.
