### PR TITLE
feat(glyph): add bake glyph map output

### DIFF
--- a/.agents/docs/log.md
+++ b/.agents/docs/log.md
@@ -229,6 +229,12 @@
   cache leases without invalidating independently bound Fonts. The planned direct CLI zero-flag default changes from
   shaping-only to embedded Bitmap 8/16, MSDF, and Slug.
 
+## 2026-08-31
+
+- **Added direct-bake glyph lookups** — `glyph bake --glyph-map <path>` emits a deterministic JSON name-to-code-point
+  lookup from the same font face and Unicode selection as the GLB. The lookup and font publish together with rollback,
+  `--check` verifies both outputs byte-for-byte, and ambiguous selected aliases fail before either output is written.
+
 ## 2026-08-30
 
 - **TypeGPU is the shader authority** — Moved the remaining Slug shader modules under `/typegpu`, added canonical TypeGPU Bitmap, MTSDF, and decoration stages, and replaced native TSL formulas with `@typegpu/three` adapters. Resource operations are specialized through slots and schema-aware accessors, so direct TypeGPU hosts, procedural consumers, raw WebGPU-backed resources, and Three data textures share the same algorithms. Device-free WGSL/GLSL tests cover every first-party adapter, and direct TypeGPU resolution tests prove texture-free function sources.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ pnpm exec glyph bake --input Inter-Regular.ttf --output Inter.font.glb --bitmap 
 ```
 
 Add `--unicodes U+0020-007E` to bake a subset, or `--check` to rebuild temporarily and require byte-identical output.
+For an icon font, `--glyph-map <path>` writes a directly importable JSON lookup from each authored glyph name in that
+same Unicode selection to its code point:
+
+```sh
+pnpm exec glyph bake --input fa-solid-900.ttf --output icons.font.glb --unicodes U+F000-F8FF --glyph-map icons.json --msdf
+```
+
+Names with multiple code points inside the selected set are rejected as ambiguous; narrow `--unicodes` rather than
+letting the generator silently choose an alias.
 
 Or let the CLI discover every `glyph.fontFace()` declaration in a project and write each artifact beside its source asset:
 

--- a/packages/glyph/src/internal/node-bake-error.ts
+++ b/packages/glyph/src/internal/node-bake-error.ts
@@ -1,0 +1,13 @@
+import { GlyphError } from '../glyph-error.js';
+
+export class NodeBakeError extends GlyphError<'bake-failed'> {
+  readonly reason: string;
+  readonly path: string | undefined;
+
+  constructor(reason: string, message: string, path?: string, options?: ErrorOptions) {
+    super('bake-failed', message, options);
+    this.name = 'NodeBakeError';
+    this.reason = reason;
+    this.path = path;
+  }
+}

--- a/packages/glyph/src/internal/node-file-publication.ts
+++ b/packages/glyph/src/internal/node-file-publication.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto';
+import { lstat, mkdir, open, rename, rm, stat } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
+
+import { NodeBakeError } from './node-bake-error.js';
+
+export interface NodeFileOutput {
+  readonly bytes: Uint8Array;
+  readonly file: string;
+}
+
+interface StagedFileOutput {
+  readonly temporaryFile: string;
+  readonly target: string;
+  backupFile?: string;
+  published: boolean;
+}
+
+export async function assertDistinctInputOutputs(input: string, outputs: readonly string[]): Promise<void> {
+  const inputIdentity = await stat(input);
+  const targets = new Set<string>();
+  for (const output of outputs) {
+    const canonical = resolve(output);
+    if (targets.has(canonical)) {
+      throw new NodeBakeError('OUTPUT_CONFLICT', 'multiple artifacts resolve to one output', canonical);
+    }
+    targets.add(canonical);
+    if (resolve(input) === canonical) {
+      throw new NodeBakeError('OUTPUT_OVERLAPS_INPUT', 'output must not overwrite its source', output);
+    }
+    let outputIdentity;
+    try {
+      outputIdentity = await stat(output);
+    } catch (error) {
+      if (isMissing(error)) continue;
+      throw error;
+    }
+    if (inputIdentity.dev === outputIdentity.dev && inputIdentity.ino === outputIdentity.ino) {
+      throw new NodeBakeError('OUTPUT_OVERLAPS_INPUT', 'output must not alias its source', output);
+    }
+    if (!outputIdentity.isFile()) {
+      throw new NodeBakeError('OUTPUT_TARGET_TYPE', 'existing artifact output must be a regular file', output);
+    }
+  }
+}
+
+export async function publishFilesWithRollback(
+  outputs: readonly NodeFileOutput[],
+  signal?: AbortSignal,
+): Promise<void> {
+  const staged: StagedFileOutput[] = [];
+  let publicationCompleted = false;
+  let rollbackCompleted = false;
+  try {
+    for (const { bytes, file } of outputs) {
+      signal?.throwIfAborted();
+      await mkdir(dirname(file), { recursive: true });
+      const temporaryFile = join(dirname(file), `.${file.split(sep).at(-1)}.${randomUUID()}.tmp`);
+      staged.push({ temporaryFile, target: file, published: false });
+      const handle = await open(temporaryFile, 'wx');
+      try {
+        await handle.writeFile(bytes);
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+    }
+    signal?.throwIfAborted();
+    for (const entry of staged) await preservePreviousTarget(entry);
+    for (const entry of staged) {
+      await rename(entry.temporaryFile, entry.target);
+      entry.published = true;
+    }
+    publicationCompleted = true;
+  } catch (error) {
+    try {
+      await rollbackPublication(staged);
+      rollbackCompleted = true;
+    } catch (rollbackError) {
+      throw new Error(
+        `artifact publication failed (${error instanceof Error ? error.message : String(error)}) ` +
+          `and rollback was incomplete: ${
+            rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+          }`,
+        { cause: rollbackError },
+      );
+    }
+    throw error;
+  } finally {
+    await Promise.all(
+      staged.flatMap(({ temporaryFile, backupFile }) => [
+        rm(temporaryFile, { force: true }),
+        ...(backupFile === undefined || (!publicationCompleted && !rollbackCompleted)
+          ? []
+          : [rm(backupFile, { force: true })]),
+      ]),
+    );
+  }
+}
+
+async function preservePreviousTarget(entry: StagedFileOutput): Promise<void> {
+  try {
+    const previous = await lstat(entry.target);
+    if (!previous.isFile()) {
+      throw new NodeBakeError('OUTPUT_TARGET_TYPE', 'existing artifact output must be a regular file', entry.target);
+    }
+    const backupFile = join(dirname(entry.target), `.${entry.target.split(sep).at(-1)}.${randomUUID()}.bak`);
+    await rename(entry.target, backupFile);
+    entry.backupFile = backupFile;
+  } catch (error) {
+    if (isMissing(error)) return;
+    throw error;
+  }
+}
+
+async function rollbackPublication(staged: readonly StagedFileOutput[]): Promise<void> {
+  const failures: unknown[] = [];
+  for (const entry of [...staged].reverse()) {
+    try {
+      if (entry.published) await rm(entry.target, { force: true });
+      if (entry.backupFile !== undefined) {
+        await rename(entry.backupFile, entry.target);
+        delete entry.backupFile;
+      }
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length !== 0) {
+    throw new AggregateError(failures, 'failed to restore pre-existing artifact outputs');
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}

--- a/packages/glyph/src/node/bake.ts
+++ b/packages/glyph/src/node/bake.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from 'node:crypto';
-import { lstat, mkdir, open, readFile, rename, rm, stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -15,7 +14,6 @@ import {
 } from '../font-baker/index.js';
 import { fontBakerWasmUrl } from '../font-baker/wasm-url.js';
 import { validateFontArtifact } from '../font-baker/validator.js';
-import { GlyphError } from '../glyph-error.js';
 
 export {
   FontBakeError,
@@ -44,6 +42,8 @@ import type {
 } from '../discovery.js';
 import { fontBakeDescriptor } from '../internal/core-bake-policy.js';
 import { bakeFontPipeline } from '../internal/font-bake-pipeline.js';
+import { NodeBakeError } from '../internal/node-bake-error.js';
+import { assertDistinctInputOutputs, publishFilesWithRollback } from '../internal/node-file-publication.js';
 import { resolveRasterBakePlan, type ResolvedRasterBakePlan } from '../internal/raster-bake-plan.js';
 import { cacheSuccessfulPromise } from '../internal/successful-promise-cache.js';
 import { fingerprint128, fingerprintDomain } from '../internal/fingerprint.js';
@@ -125,17 +125,7 @@ export interface ProjectBakeReport {
   readonly diagnostics: readonly ProjectBakeDiagnostic[];
 }
 
-export class NodeBakeError extends GlyphError<'bake-failed'> {
-  readonly reason: string;
-  readonly path: string | undefined;
-
-  constructor(reason: string, message: string, path?: string, options?: ErrorOptions) {
-    super('bake-failed', message, options);
-    this.name = 'NodeBakeError';
-    this.reason = reason;
-    this.path = path;
-  }
-}
+export { NodeBakeError } from '../internal/node-bake-error.js';
 
 const defaultFontBaker = cacheSuccessfulPromise(async () => createFontBaker(await readFile(new URL(fontBakerWasmUrl))));
 
@@ -172,7 +162,7 @@ async function bakeFontWithResolvedPlans<const Rasters extends readonly object[]
   options.signal?.throwIfAborted();
   const input = filePath(options.input, 'input');
   const output = filePath(options.output, 'output');
-  await assertDistinctInputOutput(input, output);
+  await assertDistinctInputOutputs(input, [output]);
 
   let phase = performance.now();
   const originalSource = new Uint8Array(await readFile(input));
@@ -208,7 +198,10 @@ async function bakeFontWithResolvedPlans<const Rasters extends readonly object[]
 
   phase = performance.now();
   const outputs = outputTargets(output, composed.artifacts);
-  await publishArtifactsWithRollback(outputs, options.signal);
+  await publishFilesWithRollback(
+    outputs.map(({ artifact, file }) => ({ bytes: artifact.bytes, file })),
+    options.signal,
+  );
   timings.write = performance.now() - phase;
   const rssAfterBytes = process.memoryUsage.rss();
   return {
@@ -410,124 +403,6 @@ function outputTargets(
     files.add(canonical);
   }
   return targets;
-}
-
-interface StagedArtifactOutput {
-  readonly temporaryFile: string;
-  readonly target: string;
-  backupFile?: string;
-  published: boolean;
-}
-
-async function publishArtifactsWithRollback(
-  outputs: readonly { artifact: BakeArtifact; file: string }[],
-  signal?: AbortSignal,
-): Promise<void> {
-  const staged: StagedArtifactOutput[] = [];
-  let publicationCompleted = false;
-  let rollbackCompleted = false;
-  try {
-    for (const { artifact, file } of outputs) {
-      signal?.throwIfAborted();
-      await mkdir(dirname(file), { recursive: true });
-      const temporaryFile = join(dirname(file), `.${file.split(sep).at(-1)}.${randomUUID()}.tmp`);
-      staged.push({ temporaryFile, target: file, published: false });
-      const handle = await open(temporaryFile, 'wx');
-      try {
-        await handle.writeFile(artifact.bytes);
-        await handle.sync();
-      } finally {
-        await handle.close();
-      }
-    }
-    signal?.throwIfAborted();
-    for (const entry of staged) await preservePreviousTarget(entry);
-    for (const entry of staged) {
-      await rename(entry.temporaryFile, entry.target);
-      entry.published = true;
-    }
-    publicationCompleted = true;
-  } catch (error) {
-    try {
-      await rollbackPublication(staged);
-      rollbackCompleted = true;
-    } catch (rollbackError) {
-      throw new Error(
-        `artifact publication failed (${error instanceof Error ? error.message : String(error)}) ` +
-          `and rollback was incomplete: ${
-            rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
-          }`,
-        { cause: rollbackError },
-      );
-    }
-    throw error;
-  } finally {
-    await Promise.all(
-      staged.flatMap(({ temporaryFile, backupFile }) => [
-        rm(temporaryFile, { force: true }),
-        ...(backupFile === undefined || (!publicationCompleted && !rollbackCompleted)
-          ? []
-          : [rm(backupFile, { force: true })]),
-      ]),
-    );
-  }
-}
-
-async function preservePreviousTarget(entry: StagedArtifactOutput): Promise<void> {
-  try {
-    const previous = await lstat(entry.target);
-    if (!previous.isFile()) {
-      throw new NodeBakeError('OUTPUT_TARGET_TYPE', 'existing artifact output must be a regular file', entry.target);
-    }
-    const backupFile = join(dirname(entry.target), `.${entry.target.split(sep).at(-1)}.${randomUUID()}.bak`);
-    await rename(entry.target, backupFile);
-    entry.backupFile = backupFile;
-  } catch (error) {
-    if (isMissing(error)) return;
-    throw error;
-  }
-}
-
-async function assertDistinctInputOutput(input: string, output: string): Promise<void> {
-  if (resolve(input) === resolve(output)) {
-    throw new NodeBakeError('OUTPUT_OVERLAPS_INPUT', 'font output must not overwrite its source', output);
-  }
-  const inputIdentity = await stat(input);
-  let outputIdentity;
-  try {
-    outputIdentity = await stat(output);
-  } catch (error) {
-    if (isMissing(error)) return;
-    throw error;
-  }
-  if (inputIdentity.dev === outputIdentity.dev && inputIdentity.ino === outputIdentity.ino) {
-    throw new NodeBakeError('OUTPUT_OVERLAPS_INPUT', 'font output must not alias its source', output);
-  }
-  if (!outputIdentity.isFile()) {
-    throw new NodeBakeError('OUTPUT_TARGET_TYPE', 'existing artifact output must be a regular file', output);
-  }
-}
-
-async function rollbackPublication(staged: readonly StagedArtifactOutput[]): Promise<void> {
-  const failures: unknown[] = [];
-  for (const entry of [...staged].reverse()) {
-    try {
-      if (entry.published) await rm(entry.target, { force: true });
-      if (entry.backupFile !== undefined) {
-        await rename(entry.backupFile, entry.target);
-        delete entry.backupFile;
-      }
-    } catch (error) {
-      failures.push(error);
-    }
-  }
-  if (failures.length !== 0) {
-    throw new AggregateError(failures, 'failed to restore pre-existing artifact outputs');
-  }
-}
-
-function isMissing(error: unknown): boolean {
-  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
 
 function finalizeTransport(report: FontPayloadReport, artifacts: readonly BakeArtifact[]): FontPayloadReport {

--- a/packages/glyph/src/node/cli.ts
+++ b/packages/glyph/src/node/cli.ts
@@ -10,6 +10,7 @@ import { pathToFileURL } from 'node:url';
 import type { RasterBakePlan } from '../bake.js';
 import type { UnicodeRange } from '../font-baker/index.js';
 import { normalizeUnicodeRanges } from '../internal/font-selection.js';
+import { assertDistinctInputOutputs, publishFilesWithRollback } from '../internal/node-file-publication.js';
 import { resolveRasterBakePlan, type ResolvedRasterBakePlan } from '../internal/raster-bake-plan.js';
 import {
   bakeFont,
@@ -245,6 +246,7 @@ interface ParsedBakeArguments {
 interface DirectBakeArguments {
   readonly input: string;
   readonly output: string;
+  readonly glyphMap?: string;
   readonly fontFaceIndex: number;
   readonly bitmapStrikes?: readonly [number, ...number[]];
   readonly msdf: boolean;
@@ -285,6 +287,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
   const assetRoots: string[] = [];
   let input: string | undefined;
   let output: string | undefined;
+  let glyphMap: string | undefined;
   let fontFaceIndex = 0;
   let fontFaceIndexSet = false;
   let split = false;
@@ -317,6 +320,8 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
       input = uniqueValue(input, valueAfter(argv, ++index, argument), argument);
     } else if (argument === '--output') {
       output = uniqueValue(output, valueAfter(argv, ++index, argument), argument);
+    } else if (argument === '--glyph-map') {
+      glyphMap = uniqueValue(glyphMap, valueAfter(argv, ++index, argument), argument);
     } else if (argument === '--font-face-index') {
       if (fontFaceIndexSet) throw new TypeError('--font-face-index may be provided only once');
       fontFaceIndexSet = true;
@@ -360,6 +365,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
   const directSelected =
     input !== undefined ||
     output !== undefined ||
+    glyphMap !== undefined ||
     bitmapStrikes !== undefined ||
     msdf ||
     slug ||
@@ -388,6 +394,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
           direct: {
             input: input!,
             output: output ?? derivedOutputPath(input!),
+            ...(glyphMap === undefined ? {} : { glyphMap }),
             fontFaceIndex,
             ...(bitmapStrikes === undefined ? {} : { bitmapStrikes }),
             msdf,
@@ -465,7 +472,13 @@ async function bakeDirect(
   }
   const temporaryDirectory = await mkdtemp(join(tmpdir(), 'text-bake-'));
   try {
-    const output = options.check ? join(temporaryDirectory, 'checked.font.glb') : options.output;
+    const staged = options.check || options.glyphMap !== undefined;
+    const output = staged ? join(temporaryDirectory, 'checked.font.glb') : options.output;
+    let glyphMapBytes: Uint8Array | undefined;
+    if (options.glyphMap !== undefined) {
+      await assertDistinctInputOutputs(options.input, [options.output, options.glyphMap]);
+      glyphMapBytes = await createGlyphMap(options);
+    }
     const report = await bakeFont({
       input: options.input,
       output,
@@ -482,11 +495,76 @@ async function bakeDirect(
           options.output,
         );
       }
+      if (options.glyphMap !== undefined && glyphMapBytes !== undefined) {
+        const expectedGlyphMap = await readFile(options.glyphMap);
+        if (!expectedGlyphMap.equals(glyphMapBytes)) {
+          throw new NodeBakeError(
+            'STALE_GLYPH_MAP',
+            'generated glyph map is not byte-identical to the requested output',
+            options.glyphMap,
+          );
+        }
+      }
+    } else if (options.glyphMap !== undefined && glyphMapBytes !== undefined) {
+      const fontBytes = await readFile(output);
+      const started = performance.now();
+      await publishFilesWithRollback([
+        { bytes: fontBytes, file: options.output },
+        { bytes: glyphMapBytes, file: options.glyphMap },
+      ]);
+      return reportWithPublishedOutput(report, output, options.output, performance.now() - started);
     }
-    return report;
+    return staged ? reportWithPublishedOutput(report, output, options.output, 0) : report;
   } finally {
     await rm(temporaryDirectory, { force: true, recursive: true });
   }
+}
+
+async function createGlyphMap(options: DirectBakeArguments): Promise<Uint8Array> {
+  const inspection = await inspectFont({ input: options.input, fontFaceIndex: options.fontFaceIndex });
+  const names = new Map<string, number>();
+  for (const { codePoint, name } of inspection.glyphs) {
+    if (name === undefined || name.length === 0 || !selectedCodePoint(codePoint, options.unicodeRanges)) continue;
+    const previous = names.get(name);
+    if (previous !== undefined && previous !== codePoint) {
+      throw new NodeBakeError(
+        'AMBIGUOUS_GLYPH_NAME',
+        `${name} maps to both ${formatCodePoint(previous)} and ${formatCodePoint(codePoint)} in the selected Unicode set`,
+        options.input,
+      );
+    }
+    names.set(name, codePoint);
+  }
+  return new TextEncoder().encode(
+    `${JSON.stringify(Object.fromEntries([...names].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))), null, 2)}\n`,
+  );
+}
+
+function selectedCodePoint(codePoint: number, ranges: readonly UnicodeRange[] | undefined): boolean {
+  return ranges === undefined || ranges.some(({ start, end }) => codePoint >= start && codePoint <= end);
+}
+
+function reportWithPublishedOutput(
+  report: NodeFontBakeReport,
+  stagedOutput: string,
+  publishedOutput: string,
+  publishDuration: number,
+): NodeFontBakeReport {
+  return {
+    ...report,
+    execution: {
+      ...report.execution,
+      timingsMs: {
+        ...report.execution.timingsMs,
+        write: report.execution.timingsMs.write + publishDuration,
+        total: report.execution.timingsMs.total + publishDuration,
+      },
+      outputs: report.execution.outputs.map((output) => ({
+        ...output,
+        file: output.file === stagedOutput ? publishedOutput : output.file,
+      })),
+    },
+  };
 }
 
 type DirectRasterBakePlan =
@@ -669,6 +747,7 @@ Direct font options:
   --input <path>         Source TTF, OTF, TTC, or OTC font
   --output <path>        Output GLB (default: the input name, beside it, url-safe)
                         Example: "My Font.ttf" bakes to my-font.glb
+  --glyph-map <path>     Write name-to-code-point JSON for the selected Unicode set
   --font-face-index <n>  Collection face to bake (default: 0)
   --unicodes <set>       Unicode set used to prepare a smaller source font
                         Example: U+0020-007E,U+00A0-00FF,U+4E00-9FFF
@@ -704,6 +783,7 @@ Output options:
 Examples:
   glyph bake --input Inter-Regular.ttf --output inter.font.glb --bitmap 16,32 --msdf --slug
   glyph bake --input Inter-Regular.ttf --output inter-latin.font.glb --unicodes U+0020-007E --msdf
+  glyph bake --input fa-solid-900.ttf --output icons.font.glb --unicodes U+F000-F8FF --glyph-map icons.json --msdf
   glyph bake --input Inter-Regular.ttf --output inter-small.font.glb --msdf em-size=32
   glyph bake --project-root . --output-root public/generated
   glyph bake --input Inter-Regular.ttf --output inter.font.glb --msdf --check

--- a/packages/glyph/tests/integration/node-bake.test.mjs
+++ b/packages/glyph/tests/integration/node-bake.test.mjs
@@ -321,6 +321,73 @@ test('the CLI directly bakes and checks one known font from arguments', async (t
   );
 });
 
+test('direct bake writes and checks a glyph-name lookup for its selected Unicode set', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'pmndrs-glyph-map-cli-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const input = join(root, 'fa-solid-900.ttf');
+  const output = join(root, 'icons.font.glb');
+  const glyphMap = join(root, 'icons.json');
+  await writeFile(input, await readFile(iconFontUrl));
+
+  const bake = captureIo();
+  assert.equal(
+    await runCli(
+      ['bake', '--input', input, '--output', output, '--unicodes', 'U+F0AC,U+F57D', '--glyph-map', glyphMap, '--json'],
+      bake.io,
+    ),
+    0,
+    bake.stderr(),
+  );
+  assert.deepEqual(JSON.parse(await readFile(glyphMap, 'utf8')), {
+    'earth-americas': 0xf57d,
+    globe: 0xf0ac,
+  });
+  assert.equal(JSON.parse(bake.stdout()).execution.outputs[0].file, output);
+
+  const check = captureIo();
+  assert.equal(
+    await runCli(
+      ['bake', '--input', input, '--output', output, '--unicodes', 'U+F0AC,U+F57D', '--glyph-map', glyphMap, '--check'],
+      check.io,
+    ),
+    0,
+    check.stderr(),
+  );
+
+  await writeFile(glyphMap, '{}\n');
+  const stale = captureIo();
+  assert.equal(
+    await runCli(
+      ['bake', '--input', input, '--output', output, '--unicodes', 'U+F0AC,U+F57D', '--glyph-map', glyphMap, '--check'],
+      stale.io,
+    ),
+    1,
+  );
+  assert.match(stale.stderr(), /^STALE_GLYPH_MAP:/);
+  assert.equal(await readFile(glyphMap, 'utf8'), '{}\n');
+});
+
+test('glyph-map aliases fail before either direct bake output is published', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'pmndrs-glyph-map-alias-cli-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const input = join(root, 'fa-solid-900.ttf');
+  const output = join(root, 'icons.font.glb');
+  const glyphMap = join(root, 'icons.json');
+  await writeFile(input, await readFile(iconFontUrl));
+
+  const ambiguous = captureIo();
+  assert.equal(
+    await runCli(
+      ['bake', '--input', input, '--output', output, '--unicodes', 'U+F0AC,U+1F310', '--glyph-map', glyphMap],
+      ambiguous.io,
+    ),
+    1,
+  );
+  assert.match(ambiguous.stderr(), /^AMBIGUOUS_GLYPH_NAME:/);
+  await assert.rejects(readFile(output), { code: 'ENOENT' });
+  await assert.rejects(readFile(glyphMap), { code: 'ENOENT' });
+});
+
 test('pre-cancellation and source/output overlap fail before filesystem mutation', async (t) => {
   const root = await mkdtemp(join(tmpdir(), 'pmndrs-glyph-node-errors-'));
   t.after(() => rm(root, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

- add `--glyph-map <path>` to the existing direct `glyph bake` command
- emit a deterministic, directly importable JSON object mapping authored glyph names to code points from the same font face and `--unicodes` selection as the GLB
- publish the GLB and glyph map as one rollback-safe output set, and make `--check` verify both byte-for-byte
- reject duplicate selected aliases before either output is written instead of choosing by font-table order

## Usage

```sh
pnpm exec glyph bake \
  --input fa-solid-900.ttf \
  --output icons.font.glb \
  --unicodes U+F000-F8FF \
  --glyph-map icons.json \
  --msdf
```

The generated file is a plain lookup:

```json
{
  "paintbrush": 61948,
  "rocket": 61749
}
```

## Verification

- `node --test packages/glyph/tests/integration/node-bake.test.mjs` — 15/15 passed
- `pnpm --filter @pmndrs/glyph check` — full package, Rust, Unicode conformance, fuzz, type, lint, and format gates passed
- `pnpm scripts run docs:update` — OKF conformance errors: 0; warnings: 0

## Contract

This remains CLI-only authoring orchestration. Programmatic consumers continue to use `inspectFont()` as the primitive inspection API.