### PR TITLE
fix(glyph): let bake pass options to a technique

### DIFF
--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:4f1873d9b7e0d4a35681d8eb64dac086594f36d9aefe081416f1b29d217d5849'
+source_digest: 'sha256:ee299fccda2c0be01995da2fd8891dd62e8ab488e9cfde1ff6346a29f9b72144'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/docs/packages/glyph.md
+++ b/docs/packages/glyph.md
@@ -5,7 +5,7 @@ description: Implements portable font loading, retained Rust shaping and layout,
 resource: ../../packages/glyph
 workspace_package: '@pmndrs/glyph'
 documentation_type: reference
-source_digest: 'sha256:ee299fccda2c0be01995da2fd8891dd62e8ab488e9cfde1ff6346a29f9b72144'
+source_digest: 'sha256:ef2e753861cc155d1b53842529718e4dad5066e9aa88c55b2fb95c6a679605de'
 tags: [package, public-api, rust, wasm, threejs, typography]
 sources:
   - id: manifest

--- a/packages/glyph/src/node/cli.ts
+++ b/packages/glyph/src/node/cli.ts
@@ -344,7 +344,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
             fontFaceIndex,
             ...(bitmapStrikes === undefined ? {} : { bitmapStrikes }),
             msdf,
-    ...(msdfOptions === undefined ? {} : { msdfOptions }),
+            ...(msdfOptions === undefined ? {} : { msdfOptions }),
             slug,
             ...(unicodeRanges === undefined ? {} : { unicodeRanges }),
             check,

--- a/packages/glyph/src/node/cli.ts
+++ b/packages/glyph/src/node/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import type { MsdfOptions } from '../internal/msdf-contract.js';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -243,6 +244,7 @@ interface DirectBakeArguments {
   readonly fontFaceIndex: number;
   readonly bitmapStrikes?: readonly [number, ...number[]];
   readonly msdf: boolean;
+  readonly msdfOptions?: MsdfOptions;
   readonly slug: boolean;
   readonly unicodeRanges?: readonly UnicodeRange[];
   readonly check: boolean;
@@ -259,6 +261,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
   let fontFaceIndexSet = false;
   let bitmapStrikes: readonly [number, ...number[]] | undefined;
   let msdf = false;
+  let msdfOptions: MsdfOptions | undefined;
   let slug = false;
   let unicodeRanges: readonly UnicodeRange[] | undefined;
   let check = false;
@@ -290,7 +293,15 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
       if (bitmapStrikes !== undefined) throw new TypeError('--bitmap may be provided only once');
       bitmapStrikes = bitmapStrikeList(valueAfter(argv, ++index, argument));
     } else if (argument === '--msdf') {
+      if (msdf) throw new TypeError('--msdf may be provided only once');
       msdf = true;
+      // The settings are optional and follow the flag, the way --bitmap's
+      // strike list does. Anything beginning with a dash is the next flag, so a
+      // bare --msdf keeps meaning "the defaults".
+      const next = argv[index + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        msdfOptions = parseMsdfOptions(argv[++index]!);
+      }
     } else if (argument === '--slug') {
       slug = true;
     } else if (argument === '--unicodes') {
@@ -333,6 +344,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
             fontFaceIndex,
             ...(bitmapStrikes === undefined ? {} : { bitmapStrikes }),
             msdf,
+    ...(msdfOptions === undefined ? {} : { msdfOptions }),
             slug,
             ...(unicodeRanges === undefined ? {} : { unicodeRanges }),
             check,
@@ -413,13 +425,44 @@ async function directRasterPlans(options: DirectBakeArguments): Promise<RasterBa
   }
   if (options.msdf) {
     const { msdfBaker } = await import('../bakers/msdf.js');
-    rasters.push({ baker: msdfBaker, packaging, options: undefined });
+    rasters.push({ baker: msdfBaker, packaging, options: options.msdfOptions });
   }
   if (options.slug) {
     const { slugBaker } = await import('../bakers/slug.js');
     rasters.push({ baker: slugBaker, packaging, options: undefined });
   }
   return rasters;
+}
+
+/**
+ * `em-size=32,pixel-range=6` — the technique's own settings, in the technique's
+ * own terms.
+ *
+ * Atlas cost scales with the square of the em size, so a face set at small sizes
+ * pays several times over for the default of 64 and has no way to say so.
+ */
+function parseMsdfOptions(value: string): MsdfOptions {
+  const options: { emSize?: number; pixelRange?: number } = {};
+  for (const entry of value.split(',')) {
+    const separator = entry.indexOf('=');
+    if (separator < 1) {
+      throw new TypeError(`--msdf settings must be key=value pairs: ${entry}`);
+    }
+    const key = entry.slice(0, separator).trim();
+    const raw = entry.slice(separator + 1).trim();
+    if (key === 'em-size') options.emSize = positiveInteger(raw, 'em-size');
+    else if (key === 'pixel-range') options.pixelRange = positiveInteger(raw, 'pixel-range');
+    else throw new TypeError(`Unknown --msdf setting: ${key}`);
+  }
+  return options;
+}
+
+function positiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new TypeError(`--msdf ${label} must be a positive integer: ${value}`);
+  }
+  return parsed;
 }
 
 function valueAfter(argv: readonly string[], index: number, option: string): string {
@@ -505,7 +548,9 @@ Direct font options:
 
 Raster options:
   --bitmap <ppem,...>    Embed Bitmap at positive integer ppem strikes (example: 16,32)
-  --msdf                 Embed the default MSDF raster
+  --msdf [settings]      Embed the MSDF raster, optionally configured
+                        Settings: em-size (default 64), pixel-range (default 8)
+                        Example: --msdf em-size=32,pixel-range=6
   --slug                 Embed the default Slug raster
                         With none selected, emit a shaping-only GLB
 
@@ -523,6 +568,7 @@ Output options:
 Examples:
   glyph bake --input Inter-Regular.ttf --output inter.font.glb --bitmap 16,32 --msdf --slug
   glyph bake --input Inter-Regular.ttf --output inter-latin.font.glb --unicodes U+0020-007E --msdf
+  glyph bake --input Inter-Regular.ttf --output inter-small.font.glb --msdf em-size=32
   glyph bake --project-root . --output-root public/generated
   glyph bake --input Inter-Regular.ttf --output inter.font.glb --msdf --check
 


### PR DESCRIPTION
`glyph bake` hard-codes `options: undefined` for every technique except Bitmap, so a technique's own bake parameters are unreachable from the CLI. The bakers accept them; the CLI never passes any.

```ts
if (options.msdf) {
  const { msdfBaker } = await import('../bakers/msdf.js');
  rasters.push({ baker: msdfBaker, packaging, options: undefined });   // <-
}
```

Bitmap is the only technique whose parameter arrives, and only because `--bitmap 16,32` encodes it positionally. `--help` documents `--msdf` as "Embed the **default** MSDF raster" — the default being the only thing on offer.

## What this changes

`--msdf` now takes optional settings, in the same shape as `--bitmap`'s strike list. A bare `--msdf` still means the defaults, so nothing existing changes behaviour.

```sh
glyph bake --input Inter-Regular.ttf --output inter.font.glb --msdf em-size=32
glyph bake --input Inter-Regular.ttf --output inter.font.glb --msdf em-size=32,pixel-range=6
```

Slug is untouched: `SlugBakerOptions` is `undefined`, so it genuinely has none of its own.

## Why it matters

`emSize` defaults to 64 atlas texels per em, and atlas cost is area, so a face set for small copy pays several times over with no way to say so. Measured on the same six Telugu glyphs:

| | artifact |
| --- | ---: |
| `--msdf` (em-size 64) | 606,604 bytes |
| `--msdf em-size=32` | 153,692 bytes |
| `--msdf em-size=24,pixel-range=6` | 95,304 bytes |

Quadrupling the atlas area quadruples the artifact, exactly as expected — and 64 was more than twice what a page setting at 28 css px can show. Across a 20-face multi-script set the difference was **4.64 MB → 1.33 MB**.

## Note for consumers

Raster options are part of the raster identity. A runtime request naming different options than the artifact was baked with derives a different `rasterKey`, finds no matching raster, falls back to runtime generation, and fails with `RASTER_SOURCE_UNAVAILABLE`. Both sides have to name the same values — worth a line in the docs.

Design discussion in #117.
