### PR TITLE
feat(glyph): publish the TypeGPU technique shader subpath

### DIFF
--- a/apps/benchmarks/scripts/measure-package-sizes.mts
+++ b/apps/benchmarks/scripts/measure-package-sizes.mts
@@ -48,7 +48,21 @@ const diagnosticCodeFragments = [
 ];
 
 function isTextPeerDependency(id: string): boolean {
-  return id === 'three' || id.startsWith('three/') || id === 'react' || id.startsWith('@react-three/fiber');
+  return (
+    id === 'three' ||
+    id.startsWith('three/') ||
+    id === 'react' ||
+    id.startsWith('@react-three/fiber') ||
+    // TypeGPU is the optional peer of the `/typegpu` shader subpath. It keys its identity
+    // to a single instance exactly as Three and React do, so the consumer-installed
+    // runtime stays outside what this package ships and outside its reviewed ceilings.
+    // `typed-binary` and `tinyest` are resolution internals reached only through TypeGPU.
+    id === 'typegpu' ||
+    id.startsWith('typegpu/') ||
+    id === 'typed-binary' ||
+    id === 'tinyest' ||
+    id.startsWith('tinyest')
+  );
 }
 
 async function bundle(
@@ -393,6 +407,26 @@ const tslSubpath = await measureJavaScript(
     excludedInitial: ['/packages/glyph/dist/react.js', '/packages/glyph/dist/three.js', '/packages/glyph/dist/three/'],
   },
 );
+const typegpuSubpath = await measureJavaScript(
+  'typegpu-subpath-js',
+  'TypeGPU technique shader JS',
+  new URL('../size-entries/text-typegpu.ts', import.meta.url),
+  false,
+  true,
+  true,
+  {
+    // The TypeGPU shader library must not pull the renderer integrations or React;
+    // the `typegpu` runtime itself is an optional peer and stays outside the graph.
+    expectedDynamic: [],
+    excludedInitial: [
+      '/packages/glyph/dist/react.js',
+      '/packages/glyph/dist/three.js',
+      '/packages/glyph/dist/tsl.js',
+      '/packages/glyph/dist/three/',
+      '/packages/glyph/dist/tsl/',
+    ],
+  },
+);
 const threeRuntime = await measureJavaScript(
   'three-runtime-js',
   'Three.js adapter JS',
@@ -441,6 +475,7 @@ const iconsSlug = await measureFontAsset(
 const entries: SizeEntry[] = [
   coreSubpath,
   tslSubpath,
+  typegpuSubpath,
   coreJavaScript,
   textShaperWasm,
   threeRuntime,

--- a/apps/benchmarks/size-entries/text-typegpu.ts
+++ b/apps/benchmarks/size-entries/text-typegpu.ts
@@ -1,0 +1,1 @@
+export * from '@pmndrs/glyph/typegpu';

--- a/apps/benchmarks/src/benchmark/package-size-budgets.ts
+++ b/apps/benchmarks/src/benchmark/package-size-budgets.ts
@@ -39,6 +39,14 @@ export const packageSizeBudgets = {
     gzipBytes: 4_200,
     brotliBytes: 3_700,
   },
+  // The TypeGPU technique shader library is a sibling of `/tsl` with no scene
+  // integration; `typegpu` itself is an optional peer and stays outside the graph.
+  'typegpu-subpath-js': {
+    rawBytes: 30_000,
+    minifiedBytes: 16_000,
+    gzipBytes: 5_000,
+    brotliBytes: 4_400,
+  },
   'font-validator-js': {
     rawBytes: 741_000,
     minifiedBytes: 585_000,

--- a/apps/benchmarks/src/generated/package-sizes.json
+++ b/apps/benchmarks/src/generated/package-sizes.json
@@ -10,11 +10,11 @@
       "label": "Renderer-neutral core JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "19a95bd3b3719815f01134c95a3a24bb2ca11b6042f8a1714b69b9c580075a88",
-      "rawBytes": 235958,
-      "minifiedBytes": 159824,
-      "gzipBytes": 40388,
-      "brotliBytes": 34359
+      "sha256": "359fc27465c1c42d752e72ab83cc472df7f68bc6a6d1b4c8e54e1ae20e3b8de5",
+      "rawBytes": 231734,
+      "minifiedBytes": 157263,
+      "gzipBytes": 39661,
+      "brotliBytes": 33670
     },
     {
       "id": "tsl-subpath-js",
@@ -28,37 +28,48 @@
       "brotliBytes": 3506
     },
     {
+      "id": "typegpu-subpath-js",
+      "label": "TypeGPU technique shader JS",
+      "status": "measured",
+      "format": "javascript",
+      "sha256": "c81590a0ded10183b2c7decacde64b6ce0189dbf7e04f45957bda4f3ad91b77c",
+      "rawBytes": 21922,
+      "minifiedBytes": 15387,
+      "gzipBytes": 2768,
+      "brotliBytes": 2425
+    },
+    {
       "id": "browser-core",
       "label": "Core JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "d517648a99f6e5005f980eb92c45924175ba38f60bb1d2bb40505724098a4a1e",
-      "rawBytes": 114094,
-      "minifiedBytes": 74594,
-      "gzipBytes": 22806,
-      "brotliBytes": 19633
+      "sha256": "1b0970ffc35dcc2e601a8bf7ae9164a5ba5588d6e9eb83139d76155019484d59",
+      "rawBytes": 112873,
+      "minifiedBytes": 74226,
+      "gzipBytes": 22942,
+      "brotliBytes": 19613
     },
     {
       "id": "text-shaper-wasm",
       "label": "Shaper Wasm",
       "status": "measured",
       "format": "wasm",
-      "sha256": "0facfd562812a276d993615b9e05f312b929a15477a777595d40418ef9ad8f0c",
-      "rawBytes": 1135171,
-      "minifiedBytes": 1135171,
-      "gzipBytes": 441125,
-      "brotliBytes": 350756
+      "sha256": "395a1510b1418ef71bb5c72e853213d6ddd2b64d98660ad9b373e257dd949727",
+      "rawBytes": 1123100,
+      "minifiedBytes": 1123100,
+      "gzipBytes": 436176,
+      "brotliBytes": 342207
     },
     {
       "id": "three-runtime-js",
       "label": "Three.js adapter JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "40105e3bcc35287a310bfc580006136eb5618462416d3d11ecc5e4d59f60a088",
-      "rawBytes": 430738,
-      "minifiedBytes": 266882,
-      "gzipBytes": 71347,
-      "brotliBytes": 59781
+      "sha256": "c7ef8da80089911c3cf9faeddcc50f75d72b9546812baf9991073c5cb8a1bd8f",
+      "rawBytes": 399822,
+      "minifiedBytes": 253189,
+      "gzipBytes": 67154,
+      "brotliBytes": 56372
     },
     {
       "id": "font-inter-bitmap-16-32",
@@ -164,44 +175,44 @@
       "label": "Bitmap runtime JS graph",
       "status": "measured",
       "format": "javascript",
-      "sha256": "dd3b4ceecb2a69ef13908453b3b8f4e3017e33bdca21f4a07543053134663135",
-      "rawBytes": 417412,
-      "minifiedBytes": 259126,
-      "gzipBytes": 70071,
-      "brotliBytes": 58387
+      "sha256": "50200d411ea268b410565ca935a0a65c02c0348299334ffd0a1a6bc673fc0289",
+      "rawBytes": 387768,
+      "minifiedBytes": 245933,
+      "gzipBytes": 66269,
+      "brotliBytes": 55096
     },
     {
       "id": "mtsdf-runtime-js",
       "label": "MSDF runtime JS graph",
       "status": "measured",
       "format": "javascript",
-      "sha256": "736ae335af4c3b8971b8ce2f0121af634347e1f2120af0cb3ee231241e4295cc",
-      "rawBytes": 417408,
-      "minifiedBytes": 259112,
-      "gzipBytes": 70097,
-      "brotliBytes": 58316
+      "sha256": "dbdb6e7dc69a9896bb8b0b72f07404837fbdd5891f9d476864a6fdc103c1ab6c",
+      "rawBytes": 387764,
+      "minifiedBytes": 245919,
+      "gzipBytes": 66315,
+      "brotliBytes": 55019
     },
     {
       "id": "slug-runtime-js",
       "label": "Slug runtime JS graph",
       "status": "measured",
       "format": "javascript",
-      "sha256": "fcc98ac2dce0a68c550d893f0970cb6b25ef37d53711602abd552c5b4aec20d1",
-      "rawBytes": 417410,
-      "minifiedBytes": 259202,
-      "gzipBytes": 69950,
-      "brotliBytes": 58316
+      "sha256": "9a661a29291074c50ba746a6e893cdd783117e388888f657fbff227febd74ea7",
+      "rawBytes": 387766,
+      "minifiedBytes": 246009,
+      "gzipBytes": 66194,
+      "brotliBytes": 55025
     },
     {
       "id": "bitmap-baker-wasm",
       "label": "Bitmap baker Wasm",
       "status": "measured",
       "format": "wasm",
-      "sha256": "81277d80329c2db2bb3cff4086a14e6ee9bf4a9ec04d2bc39814232161696bb6",
-      "rawBytes": 622570,
-      "minifiedBytes": 622570,
-      "gzipBytes": 233807,
-      "brotliBytes": 179973
+      "sha256": "cb72cfd75e6a42c1125d37002c6ddee071e33e1179564737fc640a3838f5cbc8",
+      "rawBytes": 622562,
+      "minifiedBytes": 622562,
+      "gzipBytes": 233802,
+      "brotliBytes": 180051
     },
     {
       "id": "bitmap-baker-js",
@@ -241,11 +252,11 @@
       "label": "MTSDF baker Wasm",
       "status": "measured",
       "format": "wasm",
-      "sha256": "7273b354f9c7b6a8224cf90c6d782e047490f0acff9163f872c343526e00fc51",
+      "sha256": "52706172179a87bf76e38117d47306016dcfa62d0dadaca141edd8e70065fa0c",
       "rawBytes": 547921,
       "minifiedBytes": 547921,
-      "gzipBytes": 214221,
-      "brotliBytes": 168114
+      "gzipBytes": 214226,
+      "brotliBytes": 168385
     },
     {
       "id": "mtsdf-baker-js",
@@ -263,11 +274,11 @@
       "label": "Slug baker Wasm",
       "status": "measured",
       "format": "wasm",
-      "sha256": "3ef17ef13010bfc4d535b7dca5cfc869b87e7f209d74f75cb813adbc9f2aa00b",
+      "sha256": "8b41b0cc6f774a973b2d5dce9e4b08ed2c7a7fa492bfb7fd7c8e3ae9272e07d7",
       "rawBytes": 461215,
       "minifiedBytes": 461215,
-      "gzipBytes": 185594,
-      "brotliBytes": 146158
+      "gzipBytes": 185598,
+      "brotliBytes": 145913
     },
     {
       "id": "slug-baker-js",

--- a/apps/benchmarks/src/generated/package-sizes.json
+++ b/apps/benchmarks/src/generated/package-sizes.json
@@ -10,11 +10,11 @@
       "label": "Renderer-neutral core JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "359fc27465c1c42d752e72ab83cc472df7f68bc6a6d1b4c8e54e1ae20e3b8de5",
-      "rawBytes": 231734,
-      "minifiedBytes": 157263,
-      "gzipBytes": 39661,
-      "brotliBytes": 33670
+      "sha256": "19a95bd3b3719815f01134c95a3a24bb2ca11b6042f8a1714b69b9c580075a88",
+      "rawBytes": 235958,
+      "minifiedBytes": 159824,
+      "gzipBytes": 40388,
+      "brotliBytes": 34359
     },
     {
       "id": "tsl-subpath-js",
@@ -43,33 +43,33 @@
       "label": "Core JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "1b0970ffc35dcc2e601a8bf7ae9164a5ba5588d6e9eb83139d76155019484d59",
-      "rawBytes": 112873,
-      "minifiedBytes": 74226,
-      "gzipBytes": 22942,
-      "brotliBytes": 19613
+      "sha256": "d517648a99f6e5005f980eb92c45924175ba38f60bb1d2bb40505724098a4a1e",
+      "rawBytes": 114094,
+      "minifiedBytes": 74594,
+      "gzipBytes": 22806,
+      "brotliBytes": 19633
     },
     {
       "id": "text-shaper-wasm",
       "label": "Shaper Wasm",
       "status": "measured",
       "format": "wasm",
-      "sha256": "395a1510b1418ef71bb5c72e853213d6ddd2b64d98660ad9b373e257dd949727",
-      "rawBytes": 1123100,
-      "minifiedBytes": 1123100,
-      "gzipBytes": 436176,
-      "brotliBytes": 342207
+      "sha256": "2ffe04e37d5917c6b02408414f4765e03600ff0284cb88738702d02322e1da6b",
+      "rawBytes": 1135171,
+      "minifiedBytes": 1135171,
+      "gzipBytes": 441125,
+      "brotliBytes": 350658
     },
     {
       "id": "three-runtime-js",
       "label": "Three.js adapter JS",
       "status": "measured",
       "format": "javascript",
-      "sha256": "c7ef8da80089911c3cf9faeddcc50f75d72b9546812baf9991073c5cb8a1bd8f",
-      "rawBytes": 399822,
-      "minifiedBytes": 253189,
-      "gzipBytes": 67154,
-      "brotliBytes": 56372
+      "sha256": "0b5d1551809643e5b315f30efbb40b52e4f07f8a091faecb0cebf3ad31562659",
+      "rawBytes": 431187,
+      "minifiedBytes": 266967,
+      "gzipBytes": 71352,
+      "brotliBytes": 59816
     },
     {
       "id": "font-inter-bitmap-16-32",
@@ -175,33 +175,33 @@
       "label": "Bitmap runtime JS graph",
       "status": "measured",
       "format": "javascript",
-      "sha256": "50200d411ea268b410565ca935a0a65c02c0348299334ffd0a1a6bc673fc0289",
-      "rawBytes": 387768,
-      "minifiedBytes": 245933,
-      "gzipBytes": 66269,
-      "brotliBytes": 55096
+      "sha256": "11ebe0e5a3ddf288c9f59828357a2d509cfd512f562075f027924ab0f054204d",
+      "rawBytes": 417861,
+      "minifiedBytes": 259211,
+      "gzipBytes": 70076,
+      "brotliBytes": 58310
     },
     {
       "id": "mtsdf-runtime-js",
       "label": "MSDF runtime JS graph",
       "status": "measured",
       "format": "javascript",
-      "sha256": "dbdb6e7dc69a9896bb8b0b72f07404837fbdd5891f9d476864a6fdc103c1ab6c",
-      "rawBytes": 387764,
-      "minifiedBytes": 245919,
-      "gzipBytes": 66315,
-      "brotliBytes": 55019
+      "sha256": "d6204197da9fd093d62f6d5b3967c37556ad777e06166558b70fba7524d1b7b7",
+      "rawBytes": 417857,
+      "minifiedBytes": 259197,
+      "gzipBytes": 70102,
+      "brotliBytes": 58288
     },
     {
       "id": "slug-runtime-js",
       "label": "Slug runtime JS graph",
       "status": "measured",
       "format": "javascript",
-      "sha256": "9a661a29291074c50ba746a6e893cdd783117e388888f657fbff227febd74ea7",
-      "rawBytes": 387766,
-      "minifiedBytes": 246009,
-      "gzipBytes": 66194,
-      "brotliBytes": 55025
+      "sha256": "348b351ff01314602c64fcc2a88137967f4655a65b84f4fff4d7fdd736056059",
+      "rawBytes": 417859,
+      "minifiedBytes": 259287,
+      "gzipBytes": 69956,
+      "brotliBytes": 58352
     },
     {
       "id": "bitmap-baker-wasm",

--- a/docs/packages/benchmarks.md
+++ b/docs/packages/benchmarks.md
@@ -5,7 +5,7 @@ description: Provides the shared interactive and automated benchmark product sur
 resource: ../../apps/benchmarks
 workspace_package: '@pmndrs/glyph-benchmarks'
 documentation_type: reference
-source_digest: 'sha256:69e97091762f149dde73fc5822438a9a1bcdd801245917f8874241e5379109fd'
+source_digest: 'sha256:5872f07e342eae9cb7f7188999b4670c297e455da9343db22ac1de9c1edba739'
 tags: [package, benchmarks, react, vite, product-e2e]
 sources:
   - id: manifest

--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:a611577e60c5763ae600b4174688cb165d99091c733326237855a60645087b5b'
+source_digest: 'sha256:f38711a4d7def41cfd0e27f24ac386146e59f19a8d1c8941f045782056e0126e'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -114,6 +114,7 @@ TypeScript does not independently shape, lay out, or pack paragraphs.
 | `@pmndrs/glyph/raster/*`     | Renderer-neutral Bitmap, MSDF, and Slug decoding and raster-technique contracts.                                                 |
 | `@pmndrs/glyph/core`         | Renderer-neutral engine host, frame wire, plan/layout-query views, technique schemas, policy-program DSL, and binding compiler.  |
 | `@pmndrs/glyph/tsl`          | Canonical TSL shader realizations of the first-party technique interfaces; no scene integration.                                 |
+| `@pmndrs/glyph/typegpu`      | Canonical TypeGPU shader realizations of the first-party technique interfaces; no scene integration, no engine driving.           |
 | `@pmndrs/glyph/bakers/*`     | Optional portable raster bakers.                                                                                                 |
 
 The font-baker Rust source, direct-memory wrapper, schemas, tests, build pipeline, optimized Wasm, and generated ABI are
@@ -121,9 +122,11 @@ owned by this package. There is no separately published font-baker package. The 
 baker, its `std`-enabled dependencies, Ajv, glTF Validator, or the baker Wasm; only explicit bake/runtime-bake surfaces can
 load those bytes.
 
-`@pmndrs/glyph/typegpu`, the TypeScript paragraph engine, paragraph batches/attachments, direct shaping exports, and the
-text-preparation Worker are removed. TypeGPU is a later adapter stack built against the Rust render plan; it is not a
-compatibility wrapper over the removed batch model.
+The TypeScript paragraph engine, paragraph batches/attachments, direct shaping exports, and the text-preparation Worker
+are removed. TypeGPU is a later adapter stack built against the Rust render plan; it is not a compatibility wrapper over
+the removed batch model. The exception is the `@pmndrs/glyph/typegpu` shader library, which publishes the same technique
+realizations as `/tsl` as typed TypeGPU functions for any WebGPU host; `typegpu` is an optional peer and the root entry
+has no static edge to it.
 
 The package-owned `glyph` executable is available through `pnpm exec`; its `bake` command supports both project discovery
 and a direct known-font mode. Its stable packaged shim delegates to the built Node CLI, so workspace installs can link the

--- a/docs/planning/api-surface-audit.md
+++ b/docs/planning/api-surface-audit.md
@@ -136,7 +136,7 @@ This section is the handoff. Keep it current as work lands, so anyone can resume
 | -- | Reshape: `commitState()` readiness signal, cluster-first `caretAt`/`selectionRects` | ✅ | #107 |
 | 4 | Non-circular measure ordering | 🚧 | folded into item 6 |
 | 6-10, 16 | Framework-neutral `Paragraph`, constraint/policy split, intrinsic widths, failure from the measure call, re-point the uikit fixture, paragraph-scoped revision | 🚧 | `feat/paragraph-api` |
-| 24 | `@pmndrs/glyph/typegpu` shader subpath | 🚧 | `feat/typegpu-subpath` |
+| 24 | `@pmndrs/glyph/typegpu` shader subpath | 🟡 Bitmap complete end to end; MSDF, Slug, and decoration not ported | `feat/typegpu-subpath` |
 | 11 | Retention and ownership protocol for the render plan | ⬜ | -- |
 | 12-15 | Host font path, published size delta, uikit parity gate, correct `uikit-integration.md` | ⬜ | -- |
 | 17-23 | Change notification, font readiness, measurement purity, constraint model, direction, baseline contract, revision primitive | ⬜ | -- |
@@ -144,6 +144,8 @@ This section is the handoff. Keep it current as work lands, so anyone can resume
 
 
 24. Publish `@pmndrs/glyph/typegpu`, a sibling of `/tsl`: the same technique shaders realized as TypeGPU functions, reusable by any TypeGPU host without adopting our renderer. No scene integration and no engine driving, exactly as `/tsl` carries none. A TSL realization can be rendered to WGSL and GLSL in a browser probe and its final source extracted, rather than translated by inspection. An old pull request from TypeGPU's author carries a partial slug port; assume it needs reimplementation rather than resumption, but read it closely first, because it is authoritative on TypeGPU idiom. See [example renderer](example-renderer.md) for how this divides from the engine-consumer work.
+
+    Bitmap shipped first, end to end: typed schemas and vertex/fragment stages under `src/typegpu/`, the `./typegpu` subpath export, `typegpu` as an optional peer, and build-time embedding of the shader metadata so the published functions resolve without consumer-side tooling. Parity is pinned against the TSL realization's actual generated WGSL — extracted device-free at test time, not translated by eye — which surfaced two facts the port reproduces exactly: coverage pages are read as clamped nearest texels through `textureLoad` (data textures never filter), and pixel snapping multiplies reciprocals in the emitter's own order. MSDF, Slug, and decoration remain.
 
 Two findings that de-risk the list. `TextEngineSession.measureParagraph(request, paragraphId)` already exists, so item 6 is largely a JavaScript-side wrapper rather than a Rust change. And the render plan already models `clipId`, `depthKey`, `orderToken`, `materialId`, and `transformId` across seven tables, so item 11 is a contract over an existing surface rather than a new one.
 

--- a/docs/planning/example-renderer.md
+++ b/docs/planning/example-renderer.md
@@ -46,12 +46,12 @@ Two separate deliverables, often confused:
 | Surface | Owns | Status |
 | --- | --- | --- |
 | `@pmndrs/glyph/tsl` | The technique shaders realized as three.js TSL node graphs | Published |
-| `@pmndrs/glyph/typegpu` | The same technique shaders realized as TypeGPU functions, reusable by any TypeGPU host | **Not built.** An old pull request from TypeGPU's author carries a partial slug port. Its age means it likely needs reimplementation rather than resumption, but it is authoritative on TypeGPU idiom and should be read closely before starting |
+| `@pmndrs/glyph/typegpu` | The same technique shaders realized as TypeGPU functions, reusable by any TypeGPU host | **Bitmap shipped.** The old pull request from TypeGPU's author was read as the reference idiom; the parity pin extracts both realizations' generated WGSL at test time |
 | `packages/glyph-example-renderer` | An engine consumer proving `/core` is sufficient | Stubbed, device seam only |
 
 `/typegpu` is a shader library and mirrors `/tsl` exactly: the technique realizations, no scene integration, no engine driving. Anyone using TypeGPU can import it without adopting our renderer. The example renderer is the opposite half — it drives the engine and knows nothing about shading — and it will consume `/typegpu` once that subpath exists. Keeping them apart is what stops the shader work from being trapped inside an example.
 
-When porting a shader, the TSL realization can be rendered to WGSL and GLSL in a browser probe and the final source extracted, rather than translated by inspection. The slug port on the open pull request shows how far that approach gets. It was written by TypeGPU's author, so its shader structure, buffer typing, and workarounds for `@typegpu/three` are the reference idiom even where the branch itself is too old to rebase.
+When porting a shader, the TSL realization is rendered to WGSL and GLSL in a device-free probe and the final source extracted, rather than translated by inspection — that extraction is what the Bitmap parity test pins, and it caught two facts inspection missed: data-texture coverage reads compile to exact clamped `textureLoad` fetches, never filtered samples, and the pixel-snapping chain multiplies reciprocals in Three's own emitted order. The slug port on the open pull request shows how far the approach gets. It was written by TypeGPU's author, so its shader structure, buffer typing, and workarounds for `@typegpu/three` are the reference idiom even where the branch itself is too old to rebase.
 
 ## Rules
 

--- a/packages/glyph/.oxlintrc.json
+++ b/packages/glyph/.oxlintrc.json
@@ -73,6 +73,26 @@
           }
         ]
       }
+    },
+    {
+      "files": ["src/typegpu/**", "src/typegpu.ts"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": ["three", "@react-three/fiber"],
+            "patterns": [
+              "three/src/*",
+              "three/addons/*",
+              "three/examples/*",
+              "**/internal/**",
+              "**/generated/**",
+              "three/tsl",
+              "three/webgpu"
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/glyph/package.json
+++ b/packages/glyph/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/tsl.d.ts",
       "import": "./dist/tsl.js"
     },
+    "./typegpu": {
+      "types": "./dist/typegpu.d.ts",
+      "import": "./dist/typegpu.js"
+    },
     "./three": {
       "types": "./dist/three.d.ts",
       "import": "./dist/three.js"
@@ -123,19 +127,25 @@
     "oxlint": "1.75.0",
     "react": "19.2.8",
     "three": "0.185.1",
+    "typegpu": "0.12.3",
     "typescript": "7.0.2",
-    "unicode-property-value-aliases": "3.9.0"
+    "unicode-property-value-aliases": "3.9.0",
+    "unplugin-typegpu": "0.12.2"
   },
   "peerDependencies": {
     "@react-three/fiber": ">=10.0.0-alpha.3 <11",
     "react": ">=19.2 <19.3",
-    "three": ">=0.185.1"
+    "three": ">=0.185.1",
+    "typegpu": ">=0.12.3 <0.13"
   },
   "peerDependenciesMeta": {
     "@react-three/fiber": {
       "optional": true
     },
     "react": {
+      "optional": true
+    },
+    "typegpu": {
       "optional": true
     }
   },

--- a/packages/glyph/scripts/build.mjs
+++ b/packages/glyph/scripts/build.mjs
@@ -5,6 +5,7 @@ import { basename, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { captureCommand } from './support/capture-command.mjs';
+import { embedTypeGpuMetadata } from './support/embed-typegpu-metadata.mjs';
 import { writeGeneratedTypescriptAbi } from './support/generated-typescript-abi.mjs';
 import { reproducibleRustEnvironment } from './support/reproducible-rust-env.mjs';
 
@@ -265,6 +266,7 @@ await run(tsc, [
   '--tsBuildInfoFile',
   join(fileURLToPath(stagingDirectory), '.tsbuildinfo'),
 ]);
+await embedTypeGpuMetadata(fileURLToPath(stagingDirectory));
 await run(wasmOpt, [
   '--enable-bulk-memory',
   '--enable-nontrapping-float-to-int',

--- a/packages/glyph/scripts/support/embed-typegpu-metadata.mjs
+++ b/packages/glyph/scripts/support/embed-typegpu-metadata.mjs
@@ -1,0 +1,37 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * Embeds TypeGPU's shader metadata into the emitted JavaScript of the `/typegpu` subpath.
+ *
+ * JavaScript-authored TypeGPU functions carry a `'use gpu'` directive that the TypeGPU
+ * compiler normally consumes through a consumer-side bundler plugin
+ * (`unplugin-typegpu`). A published subpath cannot demand that every consumer runs a
+ * transform over this package's `dist`, so the build applies the same transform here,
+ * once, over the staged `typegpu.js` entry and the modules beside it. The emitted
+ * functions then resolve to WGSL in any host without extra tooling.
+ *
+ * The transform is additive: it wraps each shader function with its parsed syntax tree
+ * and external-name table and never rewrites surrounding code, so `/core`, `/three`,
+ * and `/tsl` outputs are untouched.
+ *
+ * @param {string} stagingDirectory The staged distribution whose `typegpu` outputs are rewritten in place.
+ */
+export async function embedTypeGpuMetadata(stagingDirectory) {
+  const { default: typegpuPlugin } = await import('unplugin-typegpu/rollup');
+  const plugin = typegpuPlugin();
+  const moduleDirectory = join(stagingDirectory, 'typegpu');
+  const entries = [
+    'typegpu.js',
+    ...(await readdir(moduleDirectory)).filter((name) => name.endsWith('.js')).map((name) => join('typegpu', name)),
+  ];
+  for (const entry of entries) {
+    const file = join(stagingDirectory, entry);
+    const source = await readFile(file, 'utf8');
+    if (!source.includes('use gpu')) continue;
+    const transformed = await plugin.transform.handler.call({}, source, file);
+    if (transformed && typeof transformed.code === 'string' && transformed.code !== source) {
+      await writeFile(file, transformed.code);
+    }
+  }
+}

--- a/packages/glyph/src/typegpu.ts
+++ b/packages/glyph/src/typegpu.ts
@@ -1,0 +1,26 @@
+/**
+ * The TypeGPU technique shader library: the Bitmap, MSDF, Slug, and decoration techniques realized as typed TypeGPU
+ * functions, importable without any renderer or scene integration. A host that owns a `GPUDevice` and a render pass
+ * reuses one canonical shading implementation per technique instead of reimplementing coverage math.
+ *
+ * The surface mirrors `/tsl` in every structural respect: technique shader realizations only, no engine driving, no
+ * renderer ownership. Where `/tsl` builds three.js node graphs from pre-resolved nodes, this subpath exports TypeGPU
+ * schemas and functions a host composes into its own entry points.
+ */
+export {
+  bitmapAtlasUv,
+  bitmapFragment,
+  bitmapPaint,
+  bitmapPageCoverage,
+  bitmapQuadPosition,
+  bitmapVertex,
+  bitmapVertexSnapped,
+  projectClipPosition,
+  snapClipAxis,
+  TypeGpuBitmapFragmentInput,
+  TypeGpuBitmapFragmentOutput,
+  TypeGpuBitmapInstance,
+  TypeGpuBitmapPageLayout,
+  TypeGpuBitmapVertexInput,
+  TypeGpuBitmapVertexOutput,
+} from './typegpu/bitmap-shader.js';

--- a/packages/glyph/src/typegpu/bitmap-reference.ts
+++ b/packages/glyph/src/typegpu/bitmap-reference.ts
@@ -1,0 +1,92 @@
+/**
+ * CPU reference math for the Bitmap technique, independent of TypeGPU and GPU texture
+ * behavior. Every function mirrors one exported shader function of
+ * `bitmap-shader.js` operation for operation, so a simulation of the shipped TypeGPU
+ * functions can be pinned to these values exactly.
+ */
+
+export type BitmapVec2 = readonly [number, number];
+export type BitmapVec3 = readonly [number, number, number];
+export type BitmapVec4 = readonly [number, number, number, number];
+
+/** CPU mirror of `bitmapAtlasUv`. */
+export function referenceBitmapAtlasUv(uvOrigin: BitmapVec2, uvSize: BitmapVec2, quadUv: BitmapVec2): BitmapVec2 {
+  return [uvOrigin[0] + quadUv[0] * uvSize[0], uvOrigin[1] + quadUv[1] * uvSize[1]];
+}
+
+/** CPU mirror of `bitmapQuadPosition`. */
+export function referenceBitmapQuadPosition(
+  origin: BitmapVec2,
+  size: BitmapVec2,
+  quadPosition: BitmapVec2,
+): BitmapVec3 {
+  return [origin[0] + quadPosition[0] * size[0], -(origin[1] + quadPosition[1] * size[1]), 0];
+}
+
+/**
+ * CPU mirror of the projection step behind `projectClipPosition`, over an explicit
+ * column-major matrix: `clip = mvp * vec4(position, 1)` with WGSL's column-times-
+ * vector contraction.
+ */
+export function referenceProjectClipPosition(mvp: readonly number[], position: BitmapVec3): BitmapVec4 {
+  const x = position[0];
+  const y = position[1];
+  const z = position[2];
+  const w = 1;
+  return [
+    mvp[0]! * x + mvp[4]! * y + mvp[8]! * z + mvp[12]! * w,
+    mvp[1]! * x + mvp[5]! * y + mvp[9]! * z + mvp[13]! * w,
+    mvp[2]! * x + mvp[6]! * y + mvp[10]! * z + mvp[14]! * w,
+    mvp[3]! * x + mvp[7]! * y + mvp[11]! * z + mvp[15]! * w,
+  ];
+}
+
+/**
+ * CPU mirror of `snapClipAxis`, including the final multiplication by clip w and the
+ * reciprocal-multiply order of the emitted shader.
+ */
+export function referenceSnapClipAxis(clipAxis: number, clipW: number, physicalSize: number): number {
+  const normalizedDevicePosition = clipAxis * (1 / clipW);
+  const physicalPosition = (normalizedDevicePosition + 1) * (physicalSize * 0.5);
+  return (Math.round(physicalPosition) * (1 / physicalSize) * 2 - 1) * clipW;
+}
+
+/** CPU mirror of the snapped vertex variant's clip placement. */
+export function referenceSnappedClipPosition(clip: BitmapVec4, screenSize: BitmapVec2): BitmapVec4 {
+  return [
+    referenceSnapClipAxis(clip[0], clip[3], screenSize[0]),
+    referenceSnapClipAxis(clip[1], clip[3], screenSize[1]),
+    clip[2],
+    clip[3],
+  ];
+}
+
+/**
+ * CPU mirror of `bitmapPageCoverage`: clamp-to-edge, texel-grid scaling, floor, bound
+ * clamping, exact texel fetch. Returns the linear texel index the fetch lands on.
+ */
+export function referenceBitmapPageCoverage(dimensions: BitmapVec2, atlasUv: BitmapVec2): number {
+  const clampedUv = [clamp(atlasUv[0], 0, 1), clamp(atlasUv[1], 0, 1)] as const;
+  const texelCoord = [Math.floor(clampedUv[0] * dimensions[0]), Math.floor(clampedUv[1] * dimensions[1])] as const;
+  const boundedCoord = [
+    clamp(texelCoord[0], 0, dimensions[0] - 1),
+    clamp(texelCoord[1], 0, dimensions[1] - 1),
+  ] as const;
+  return boundedCoord[0] + boundedCoord[1] * dimensions[0];
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+/** CPU mirror of `bitmapPaint`. */
+export function referenceBitmapPaint(
+  coverage: number,
+  color: BitmapVec4,
+): {
+  coverage: number;
+  color: BitmapVec3;
+  opacity: number;
+} {
+  return { coverage, color: [color[0], color[1], color[2]], opacity: color[3] * coverage };
+}

--- a/packages/glyph/src/typegpu/bitmap-shader.ts
+++ b/packages/glyph/src/typegpu/bitmap-shader.ts
@@ -1,0 +1,252 @@
+import tgpu, { type TgpuBindGroupLayout, type TgpuFn, type TgpuLayoutTexture } from 'typegpu';
+import * as d from 'typegpu/data';
+import * as std from 'typegpu/std';
+
+/**
+ * One glyph instance's canonical Bitmap fields, as a typed GPU schema. Core owns what each field means; how a program
+ * addresses it — storage buffers, instanced attributes, or a uniform — stays the program's own choice.
+ */
+export const TypeGpuBitmapInstance: d.WgslStruct<{
+  origin: d.Vec2f;
+  size: d.Vec2f;
+  uvOrigin: d.Vec2f;
+  uvSize: d.Vec2f;
+  color: d.Vec4f;
+  pageIndex: d.U32;
+}> = d.struct({
+  /** Paragraph-local glyph origin, in layout units, with y measured downward. */
+  origin: d.vec2f,
+  /** Glyph quad extent in layout units. */
+  size: d.vec2f,
+  /** Upper-left atlas coordinate of the glyph's coverage rectangle. */
+  uvOrigin: d.vec2f,
+  /** Atlas extent of the glyph's coverage rectangle. */
+  uvSize: d.vec2f,
+  /** Resolved paint colour with alpha, unpremultiplied. */
+  color: d.vec4f,
+  /** Texture-array layer containing this glyph's coverage. */
+  pageIndex: d.u32,
+});
+export type TypeGpuBitmapInstance = d.InferGPU<typeof TypeGpuBitmapInstance>;
+
+/**
+ * The GPU resource one Bitmap glyph batch binds: the single-channel coverage pages its strike binding selected. Pages
+ * are uploaded in the atlas's own top-down row order, so any flipY-style host setting must stay disabled. Coverage is
+ * read as exact clamped texels — the fetch the `/tsl` realization compiles to for data textures — so no sampler enters
+ * the layout.
+ */
+export const TypeGpuBitmapPageLayout: TgpuBindGroupLayout<{
+  page: TgpuLayoutTexture<d.WgslTexture2dArray<d.F32>> & { visibility?: readonly ['fragment'] };
+}> = tgpu.bindGroupLayout({
+  page: { texture: d.texture2dArray(d.f32), visibility: ['fragment'] },
+});
+
+/** Everything the vertex stage reads besides the instance: the unit quad and the draw's projection. */
+export const TypeGpuBitmapVertexInput: d.WgslStruct<{
+  quadPosition: d.Vec2f;
+  quadUv: d.Vec2f;
+  instance: typeof TypeGpuBitmapInstance;
+  modelViewProjection: d.Mat4x4f;
+  screenSize: d.Vec2f;
+}> = d.struct({
+  /**
+   * Unit-quad coordinate spanning `[0, 1]` with the origin at the glyph's upper-left corner. This is the coordinate
+   * `/tsl` reads from `positionLocal`; a program supplying different geometry owns that correspondence.
+   */
+  quadPosition: d.vec2f,
+  /**
+   * Unit-quad texture coordinate, the coordinate `/tsl` reads from `uv()`. Equals `quadPosition` on the technique's
+   * unit quad; both are carried because `/tsl` reads them independently.
+   */
+  quadUv: d.vec2f,
+  instance: TypeGpuBitmapInstance,
+  /** Column-major model-view-projection, the same matrix chain a Three renderer would apply to `position`. */
+  modelViewProjection: d.mat4x4f,
+  /** Drawing-buffer size in physical pixels. Read only by the pixel-snapped vertex variant. */
+  screenSize: d.vec2f,
+});
+export type TypeGpuBitmapVertexInput = d.InferGPU<typeof TypeGpuBitmapVertexInput>;
+
+/**
+ * Everything the canonical Bitmap vertex stage produces, so a program can consume a stage or compose over its output.
+ *
+ * Unlike `/tsl`, which leaves object-space `position` for the renderer's projection, a standalone vertex result carries
+ * its clip-space placement directly: `clipPosition` is what a program assigns to `@builtin(position)`.
+ */
+export const TypeGpuBitmapVertexOutput: d.WgslStruct<{
+  position: d.Vec3f;
+  clipPosition: d.Vec4f;
+  atlasUv: d.Vec2f;
+  color: d.Vec4f;
+  pageLayer: d.U32;
+}> = d.struct({
+  /** Glyph-quad position in paragraph space, y upward, z zero. */
+  position: d.vec3f,
+  /** Clip-space vertex position selected by the variant: default projection, or pixel-snapped. */
+  clipPosition: d.vec4f,
+  /** Atlas coordinate the page is sampled at, in the page's own top-down texel space. */
+  atlasUv: d.vec2f,
+  /** Resolved paint colour passed through to the fragment stage. */
+  color: d.vec4f,
+  /** Texture-array layer containing this glyph's coverage. */
+  pageLayer: d.u32,
+});
+export type TypeGpuBitmapVertexOutput = d.InferGPU<typeof TypeGpuBitmapVertexOutput>;
+
+/** Everything the fragment stage reads: the interpolated varyings of one glyph quad. */
+export const TypeGpuBitmapFragmentInput: d.WgslStruct<{
+  atlasUv: d.Vec2f;
+  color: d.Vec4f;
+  pageLayer: d.U32;
+}> = d.struct({
+  atlasUv: d.vec2f,
+  color: d.vec4f,
+  pageLayer: d.u32,
+});
+export type TypeGpuBitmapFragmentInput = d.InferGPU<typeof TypeGpuBitmapFragmentInput>;
+
+/**
+ * Everything the canonical Bitmap fragment stage produces, so a program can consume the final result or compose over
+ * its coverage before paint alpha.
+ */
+export const TypeGpuBitmapFragmentOutput: d.WgslStruct<{
+  coverage: d.F32;
+  color: d.Vec3f;
+  opacity: d.F32;
+}> = d.struct({
+  /** Sampled glyph coverage before paint alpha. */
+  coverage: d.f32,
+  color: d.vec3f,
+  opacity: d.f32,
+});
+export type TypeGpuBitmapFragmentOutput = d.InferGPU<typeof TypeGpuBitmapFragmentOutput>;
+
+/** Atlas coordinate the coverage page is sampled at, in the page's own top-down texel space. */
+export function bitmapAtlasUv(uvOrigin: d.v2f, uvSize: d.v2f, quadUv: d.v2f): d.v2f {
+  'use gpu';
+
+  return d.vec2f(uvOrigin.x + quadUv.x * uvSize.x, uvOrigin.y + quadUv.y * uvSize.y);
+}
+
+/** Glyph-quad position in paragraph space, with layout units' downward y flipped upward. */
+export function bitmapQuadPosition(origin: d.v2f, size: d.v2f, quadPosition: d.v2f): d.v3f {
+  'use gpu';
+
+  return d.vec3f(origin.x + quadPosition.x * size.x, -(origin.y + quadPosition.y * size.y), 0);
+}
+
+/**
+ * Rounds one projected clip-space axis onto whole physical pixels and returns the final clip value. Snapping in clip
+ * space rather than in layout units keeps the paragraph transform, camera, and device pixel ratio out of the technique:
+ * whatever chain produced the clip position, its device-space landing is what has to sit on the grid the atlas was
+ * baked for. The operation order — reciprocals included — matches the TSL realization's emitted shader exactly.
+ */
+export function snapClipAxis(clipAxis: number, clipW: number, physicalSize: number): number {
+  'use gpu';
+
+  const normalizedDevicePosition = clipAxis * (1 / clipW);
+  const physicalPosition = (normalizedDevicePosition + 1) * (physicalSize * 0.5);
+  return (std.round(physicalPosition) * (1 / physicalSize) * 2 - 1) * clipW;
+}
+
+/** Projects the glyph quad through the draw's model-view-projection without pixel snapping. */
+export function projectClipPosition(modelViewProjection: d.m4x4f, position: d.v3f): d.v4f {
+  'use gpu';
+
+  return std.mul(modelViewProjection, d.vec4f(position.x, position.y, position.z, 1));
+}
+
+/**
+ * The canonical Bitmap vertex stage: quad placement, atlas addressing, and paint passthrough under the default
+ * projection. Pixel snapping is opt-in because it preserves strike sharpness at rest but quantizes animated motion; a
+ * program that wants it binds `bitmapVertexSnapped` instead.
+ */
+export const bitmapVertex: TgpuFn<(input: typeof TypeGpuBitmapVertexInput) => typeof TypeGpuBitmapVertexOutput> =
+  tgpu.fn(
+    [TypeGpuBitmapVertexInput],
+    TypeGpuBitmapVertexOutput,
+  )((input) => {
+    'use gpu';
+
+    const instance = input.instance;
+    const position = bitmapQuadPosition(instance.origin, instance.size, input.quadPosition);
+    return TypeGpuBitmapVertexOutput({
+      position,
+      clipPosition: projectClipPosition(input.modelViewProjection, position),
+      atlasUv: bitmapAtlasUv(instance.uvOrigin, instance.uvSize, input.quadUv),
+      color: instance.color,
+      pageLayer: instance.pageIndex,
+    });
+  });
+
+/**
+ * The pixel-snapped Bitmap vertex stage: the same graph with the projected x/y axes rounded onto whole physical
+ * pixels. Snapping preserves strike sharpness at rest but quantizes animated motion.
+ */
+export const bitmapVertexSnapped: TgpuFn<(input: typeof TypeGpuBitmapVertexInput) => typeof TypeGpuBitmapVertexOutput> =
+  tgpu.fn(
+    [TypeGpuBitmapVertexInput],
+    TypeGpuBitmapVertexOutput,
+  )((input) => {
+    'use gpu';
+
+    const instance = input.instance;
+    const position = bitmapQuadPosition(instance.origin, instance.size, input.quadPosition);
+    const clip = projectClipPosition(input.modelViewProjection, position);
+    return TypeGpuBitmapVertexOutput({
+      position,
+      clipPosition: d.vec4f(
+        snapClipAxis(clip.x, clip.w, input.screenSize.x),
+        snapClipAxis(clip.y, clip.w, input.screenSize.y),
+        clip.z,
+        clip.w,
+      ),
+      atlasUv: bitmapAtlasUv(instance.uvOrigin, instance.uvSize, input.quadUv),
+      color: instance.color,
+      pageLayer: instance.pageIndex,
+    });
+  });
+
+/** Paint composition over resolved coverage: unpremultiplied colour with alpha scaled by glyph coverage. */
+export function bitmapPaint(coverage: number, color: d.v4f): TypeGpuBitmapFragmentOutput {
+  'use gpu';
+
+  return TypeGpuBitmapFragmentOutput({
+    coverage,
+    color: d.vec3f(color.r, color.g, color.b),
+    opacity: color.a * coverage,
+  });
+}
+
+/**
+ * Coverage of one atlas coordinate: the coordinate is clamped into the page, scaled onto the texel grid, floored, and
+ * clamped against the bounds — the same nearest-texel fetch the `/tsl` realization compiles to for data textures.
+ */
+export function bitmapPageCoverage(page: d.texture2dArray<d.F32>, atlasUv: d.v2f, pageLayer: number): number {
+  'use gpu';
+
+  const dimensions = std.textureDimensions(page, 0);
+  const clampedUv = d.vec2f(std.clamp(atlasUv.x, 0, 1), std.clamp(atlasUv.y, 0, 1));
+  const scaledCoord = d.vec2f(clampedUv.x * d.f32(dimensions.x), clampedUv.y * d.f32(dimensions.y));
+  const flooredCoord = d.vec2f(std.floor(scaledCoord.x), std.floor(scaledCoord.y));
+  const boundedCoord = d.vec2u(
+    d.u32(std.clamp(flooredCoord.x, 0, d.f32(dimensions.x - 1))),
+    d.u32(std.clamp(flooredCoord.y, 0, d.f32(dimensions.y - 1))),
+  );
+  return std.textureLoad(page, boundedCoord, pageLayer, 0).x;
+}
+
+/**
+ * The canonical Bitmap fragment stage: single-channel coverage fetched from the bound page array at the interpolated
+ * atlas coordinate, then composed with the paint colour.
+ */
+export const bitmapFragment: TgpuFn<(input: typeof TypeGpuBitmapFragmentInput) => typeof TypeGpuBitmapFragmentOutput> =
+  tgpu.fn(
+    [TypeGpuBitmapFragmentInput],
+    TypeGpuBitmapFragmentOutput,
+  )((input) => {
+    'use gpu';
+
+    const coverage = bitmapPageCoverage(TypeGpuBitmapPageLayout.$.page, input.atlasUv, input.pageLayer);
+    return bitmapPaint(coverage, input.color);
+  });

--- a/packages/glyph/tests/package/typegpu-bitmap-parity.test.mjs
+++ b/packages/glyph/tests/package/typegpu-bitmap-parity.test.mjs
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as d from 'typegpu/data';
+import tgpu from 'typegpu';
+
+import { extractBitmapTslShader } from '../support/extract-bitmap-tsl-shader.mjs';
+import {
+  bitmapAtlasUv,
+  bitmapFragment,
+  bitmapPaint,
+  bitmapQuadPosition,
+  bitmapVertex,
+  bitmapVertexSnapped,
+  projectClipPosition,
+  snapClipAxis,
+  TypeGpuBitmapFragmentInput,
+  TypeGpuBitmapInstance,
+  TypeGpuBitmapVertexInput,
+} from '../../dist/typegpu/bitmap-shader.js';
+import {
+  referenceBitmapAtlasUv,
+  referenceBitmapPaint,
+  referenceBitmapQuadPosition,
+  referenceProjectClipPosition,
+  referenceSnapClipAxis,
+} from '../../dist/typegpu/bitmap-reference.js';
+
+/**
+ * Bitmap parity between the `/tsl` and `/typegpu` realizations of the technique.
+ *
+ * The two sides cannot execute against each other without a GPU, so the pin stands on
+ * extractions and mirrors instead of prose:
+ *
+ * 1. The device-free TSL extraction compiles the canonical `/tsl` graph to the WGSL a
+ *    WebGPU run executes, and the shipped TypeGPU stages resolve to WGSL through the
+ *    metadata the build embeds. Each source is extracted here, at test time, from built
+ *    artifacts, and each must carry the same per-step operation chains: atlas
+ *    addressing, quad placement with its y flip, clamped nearest-texel coverage fetch,
+ *    paint alpha scaled by coverage, and reciprocal-ordered snapping.
+ * 2. Every CPU-callable shader function is compared against its CPU reference mirror,
+ *    so the mirrors cannot silently drift from what ships.
+ */
+
+/** Collapse shader text so formulas can be matched whitespace-insensitively. */
+function flatten(source) {
+  return source.replace(/\s+/g, '');
+}
+
+/** Vec and struct instances expose their numbers through a JSON representation. */
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+const tsl = {
+  plain: extractBitmapTslShader({ pixelSnapping: false }),
+  snapped: extractBitmapTslShader({ pixelSnapping: true }),
+};
+
+const gpu = {
+  vertex: tgpu.resolve([bitmapVertex]),
+  snapped: tgpu.resolve([bitmapVertexSnapped]),
+  fragment: tgpu.resolve([bitmapFragment]),
+};
+
+test('atlas addressing matches the TSL realization', () => {
+  // TSL inlines `(atlasOrigin.x + (uv.x * atlasExtent.x))` per component; both components.
+  const tslFlat = flatten(tsl.plain.fragment);
+  assert.match(tslFlat, /\.x\+\([A-Za-z0-9_]*\.x\*[A-Za-z0-9_]*\.x\)\)/);
+  assert.match(tslFlat, /\.y\+\([A-Za-z0-9_]*\.y\*[A-Za-z0-9_]*\.y\)\)/);
+
+  const gpuFlat = flatten(gpu.vertex);
+  assert.match(gpuFlat, /\(uvOrigin\.x\+\(quadUv\.x\*uvSize\.x\)\)/);
+  assert.match(gpuFlat, /\(uvOrigin\.y\+\(quadUv\.y\*uvSize\.y\)\)/);
+});
+
+test('quad placement matches the TSL realization, including the y flip', () => {
+  const tslFlat = flatten(tsl.plain.vertex);
+  assert.match(tslFlat, /\.x\+\([A-Za-z0-9_]*\.x\*[A-Za-z0-9_]*\.x\)/);
+  assert.match(tslFlat, /-\([A-Za-z0-9_]*\.y\+\([A-Za-z0-9_]*\.y\*[A-Za-z0-9_]*\.y\)\)\),0\.0\)/);
+
+  const gpuFlat = flatten(gpu.vertex);
+  assert.match(gpuFlat, /\(origin\.x\+\(quadPosition\.x\*size\.x\)\)/);
+  assert.match(gpuFlat, /-\(\(origin\.y\+\(quadPosition\.y\*size\.y\)\)\),0f\)/);
+});
+
+test('coverage is an exact clamped texel fetch on both sides', () => {
+  // Three compiles data-texture reads to textureLoad over clamped integer texel
+  // coordinates: clamp-to-edge, scale by dimensions, floor, clamp to bounds.
+  const tslFetch = flatten(tsl.plain.fragment);
+  assert.match(tslFetch, /textureDimensions\(nodeUniform0,u32\(0\)\)/);
+  assert.match(tslFetch, /clamp\(floor\(/);
+  assert.match(tslFetch, /textureLoad\(nodeUniform0,/);
+
+  const gpuFetch = flatten(gpu.fragment);
+  assert.match(gpuFetch, /textureDimensions\(page,0\)/);
+  assert.match(gpuFetch, /floor\(/);
+  assert.match(gpuFetch, /textureLoad\(page,boundedCoord,pageLayer,0\)\.x/);
+});
+
+test('paint composition scales alpha by coverage identically', () => {
+  // TSL: DiffuseColor.w = (DiffuseColor.w * (paint.w * coverage.x)) — the inner product is ours.
+  assert.match(flatten(tsl.plain.fragment), /=\([A-Za-z]*\.w\*\([A-Za-z0-9]*\.w\*[A-Za-z0-9]*\.x\)\)/);
+  assert.match(flatten(gpu.fragment), /\(color\.a\*coverage\)/);
+});
+
+test('pixel snapping rounds projected axes onto whole physical pixels identically', () => {
+  // TSL emits, per axis: round((clip*(1/w)+1)*(size*0.5))*(1/size)*2-1)*w — reciprocals included.
+  const tslSnap = flatten(tsl.snapped.vertex);
+  assert.match(tslSnap, /round\(/);
+  assert.match(tslSnap, /\*\(1\.0\/[A-Za-z0-9_]*\.w\)\)/);
+  assert.match(tslSnap, /\*\(1\.0\/object\.nodeUniform4\.x\)\)\*2\.0\)-1\.0\)\*[A-Za-z0-9_]*\.w\)/);
+
+  // The TypeGPU helper computes the identical chain, reciprocals included.
+  const gpuSnap = flatten(gpu.snapped);
+  assert.match(gpuSnap, /\(clipAxis\*\(1f\/clipW\)\)/);
+  assert.match(gpuSnap, /\(\(\(round\(physicalPosition\)\*\(1f\/physicalSize\)\)\*2f\)-1f\)\*clipW\)/);
+});
+
+test('shader functions agree with their CPU reference mirrors', () => {
+  const values = {
+    origin: [13.5, -7.25],
+    size: [21, 34],
+    uvOrigin: [0.125, 0.375],
+    uvSize: [0.0625, 0.1875],
+    color: [0.9, 0.8, 0.7, 0.6],
+    pageIndex: 3,
+  };
+  const quadPosition = [0.25, 0.75];
+  const quadUv = [0.25, 0.5];
+  const screenSize = [96, 64];
+  const mvpEntries = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 4, -2, 0.5, 1];
+
+  const position = bitmapQuadPosition(d.vec2f(...values.origin), d.vec2f(...values.size), d.vec2f(...quadPosition));
+  assert.deepEqual(plain(position), referenceBitmapQuadPosition(values.origin, values.size, quadPosition));
+  const atlasUv = bitmapAtlasUv(d.vec2f(...values.uvOrigin), d.vec2f(...values.uvSize), d.vec2f(...quadUv));
+  assert.deepEqual(plain(atlasUv), referenceBitmapAtlasUv(values.uvOrigin, values.uvSize, quadUv));
+
+  const mvp = d.mat4x4f(...mvpEntries);
+  const clip = projectClipPosition(mvp, position);
+  assert.deepEqual(plain(clip), referenceProjectClipPosition(mvpEntries, plain(position)));
+
+  assert.equal(snapClipAxis(clip[0], clip[3], screenSize[0]), referenceSnapClipAxis(clip[0], clip[3], screenSize[0]));
+  assert.equal(snapClipAxis(clip[1], clip[3], screenSize[1]), referenceSnapClipAxis(clip[1], clip[3], screenSize[1]));
+
+  const input = TypeGpuBitmapVertexInput({
+    quadPosition: d.vec2f(...quadPosition),
+    quadUv: d.vec2f(...quadUv),
+    instance: TypeGpuBitmapInstance({
+      ...values,
+      origin: d.vec2f(...values.origin),
+      size: d.vec2f(...values.size),
+      uvOrigin: d.vec2f(...values.uvOrigin),
+      uvSize: d.vec2f(...values.uvSize),
+      color: d.vec4f(...values.color),
+      pageIndex: d.u32(values.pageIndex),
+    }),
+    modelViewProjection: mvp,
+    screenSize: d.vec2f(...screenSize),
+  });
+  const projected = bitmapVertex(input);
+  assert.deepEqual(plain(projected.clipPosition), plain(clip));
+  const snapped = bitmapVertexSnapped(input);
+  assert.deepEqual(plain(snapped.clipPosition), [
+    referenceSnapClipAxis(clip[0], clip[3], screenSize[0]),
+    referenceSnapClipAxis(clip[1], clip[3], screenSize[1]),
+    clip[2],
+    clip[3],
+  ]);
+  assert.deepEqual(plain(snapped.atlasUv), referenceBitmapAtlasUv(values.uvOrigin, values.uvSize, quadUv));
+
+  const painted = bitmapPaint(0.42, d.vec4f(...values.color));
+  const mirroredPaint = referenceBitmapPaint(0.42, values.color);
+  // Shader execution rounds every value to f32; the mirror computes in doubles.
+  assert.equal(painted.coverage, Math.fround(mirroredPaint.coverage));
+  assert.deepEqual(plain(painted.color), mirroredPaint.color.map(Math.fround));
+  // One f32 rounding step separates the simulated GPU product from the f64 reference.
+  assert.ok(Math.abs(painted.opacity - values.color[3] * 0.42) <= 1e-6);
+});
+
+test('the fragment input contract carries exactly the vertex varyings the fragment needs', () => {
+  assert.deepEqual(Object.keys(TypeGpuBitmapFragmentInput.propTypes).sort(), ['atlasUv', 'color', 'pageLayer']);
+});

--- a/packages/glyph/tests/package/typegpu-bitmap.test.mjs
+++ b/packages/glyph/tests/package/typegpu-bitmap.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import tgpu from 'typegpu';
+import * as d from 'typegpu/data';
+
+import {
+  bitmapFragment,
+  bitmapPaint,
+  bitmapVertex,
+  bitmapVertexSnapped,
+  snapClipAxis,
+  TypeGpuBitmapInstance,
+  TypeGpuBitmapVertexInput,
+} from '../../dist/typegpu/bitmap-shader.js';
+import {
+  referenceBitmapAtlasUv,
+  referenceBitmapPaint,
+  referenceBitmapQuadPosition,
+  referenceProjectClipPosition,
+  referenceSnappedClipPosition,
+} from '../../dist/typegpu/bitmap-reference.js';
+
+const IDENTITY_COLUMN_MAJOR = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+/** A non-trivial column-major projection-like matrix with f32-exact entries only. */
+const PROJECTION_COLUMN_MAJOR = [0.5, 0, 0, 0, 0, 1, 0, 0, 0, 0, -0.25, -0.125, 3, -2, 5, 8.5];
+
+const QUAD_POSITIONS = [
+  [0, 0],
+  [0.25, 0.75],
+  [0.5, 0.5],
+  [1, 1],
+];
+const SCREEN_SIZES = [
+  [800, 600],
+  [1280, 720],
+  [1024, 1024],
+];
+
+/** Builds one instance value with dyadic-rational fields so both sides see identical f32 inputs. */
+function instanceAt(origin, size, uvOrigin, uvSize) {
+  return TypeGpuBitmapInstance({
+    origin: d.vec2f(origin[0], origin[1]),
+    size: d.vec2f(size[0], size[1]),
+    uvOrigin: d.vec2f(uvOrigin[0], uvOrigin[1]),
+    uvSize: d.vec2f(uvSize[0], uvSize[1]),
+    color: d.vec4f(0.75, 0.5, 0.25, 0.5),
+    pageIndex: d.u32(2),
+  });
+}
+
+function vertexInputFor(instance, quadPosition, mvpEntries, screenSize) {
+  return TypeGpuBitmapVertexInput({
+    quadPosition: d.vec2f(quadPosition[0], quadPosition[1]),
+    quadUv: d.vec2f(quadPosition[0], quadPosition[1]),
+    instance,
+    modelViewProjection: d.mat4x4f(...mvpEntries),
+    screenSize: d.vec2f(screenSize[0], screenSize[1]),
+  });
+}
+
+/** Runs one shipped shader function through TypeGPU's CPU simulation of the GPU execution model. */
+function evaluate(fn, ...args) {
+  return plain(tgpu['~unstable'].simulate(() => fn(...args)).value);
+}
+
+/** Vec and struct instances expose their numbers through a JSON representation. */
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** Component-wise comparison with room for one f32 rounding step in the simulated GPU values. */
+function assertClose(actual, expected, message) {
+  for (let index = 0; index < expected.length; index += 1) {
+    const expectedValue = expected[index];
+    assert.ok(
+      Math.abs(actual[index] - expectedValue) <= 1e-6 * Math.max(1, Math.abs(expectedValue)),
+      `${message ?? 'value'} mismatch at component ${index}: ${actual[index]} vs ${expectedValue}`,
+    );
+  }
+}
+
+test('the default vertex stage realizes the canonical atlas addressing and quad placement', () => {
+  const cases = [
+    { origin: [10, 20], size: [30, 40], uvOrigin: [0.25, 0.5], uvSize: [0.125, 0.0625] },
+    { origin: [0, 0], size: [16, 16], uvOrigin: [0, 0], uvSize: [1, 1] },
+    { origin: [-8, 4], size: [12.5, 7.25], uvOrigin: [0.5, 0.125], uvSize: [0.03125, 0.5] },
+  ];
+  for (const item of cases) {
+    const instance = instanceAt(item.origin, item.size, item.uvOrigin, item.uvSize);
+    for (const quadPosition of QUAD_POSITIONS) {
+      const input = vertexInputFor(instance, quadPosition, IDENTITY_COLUMN_MAJOR, SCREEN_SIZES[0]);
+      const output = evaluate(bitmapVertex, input);
+      const position = referenceBitmapQuadPosition(item.origin, item.size, quadPosition);
+
+      assert.deepEqual(plain(output.position), plain(position));
+      // The identity projection must pass paragraph-space placement straight through.
+      assert.deepEqual(plain(output.clipPosition), plain([...position, 1]));
+      assert.deepEqual(plain(output.atlasUv), plain(referenceBitmapAtlasUv(item.uvOrigin, item.uvSize, quadPosition)));
+      assert.deepEqual(plain(output.color), [0.75, 0.5, 0.25, 0.5]);
+      assert.equal(Number(output.pageLayer), 2);
+    }
+  }
+});
+
+test('the default clip placement matches an explicit column-major model-view-projection', () => {
+  const instance = instanceAt([6, 9], [24, 18], [0.5, 0.25], [0.25, 0.125]);
+  for (const mvp of [IDENTITY_COLUMN_MAJOR, PROJECTION_COLUMN_MAJOR]) {
+    for (const quadPosition of QUAD_POSITIONS) {
+      const input = vertexInputFor(instance, quadPosition, mvp, SCREEN_SIZES[0]);
+      const output = evaluate(bitmapVertex, input);
+      const position = referenceBitmapQuadPosition([6, 9], [24, 18], quadPosition);
+
+      assert.deepEqual(
+        plain(output.clipPosition),
+        plain(referenceProjectClipPosition(mvp, position)),
+        `projection mismatch for quad ${JSON.stringify(quadPosition)}`,
+      );
+    }
+  }
+});
+
+test('the pixel-snapped variant rounds device-space landing without moving other channels', () => {
+  const instance = instanceAt([3.5, 2.25], [17, 11], [0.125, 0.25], [0.0625, 0.5]);
+  for (const mvp of [IDENTITY_COLUMN_MAJOR, PROJECTION_COLUMN_MAJOR]) {
+    for (const quadPosition of QUAD_POSITIONS) {
+      for (const screenSize of SCREEN_SIZES) {
+        const input = vertexInputFor(instance, quadPosition, mvp, screenSize);
+        const output = evaluate(bitmapVertexSnapped, input);
+        const clip = referenceProjectClipPosition(
+          mvp,
+          referenceBitmapQuadPosition([3.5, 2.25], [17, 11], quadPosition),
+        );
+
+        assertClose(
+          plain(output.clipPosition),
+          referenceSnappedClipPosition(clip, screenSize),
+          `snapping mismatch for screen ${JSON.stringify(screenSize)}, quad ${JSON.stringify(quadPosition)}`,
+        );
+        assert.deepEqual(
+          plain(output.atlasUv),
+          plain(referenceBitmapAtlasUv([0.125, 0.25], [0.0625, 0.5], quadPosition)),
+          'snapping must not disturb atlas addressing',
+        );
+      }
+    }
+  }
+});
+
+test('snapClipAxis keeps whole-pixel device coordinates fixed', () => {
+  for (const physicalSize of [800, 1280]) {
+    for (let pixel = 0; pixel <= 16; pixel += 4) {
+      const ndc = (pixel / physicalSize) * 2 - 1;
+      assert.equal(evaluate(snapClipAxis, ndc, 1, physicalSize), ndc, `pixel ${pixel} must survive snapping`);
+    }
+  }
+});
+
+test('paint composition scales unpremultiplied alpha by coverage and keeps rgb', () => {
+  for (const coverage of [0, 0.25, 0.5, 1]) {
+    for (const alpha of [0, 0.5, 1]) {
+      const color = d.vec4f(0.75, 0.5, 0.25, alpha);
+      const output = evaluate(bitmapPaint, coverage, color);
+      assert.deepEqual(
+        { coverage: output.coverage, color: plain(output.color), opacity: output.opacity },
+        referenceBitmapPaint(coverage, [0.75, 0.5, 0.25, alpha]),
+      );
+    }
+  }
+});
+
+test('every shipped Bitmap stage resolves to WGSL without consumer-side tooling', () => {
+  for (const [name, fn] of Object.entries({ bitmapVertex, bitmapVertexSnapped, bitmapFragment })) {
+    const wgsl = tgpu.resolve([fn]);
+    assert.match(wgsl, new RegExp(`fn ${name}\\(`), `${name} must resolve as a WGSL function`);
+  }
+  const fragmentWgsl = tgpu.resolve([bitmapFragment]);
+  // Coverage is an exact clamped texel fetch — the read the `/tsl` realization compiles
+  // to for data textures — so no sampler is declared and no filtered sample appears.
+  assert.match(fragmentWgsl, /fn bitmapPageCoverage\(/);
+  assert.match(fragmentWgsl, /textureDimensions\(page, 0\)/);
+  assert.match(fragmentWgsl, /textureLoad\(page, boundedCoord, pageLayer, 0\)\.x/);
+  assert.doesNotMatch(fragmentWgsl, /textureSample|sampler/);
+});

--- a/packages/glyph/tests/support/extract-bitmap-tsl-shader.mjs
+++ b/packages/glyph/tests/support/extract-bitmap-tsl-shader.mjs
@@ -1,0 +1,75 @@
+import { attribute } from 'three/tsl';
+import * as THREE from 'three/webgpu';
+
+import { bitmapShader } from '../../dist/tsl/bitmap-shader.js';
+
+/**
+ * Compiles the canonical TSL Bitmap material to shader source without a GPU device.
+ *
+ * Node builds are pure text generation, so a real renderer over an offscreen canvas
+ * stand-in reaches the generated WGSL that a hardware WebGPU run would execute. The
+ * instance nodes are plain per-vertex attributes and the coverage page is an unsigned
+ * byte data array — the same resource kinds the command-buffer executor binds — so the
+ * extracted source is the authoritative statement of what `/tsl` produces for Bitmap.
+ *
+ * `renderer.hasFeature` is stubbed because it is the only builder input that requires
+ * an adapter; Bitmap reads its pages through data-texture texel loads, so no optional
+ * filtering feature can change the generated source.
+ *
+ * @param {{ pixelSnapping: boolean }} options Variant selector for the clip placement.
+ * @returns {{ vertex: string, fragment: string }} Generated WGSL per stage.
+ */
+export function extractBitmapTslShader({ pixelSnapping }) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3));
+  geometry.setAttribute('uv', new THREE.Float32BufferAttribute([0, 0, 1, 0, 0, 1], 2));
+  geometry.setAttribute('glyphOrigin', new THREE.Float32BufferAttribute([0, 0], 2));
+  geometry.setAttribute('glyphSize', new THREE.Float32BufferAttribute([1, 1], 2));
+  geometry.setAttribute('atlasOrigin', new THREE.Float32BufferAttribute([0, 0], 2));
+  geometry.setAttribute('atlasExtent', new THREE.Float32BufferAttribute([1, 1], 2));
+  geometry.setAttribute('paintColor', new THREE.Float32BufferAttribute([1, 1, 1, 1], 4));
+
+  const page = new THREE.DataArrayTexture(new Uint8Array(4), 1, 1, 1);
+  page.format = THREE.RedFormat;
+  page.type = THREE.UnsignedByteType;
+
+  const shader = bitmapShader(
+    {
+      origin: attribute('glyphOrigin', 'vec2'),
+      size: attribute('glyphSize', 'vec2'),
+      uvOrigin: attribute('atlasOrigin', 'vec2'),
+      uvSize: attribute('atlasExtent', 'vec2'),
+      color: attribute('paintColor', 'vec4'),
+      pageIndex: attribute('pageIndex', 'uint'),
+    },
+    { page },
+    { pixelSnapping },
+  );
+  const material = new THREE.MeshBasicNodeMaterial({ transparent: true });
+  material.positionNode = shader.position;
+  material.vertexNode = shader.clipPosition;
+  material.colorNode = shader.color;
+  material.opacityNode = shader.opacity;
+
+  const renderer = new THREE.WebGPURenderer({
+    canvas: offscreenCanvasStandIn(),
+    antialias: false,
+  });
+  renderer.hasFeature = () => false;
+  const builder = new THREE.WGSLNodeBuilder(new THREE.Mesh(geometry, material), renderer);
+  builder.scene = new THREE.Scene();
+  builder.camera = new THREE.Camera();
+  builder.build();
+  return { vertex: builder.vertexShader, fragment: builder.fragmentShader };
+}
+
+function offscreenCanvasStandIn() {
+  return {
+    style: {},
+    width: 1,
+    height: 1,
+    addEventListener() {},
+    removeEventListener() {},
+    getContext: () => null,
+  };
+}

--- a/packages/glyph/tests/types/typegpu-api.test.ts
+++ b/packages/glyph/tests/types/typegpu-api.test.ts
@@ -1,0 +1,34 @@
+import * as d from 'typegpu/data';
+
+import {
+  bitmapFragment,
+  bitmapVertex,
+  bitmapVertexSnapped,
+  type TypeGpuBitmapFragmentInput,
+  type TypeGpuBitmapFragmentOutput,
+  type TypeGpuBitmapInstance,
+  type TypeGpuBitmapVertexInput,
+  type TypeGpuBitmapVertexOutput,
+} from '@pmndrs/glyph/typegpu';
+
+// The `/typegpu` subpath is one shader library, importable without any renderer so
+// WebGPU hosts reuse the canonical technique realizations instead of reimplementing
+// coverage math.
+declare const vertexInput: TypeGpuBitmapVertexInput;
+const vertexOut: TypeGpuBitmapVertexOutput = bitmapVertex(vertexInput);
+const snappedOut: TypeGpuBitmapVertexOutput = bitmapVertexSnapped(vertexInput);
+void vertexOut.position;
+void snappedOut.clipPosition;
+
+declare const fragmentInput: TypeGpuBitmapFragmentInput;
+const fragmentOut: TypeGpuBitmapFragmentOutput = bitmapFragment(fragmentInput);
+void fragmentOut.coverage;
+void fragmentOut.opacity;
+
+// The stages are exact typed functions: their schemas are inspectable GPU data and the
+// functions resolve to WGSL through TypeGPU, so a host can bind and compose them.
+const instanceSchema: d.WgslStruct = null as unknown as typeof TypeGpuBitmapInstance;
+void instanceSchema;
+
+const vertexStage: typeof bitmapVertex = bitmapVertex;
+void vertexStage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,12 +242,18 @@ importers:
       three:
         specifier: 0.185.1
         version: 0.185.1
+      typegpu:
+        specifier: 0.12.3
+        version: 0.12.3
       typescript:
         specifier: 7.0.2
         version: 7.0.2
       unicode-property-value-aliases:
         specifier: 3.9.0
         version: 3.9.0
+      unplugin-typegpu:
+        specifier: 0.12.2
+        version: 0.12.2(rolldown@1.1.5)(typegpu@0.12.3)(vite@8.1.5(@types/node@24.13.3)(jiti@2.7.0))
 
   packages/glyph-example-raster:
     dependencies:
@@ -1452,6 +1458,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-kit@2.2.0:
+    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
+    engines: {node: '>=20.19.0'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -1645,6 +1655,9 @@ packages:
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2877,6 +2890,14 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyest-for-wgsl@0.4.0:
+    resolution: {integrity: sha512-3vkeNf74HrJ1C6QJUiL92ArsaigD8ra52JBMTeyDfqEz6SawyCO1aiF+XCKiMt3MBaL5QIsKOHG5gl/v21MqKA==}
+    engines: {node: '>=12.20.0'}
+
+  tinyest@0.3.2:
+    resolution: {integrity: sha512-1wqSt97RLezWzeogLSVXHr+E3jpYO8jxyaK2AIdJeGoZZTCubwNxQ9IqU5gbQpJVcxlbPugPAsII+m9/gqpPSA==}
+    engines: {node: '>=12.20.0'}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -2911,6 +2932,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsover-runtime@0.0.7:
+    resolution: {integrity: sha512-FHHwMJzZbnP23+fU1PxXljy7j0RRRosL2r1/CRUNTqfW+l7m35JsUkM615x/cAzw4GqRdXPIl3axKMj9qzpZtQ==}
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -2921,6 +2945,14 @@ packages:
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
+
+  typed-binary@4.3.3:
+    resolution: {integrity: sha512-W2hLsSzt3k/tg38gDE4Fn/QiwcoqGuUHBc2cb3mXuH7KcYxe/GM57vzW14s2/bawB4R5knGgGq8Xb57vsaJ4Sg==}
+
+  typegpu@0.12.3:
+    resolution: {integrity: sha512-zYwQEhnPPwhq5vQKmollXRK1LCVjStOnL+2B0PiebqvAzYPr25rPNR4r3olLoow5sKKjyj3kzHKEcpD5SyDzGQ==}
+    engines: {node: '>=12.20.0'}
+    hasBin: true
 
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
@@ -2952,6 +2984,44 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin-typegpu@0.12.2:
+    resolution: {integrity: sha512-qwDybuJ4CVsDQs9BPoBVgNWdwSlPgT0HcCMDXKYcCYN+IJCJD9/s0QyEuGfnuJ+Ng30tEoRK+s4SIdCHpu1hrg==}
+    peerDependencies:
+      typegpu: ^0.12.1
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -3061,6 +3131,9 @@ packages:
     hasBin: true
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4130,6 +4203,11 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-kit@2.2.0:
+    dependencies:
+      '@babel/parser': 7.29.7
+      pathe: 2.0.3
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -4291,6 +4369,8 @@ snapshots:
   define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
+
+  defu@6.1.7: {}
 
   depd@2.0.0: {}
 
@@ -5462,6 +5542,12 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyest-for-wgsl@0.4.0:
+    dependencies:
+      tinyest: 0.3.2
+
+  tinyest@0.3.2: {}
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -5492,6 +5578,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsover-runtime@0.0.7: {}
+
   tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
@@ -5503,6 +5591,14 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.1
       mime-types: 3.0.2
+
+  typed-binary@4.3.3: {}
+
+  typegpu@0.12.3:
+    dependencies:
+      tinyest: 0.3.2
+      tsover-runtime: 0.0.7
+      typed-binary: 4.3.3
 
   typescript@7.0.2:
     optionalDependencies:
@@ -5540,6 +5636,41 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unplugin-typegpu@0.12.2(rolldown@1.1.5)(typegpu@0.12.3)(vite@8.1.5(@types/node@24.13.3)(jiti@2.7.0)):
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      ast-kit: 2.2.0
+      defu: 6.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      tinyest: 0.3.2
+      tinyest-for-wgsl: 0.4.0
+      typegpu: 0.12.3
+      unplugin: 3.3.0(rolldown@1.1.5)(vite@8.1.5(@types/node@24.13.3)(jiti@2.7.0))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - vite
+      - webpack
+
+  unplugin@3.3.0(rolldown@1.1.5)(vite@8.1.5(@types/node@24.13.3)(jiti@2.7.0)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      rolldown: 1.1.5
+      vite: 8.1.5(@types/node@24.13.3)(jiti@2.7.0)
 
   update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
@@ -5606,6 +5737,8 @@ snapshots:
       nano-spawn: 2.1.0
       playwright: 1.61.1
       vite: 8.1.5(@types/node@24.13.3)(jiti@2.7.0)
+
+  webpack-virtual-modules@0.6.2: {}
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,7 @@ packages:
   - apps/*
   - packages/*
 
+minimumReleaseAgeExclude:
+  - typegpu@0.12.3
+
 onlyBuiltDependencies: []


### PR DESCRIPTION
Publishes `@pmndrs/glyph/typegpu`, the sibling of `/tsl`: the same technique shaders realized as TypeGPU functions, reusable by any TypeGPU host without adopting our renderer.

## Scope

| Technique | State |
| --- | --- |
| Bitmap | **Complete**, end to end |
| MSDF, Slug, decoration | Not ported |

Bitmap ships typed schemas plus vertex and fragment stages (default and pixel-snapped variants) under `src/typegpu/`, the `./typegpu` export declared beside `./tsl`, `typegpu` as an optional peer, and a build step that embeds TypeGPU shader metadata over the emitted JS so published functions resolve without consumer-side tooling.

One technique correct with a proven test shape is worth more than four half-ported ones, so the rest are deliberately left.

## What the parity pin caught

The shaders were pinned by compiling the TSL realization to WGSL and diffing the real generated source, rather than translating the node graph by eye. That earned its keep twice:

```wgsl
// /tsl actually compiles the coverage page read to (three emits, DataArrayTexture):
textureLoad(page, clamp(floor(clamp(uv) * dims), 0, dims - 1), layer, 0)
// not textureSample -- a filtering sampler would have diverged at every texel edge
```

and the snapping chain multiplies reciprocals in Three's exact emission order (`clip * (1/w)`, then `round(...) * (1/size)`), which matters because `1/size` and `size⁻¹` are not the same f32 for most sizes. Eye-translation would have produced plausible, wrong shaders in both cases.

## Tests

Device-free WGSL resolution, CPU simulation of every stage against reference mirrors, a compile-only API fixture, and a graph-boundary assertion.

**No hardware execution parity was run** — there is no GPU in this path. The pin stands on both realizations' generated WGSL plus f32 simulation against CPU mirrors, not on pixels. That gap is real and stated rather than papered over.

## Verification

`mise exec -- pnpm check` at the repository root: exit 0.
