### PR TITLE
fix(bakers): refuse outline-less fonts, and make Slug's cubic rate configurable

### DIFF
--- a/apps/benchmarks/src/benchmark/package-size-budgets.ts
+++ b/apps/benchmarks/src/benchmark/package-size-budgets.ts
@@ -200,11 +200,18 @@ export const packageSizeBudgets = {
     gzipBytes: 5_700,
     brotliBytes: 5_100,
   },
+  // The configurable CFF cubic subdivision rate and the outline-table refusal both add
+  // code to this baker. Measured on the recorded macOS host, the artifact moved 461,488
+  // raw at the base commit to 464,164 after the subdivision rate (+2,676: the split-and-fit
+  // loop, its bounded quadratic buffer, and descriptor validation) and to 464,386 after the
+  // refusal (+222: one outline-format branch per baker). Linux emits 464,113 raw / 186,785
+  // gzip / 147,013 Brotli for the same sources, so these ceilings price the larger macOS
+  // measurement plus the documented cross-host margin.
   'slug-baker-wasm': {
-    rawBytes: 464_000,
-    minifiedBytes: 464_000,
-    gzipBytes: 187_000,
-    brotliBytes: 147_000,
+    rawBytes: 467_000,
+    minifiedBytes: 467_000,
+    gzipBytes: 188_000,
+    brotliBytes: 148_000,
   },
   'slug-baker-js': {
     rawBytes: 20_000,

--- a/packages/glyph/rust/bitmap-baker/src/lib.rs
+++ b/packages/glyph/rust/bitmap-baker/src/lib.rs
@@ -215,6 +215,36 @@ mod tests {
     );
     const SHAPING_FINGERPRINT: &str = "0c522d6ea0db73ba74bcc389dc50263b";
 
+    /// Drop one table's directory record, leaving its bytes stranded. This is
+    /// the shape a CFF source reaches the raster bakers in: subsetting emits a
+    /// font whose outline table is simply gone.
+    fn without_table(source: &[u8], tag: &[u8; 4]) -> Vec<u8> {
+        let mut bytes = source.to_vec();
+        let count = usize::from(u16::from_be_bytes([bytes[4], bytes[5]]));
+        let record = (0..count)
+            .map(|index| 12 + index * 16)
+            .find(|start| &bytes[*start..*start + 4] == tag)
+            .expect("font carries the table being removed");
+        // Shift the later records down over it; the table data never moves, so
+        // every remaining offset stays valid and the tail 16 bytes go unread.
+        bytes.copy_within(record + 16..12 + count * 16, record);
+        bytes[4..6].copy_from_slice(&u16::try_from(count - 1).unwrap().to_be_bytes());
+        bytes
+    }
+
+    #[test]
+    fn a_font_without_outlines_is_refused_rather_than_baked_blank() {
+        let stripped = without_table(INTER, b"glyf");
+        let error = bake_bitmap(&stripped, request())
+            .expect_err("a font with no outline table must not bake");
+        assert_eq!(error.code, BitmapBakeErrorCode::InvalidFont);
+        assert!(
+            error.message.contains("outline table"),
+            "the message must name the cause: {}",
+            error.message
+        );
+    }
+
     fn request() -> BitmapBakeRequestV0 {
         let descriptor = BitmapDescriptorV0 {
             coverage: None,

--- a/packages/glyph/rust/bitmap-baker/src/rasterize.rs
+++ b/packages/glyph/rust/bitmap-baker/src/rasterize.rs
@@ -139,6 +139,16 @@ pub(crate) fn rasterize_strike(
     pages.push(AtlasPage::new(ATLAS_LIMIT, 1)?);
 
     let outlines = font.outline_glyphs();
+    // Once, before the loop. A font carrying no outline table at all draws an
+    // empty raster for every glyph, and `mark_absent` records that identically
+    // to a glyph the coverage set never selected — so the artifact looks whole
+    // and renders blank. Refuse it here instead, where the cause is still known.
+    if outlines.format().is_none() {
+        return Err(BitmapBakeError::new(
+            BitmapBakeErrorCode::InvalidFont,
+            "font has no glyf, CFF, or CFF2 outline table to rasterize",
+        ));
+    }
     crate::progress::report(progress_offset, progress_total);
     let mut selected_index = 0_u32;
     for raw_glyph_id in 0..glyph_count {

--- a/packages/glyph/rust/mtsdf-baker/src/artifact.rs
+++ b/packages/glyph/rust/mtsdf-baker/src/artifact.rs
@@ -355,6 +355,15 @@ fn select_font<'source>(
     let font = FontRef::from_index(source, face_index).map_err(|error| {
         MtsdfBakeError::new(MtsdfBakeErrorCode::InvalidFontFace, error).at("/fontFaceIndex")
     })?;
+    // Once, before the loop. Without an outline table every glyph produces an
+    // empty field, which is stored identically to a legitimately blank glyph —
+    // the artifact looks whole and renders nothing.
+    if font.outline_glyphs().format().is_none() {
+        return Err(MtsdfBakeError::new(
+            MtsdfBakeErrorCode::InvalidFont,
+            "font has no glyf, CFF, or CFF2 outline table to generate a field from",
+        ));
+    }
     let actual_glyph_count = glyph_count(&font)
         .map_err(|error| MtsdfBakeError::new(MtsdfBakeErrorCode::InvalidFont, error))?;
     if actual_glyph_count != expected_glyph_count {

--- a/packages/glyph/rust/slug-baker/src/artifact.rs
+++ b/packages/glyph/rust/slug-baker/src/artifact.rs
@@ -46,7 +46,7 @@ pub fn bake_slug(
     source: &[u8],
     request: SlugBakeRequestV0,
 ) -> Result<SlugBakeResultV0, SlugBakeError> {
-    request.descriptor.validate()?;
+    let settings = request.descriptor.validate()?;
     validate_fingerprint("sourceFingerprint", &request.source_fingerprint)?;
     validate_fingerprint("shapingFingerprint", &request.shaping_fingerprint)?;
     validate_fingerprint("rasterKey", &request.raster_key)?;
@@ -69,7 +69,12 @@ pub fn bake_slug(
         .at("/sourceFingerprint"));
     }
 
-    let packed = rasterize_font(source, request.font_face_index, request.glyph_count)?;
+    let packed = rasterize_font(
+        source,
+        request.font_face_index,
+        request.glyph_count,
+        settings.cubic_subdivisions,
+    )?;
     let metadata_bytes = packed.record_bytes.len();
     let built = build_slug_glb(
         &request.raster_key,
@@ -126,8 +131,15 @@ pub fn bake_slug(
 }
 
 pub fn descriptor_raster_key(descriptor: &SlugDescriptorV0) -> String {
+    // Canonical key order is alphabetical, so an explicit rate sorts ahead of
+    // the generator version. The default is absent from the descriptor entirely,
+    // which is what keeps every existing key byte-identical.
+    let subdivisions = descriptor
+        .cubic_subdivisions
+        .map(|value| format!("\"cubicSubdivisions\":{value},"))
+        .unwrap_or_default();
     let canonical = format!(
-        "{{\"descriptor\":{{\"generatorVersion\":\"{}\"}},\"extension\":\"{}\",\"kind\":\"{}\",\"version\":{}}}",
+        "{{\"descriptor\":{{{subdivisions}\"generatorVersion\":\"{}\"}},\"extension\":\"{}\",\"kind\":\"{}\",\"version\":{}}}",
         descriptor.generator_version, SLUG_EXTENSION, SLUG_KIND, SLUG_FORMAT_VERSION,
     );
     pmndrs_glyph_raster_artifact::fingerprint128(
@@ -147,6 +159,7 @@ fn rasterize_font(
     source: &[u8],
     face_index: u32,
     expected_glyph_count: u16,
+    cubic_subdivisions: u8,
 ) -> Result<PackedSlug, SlugBakeError> {
     let font = FontRef::from_index(source, face_index).map_err(|error| {
         SlugBakeError::new(SlugBakeErrorCode::InvalidFontFace, error).at("/fontFaceIndex")
@@ -172,6 +185,7 @@ fn rasterize_font(
             &font,
             GlyphId::new(u32::from(raw_glyph_id)),
             DEFAULT_BAND_COUNT,
+            cubic_subdivisions,
         )
         .map_err(|error| outline_error(raw_glyph_id, error))?;
         geometries.push(match geometry {
@@ -320,11 +334,47 @@ mod tests {
         "../../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf"
     );
 
+    /// Both derived in JavaScript from the canonical raster-key JSON, so these
+    /// pin the Rust serializer to the TypeScript one across the ABI.
+    const DEFAULT_RASTER_KEY: &str =
+        "7a0e184add86df5a220f16872425af319ba916237ae37ca72f5a9ce748271abb";
+    const RATE_EIGHT_RASTER_KEY: &str =
+        "9bfc7c767a9b07e1f3280eeceb60afc9a0e866ba522e40e82890d7d3565e5b8a";
+
+    #[test]
+    fn a_configured_rate_derives_the_same_key_typescript_derives() {
+        let configured = SlugDescriptorV0 {
+            generator_version: SLUG_GENERATOR_VERSION.into(),
+            cubic_subdivisions: Some(8),
+        };
+        assert_eq!(descriptor_raster_key(&configured), RATE_EIGHT_RASTER_KEY);
+        assert_ne!(descriptor_raster_key(&configured), DEFAULT_RASTER_KEY);
+    }
+
+    #[test]
+    fn a_rate_outside_the_supported_range_is_refused_by_name() {
+        for rate in [0_u8, 17] {
+            let error = SlugDescriptorV0 {
+                generator_version: SLUG_GENERATOR_VERSION.into(),
+                cubic_subdivisions: Some(rate),
+            }
+            .validate()
+            .expect_err("an unsupported rate must not validate");
+            assert_eq!(error.path.as_deref(), Some("/descriptor/cubicSubdivisions"));
+        }
+    }
+
     #[test]
     fn bakes_dense_inter_records_deterministically() {
         let descriptor = SlugDescriptorV0 {
             generator_version: SLUG_GENERATOR_VERSION.into(),
+            cubic_subdivisions: None,
         };
+        assert_eq!(
+            descriptor_raster_key(&descriptor),
+            DEFAULT_RASTER_KEY,
+            "the default descriptor's key must not move"
+        );
         let raster_key = descriptor_raster_key(&descriptor);
         let request = || SlugBakeRequestV0 {
             source_fingerprint: pmndrs_glyph_raster_artifact::fingerprint128(

--- a/packages/glyph/rust/slug-baker/src/artifact.rs
+++ b/packages/glyph/rust/slug-baker/src/artifact.rs
@@ -9,7 +9,7 @@ use pmndrs_glyph_slug_core::{
     quantize_f16,
 };
 use pmndrs_glyph_slug_fontations::{FontOutlineError, font_glyph_geometry, glyph_count};
-use skrifa::{FontRef, GlyphId};
+use skrifa::{FontRef, GlyphId, MetadataProvider};
 
 use crate::{
     error::{SlugBakeError, SlugBakeErrorCode, overflow},
@@ -164,6 +164,15 @@ fn rasterize_font(
     let font = FontRef::from_index(source, face_index).map_err(|error| {
         SlugBakeError::new(SlugBakeErrorCode::InvalidFontFace, error).at("/fontFaceIndex")
     })?;
+    // Once, before the loop. Without an outline table every glyph resolves to
+    // "no geometry", which is recorded identically to a legitimately blank
+    // glyph — the artifact looks whole and renders nothing.
+    if font.outline_glyphs().format().is_none() {
+        return Err(SlugBakeError::new(
+            SlugBakeErrorCode::InvalidFont,
+            "font has no glyf, CFF, or CFF2 outline table to convert",
+        ));
+    }
     let actual_glyph_count = glyph_count(&font)
         .map_err(|error| SlugBakeError::new(SlugBakeErrorCode::InvalidFont, error))?;
     if actual_glyph_count != expected_glyph_count {

--- a/packages/glyph/rust/slug-baker/src/model.rs
+++ b/packages/glyph/rust/slug-baker/src/model.rs
@@ -1,6 +1,7 @@
 use alloc::{string::String, vec::Vec};
 
 pub use pmndrs_glyph_raster_artifact::ArtifactPackaging;
+use pmndrs_glyph_slug_core::{DEFAULT_CUBIC_SUBDIVISIONS, MAX_CUBIC_SUBDIVISIONS};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{SlugBakeError, SlugBakeErrorCode};
@@ -17,10 +18,18 @@ pub const SLUG_PLANE_UNITS_PER_EM: u16 = 2048;
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SlugDescriptorV0 {
     pub generator_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cubic_subdivisions: Option<u8>,
+}
+
+/// Descriptor values resolved against their defaults.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SlugBakeSettingsV0 {
+    pub cubic_subdivisions: u8,
 }
 
 impl SlugDescriptorV0 {
-    pub(crate) fn validate(&self) -> Result<(), SlugBakeError> {
+    pub(crate) fn validate(&self) -> Result<SlugBakeSettingsV0, SlugBakeError> {
         if self.generator_version != SLUG_GENERATOR_VERSION {
             return Err(SlugBakeError::new(
                 SlugBakeErrorCode::InvalidDescriptor,
@@ -28,7 +37,17 @@ impl SlugDescriptorV0 {
             )
             .at("/descriptor/generatorVersion"));
         }
-        Ok(())
+        let cubic_subdivisions = self
+            .cubic_subdivisions
+            .unwrap_or(DEFAULT_CUBIC_SUBDIVISIONS);
+        if cubic_subdivisions < 1 || usize::from(cubic_subdivisions) > MAX_CUBIC_SUBDIVISIONS {
+            return Err(SlugBakeError::new(
+                SlugBakeErrorCode::InvalidDescriptor,
+                "cubic subdivisions must be between 1 and 16",
+            )
+            .at("/descriptor/cubicSubdivisions"));
+        }
+        Ok(SlugBakeSettingsV0 { cubic_subdivisions })
     }
 }
 

--- a/packages/glyph/rust/slug-core/src/lib.rs
+++ b/packages/glyph/rust/slug-core/src/lib.rs
@@ -41,6 +41,13 @@ impl Point {
     fn midpoint(self, other: Self) -> Self {
         Self::new((self.x + other.x) * 0.5, (self.y + other.y) * 0.5)
     }
+
+    fn lerp(self, other: Self, t: f32) -> Self {
+        Self::new(
+            self.x + (other.x - self.x) * t,
+            self.y + (other.y - self.y) * t,
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -316,10 +323,47 @@ pub fn line_to_quadratic(start: Point, end: Point, units_per_em: f32) -> Quadrat
     }
 }
 
-/// Port of the legacy fixed cubic conversion: split once and fit two quadratics.
-pub fn cubic_to_quadratics(cubic: Cubic) -> [Quadratic; 2] {
-    let (first, second) = split_cubic(cubic);
-    [fit_quadratic(first), fit_quadratic(second)]
+/// Quadratics fitted per cubic unless a descriptor asks otherwise.
+///
+/// Four, not the legacy two. Only CFF sources reach this code, and no shipped
+/// artifact contains CFF-derived curves today because subsetting drops the
+/// `CFF ` table outright, so raising the rate rewrites nothing that exists.
+/// Two left a quarter of Dancing Script's cubics more than half a font unit off
+/// the true curve, worst case 8.32 units — 1.7px on a 200px glyph, and Slug is
+/// resolution independent, so that grows with the render size. Four brings the
+/// worst case to 1.15 units for twice the curves.
+pub const DEFAULT_CUBIC_SUBDIVISIONS: u8 = 4;
+/// Most quadratics one cubic may become, and so the scratch width a caller needs.
+pub const MAX_CUBIC_SUBDIVISIONS: usize = 16;
+
+/// Split `cubic` into `subdivisions` equal-parameter pieces, midpoint-fit a
+/// quadratic to each, and write them into `out`, returning how many were written.
+///
+/// Only CFF sources reach this: TrueType outlines are already quadratic. The
+/// rate is a straight accuracy-for-payload trade, since Slug ships these curves
+/// to the GPU. Measured over Dancing Script's 9,468 cubics, the worst deviation
+/// from the true curve falls 8.32 -> 1.15 -> 0.14 font units at 2, 4, and 8
+/// subdivisions, against a payload that grows in proportion.
+pub fn cubic_to_quadratics_into(
+    cubic: Cubic,
+    subdivisions: u8,
+    out: &mut [Quadratic; MAX_CUBIC_SUBDIVISIONS],
+) -> usize {
+    let count = (subdivisions as usize).clamp(1, MAX_CUBIC_SUBDIVISIONS);
+    let mut rest = cubic;
+    for (index, slot) in out.iter_mut().enumerate().take(count) {
+        // Peel one equal-parameter piece off the front, so the tail keeps the
+        // exact remaining curve rather than accumulating a rescaled parameter.
+        let remaining = count - index;
+        if remaining == 1 {
+            *slot = fit_quadratic(rest);
+        } else {
+            let (head, tail) = split_cubic_at(rest, 1.0 / remaining as f32);
+            *slot = fit_quadratic(head);
+            rest = tail;
+        }
+    }
+    count
 }
 
 fn fit_quadratic(cubic: Cubic) -> Quadratic {
@@ -333,13 +377,23 @@ fn fit_quadratic(cubic: Cubic) -> Quadratic {
     }
 }
 
-fn split_cubic(cubic: Cubic) -> (Cubic, Cubic) {
-    let m01 = cubic.p0.midpoint(cubic.p1);
-    let m12 = cubic.p1.midpoint(cubic.p2);
-    let m23 = cubic.p2.midpoint(cubic.p3);
-    let m012 = m01.midpoint(m12);
-    let m123 = m12.midpoint(m23);
-    let middle = m012.midpoint(m123);
+fn split_cubic_at(cubic: Cubic, t: f32) -> (Cubic, Cubic) {
+    // de Casteljau. The half split keeps the original midpoint arithmetic:
+    // `(a + b) * 0.5` and `a + (b - a) * 0.5` are not bit-identical in f32, so a
+    // rate of two still reproduces the legacy payload exactly.
+    let cut = |a: Point, b: Point| {
+        if t == 0.5 {
+            a.midpoint(b)
+        } else {
+            a.lerp(b, t)
+        }
+    };
+    let m01 = cut(cubic.p0, cubic.p1);
+    let m12 = cut(cubic.p1, cubic.p2);
+    let m23 = cut(cubic.p2, cubic.p3);
+    let m012 = cut(m01, m12);
+    let m123 = cut(m12, m23);
+    let middle = cut(m012, m123);
     (
         Cubic {
             p0: cubic.p0,
@@ -423,17 +477,117 @@ mod tests {
         assert_ne!(diagonal.p1, Point::new(0.5, 0.5));
     }
 
+    const ZERO_QUADRATIC: Quadratic = Quadratic {
+        p0: Point::new(0.0, 0.0),
+        p1: Point::new(0.0, 0.0),
+        p2: Point::new(0.0, 0.0),
+    };
+    const SAMPLE_CUBIC: Cubic = Cubic {
+        p0: Point::new(0.0, 0.0),
+        p1: Point::new(0.0, 1.0),
+        p2: Point::new(1.0, 1.0),
+        p3: Point::new(1.0, 0.0),
+    };
+
     #[test]
     fn fixed_cubic_conversion_is_continuous() {
-        let converted = cubic_to_quadratics(Cubic {
-            p0: Point::new(0.0, 0.0),
-            p1: Point::new(0.0, 1.0),
-            p2: Point::new(1.0, 1.0),
-            p3: Point::new(1.0, 0.0),
-        });
+        // The legacy rate, named outright: the midpoint split it depends on is
+        // kept bit-exact, so this must stay pinned to 2 rather than the default.
+        let mut converted = [ZERO_QUADRATIC; MAX_CUBIC_SUBDIVISIONS];
+        let written = cubic_to_quadratics_into(SAMPLE_CUBIC, 2, &mut converted);
+        assert_eq!(written, 2);
         assert_eq!(converted[0].p0, Point::new(0.0, 0.0));
         assert_eq!(converted[0].p2, converted[1].p0);
         assert_eq!(converted[1].p2, Point::new(1.0, 0.0));
+    }
+
+    #[test]
+    fn every_subdivision_rate_stays_continuous_and_spans_the_cubic() {
+        for rate in 1..=MAX_CUBIC_SUBDIVISIONS as u8 {
+            let mut converted = [ZERO_QUADRATIC; MAX_CUBIC_SUBDIVISIONS];
+            let written = cubic_to_quadratics_into(SAMPLE_CUBIC, rate, &mut converted);
+            assert_eq!(
+                written,
+                usize::from(rate),
+                "rate {rate} writes one quadratic each"
+            );
+            assert_eq!(
+                converted[0].p0, SAMPLE_CUBIC.p0,
+                "rate {rate} keeps the start"
+            );
+            assert_eq!(
+                converted[written - 1].p2,
+                SAMPLE_CUBIC.p3,
+                "rate {rate} keeps the end"
+            );
+            for pair in converted[..written].windows(2) {
+                assert_eq!(pair[0].p2, pair[1].p0, "rate {rate} joins without a gap");
+            }
+        }
+    }
+
+    #[test]
+    fn a_rate_outside_the_supported_range_is_clamped_rather_than_panicking() {
+        let mut converted = [ZERO_QUADRATIC; MAX_CUBIC_SUBDIVISIONS];
+        assert_eq!(cubic_to_quadratics_into(SAMPLE_CUBIC, 0, &mut converted), 1);
+        assert_eq!(
+            cubic_to_quadratics_into(SAMPLE_CUBIC, u8::MAX, &mut converted),
+            MAX_CUBIC_SUBDIVISIONS
+        );
+    }
+
+    #[test]
+    fn raising_the_rate_moves_the_fit_closer_to_the_true_cubic() {
+        // Sample the cubic and take the nearest point on the fitted chain. The
+        // error must fall monotonically as the rate rises, which is the whole
+        // reason the knob exists.
+        let error_at = |rate: u8| -> f32 {
+            let mut converted = [ZERO_QUADRATIC; MAX_CUBIC_SUBDIVISIONS];
+            let written = cubic_to_quadratics_into(SAMPLE_CUBIC, rate, &mut converted);
+            let mut worst = 0.0_f32;
+            for step in 0..=64 {
+                let t = step as f32 / 64.0;
+                let want = cubic_point(SAMPLE_CUBIC, t);
+                let mut nearest = f32::MAX;
+                for quadratic in &converted[..written] {
+                    for probe in 0..=64 {
+                        let u = probe as f32 / 64.0;
+                        let got = quadratic_point(*quadratic, u);
+                        let distance = ((want.x - got.x).powi(2) + (want.y - got.y).powi(2)).sqrt();
+                        if distance < nearest {
+                            nearest = distance;
+                        }
+                    }
+                }
+                if nearest > worst {
+                    worst = nearest;
+                }
+            }
+            worst
+        };
+        let (two, four, eight) = (error_at(2), error_at(4), error_at(8));
+        assert!(four < two, "four subdivisions beat two: {four} vs {two}");
+        assert!(
+            eight < four,
+            "eight subdivisions beat four: {eight} vs {four}"
+        );
+    }
+
+    fn cubic_point(cubic: Cubic, t: f32) -> Point {
+        let m = 1.0 - t;
+        let (a, b, c, d) = (m * m * m, 3.0 * m * m * t, 3.0 * m * t * t, t * t * t);
+        Point::new(
+            a * cubic.p0.x + b * cubic.p1.x + c * cubic.p2.x + d * cubic.p3.x,
+            a * cubic.p0.y + b * cubic.p1.y + c * cubic.p2.y + d * cubic.p3.y,
+        )
+    }
+
+    fn quadratic_point(quadratic: Quadratic, t: f32) -> Point {
+        let m = 1.0 - t;
+        Point::new(
+            m * m * quadratic.p0.x + 2.0 * m * t * quadratic.p1.x + t * t * quadratic.p2.x,
+            m * m * quadratic.p0.y + 2.0 * m * t * quadratic.p1.y + t * t * quadratic.p2.y,
+        )
     }
 
     #[test]

--- a/packages/glyph/rust/slug-fontations/src/lib.rs
+++ b/packages/glyph/rust/slug-fontations/src/lib.rs
@@ -7,8 +7,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use pmndrs_glyph_slug_core::{
-    BuildError, Cubic, GlyphGeometry, Point, Quadratic, build_glyph_geometry, cubic_to_quadratics,
-    line_to_quadratic,
+    BuildError, Cubic, GlyphGeometry, MAX_CUBIC_SUBDIVISIONS, Point, Quadratic,
+    build_glyph_geometry, cubic_to_quadratics_into, line_to_quadratic,
 };
 use skrifa::{
     FontRef, GlyphId, MetadataProvider,
@@ -33,10 +33,14 @@ impl From<BuildError> for FontOutlineError {
 }
 
 /// Resolve and normalize one font-local glyph into Slug's quadratic geometry.
+///
+/// `cubic_subdivisions` only reaches CFF sources, whose cubics are fitted with
+/// that many quadratics each; TrueType outlines are already quadratic and ignore it.
 pub fn font_glyph_geometry(
     font: &FontRef<'_>,
     glyph_id: GlyphId,
     band_count: u16,
+    cubic_subdivisions: u8,
 ) -> Result<Option<GlyphGeometry>, FontOutlineError> {
     let units_per_em = font
         .metrics(Size::unscaled(), LocationRef::default())
@@ -47,7 +51,7 @@ pub fn font_glyph_geometry(
     let Some(glyph) = font.outline_glyphs().get(glyph_id) else {
         return Ok(None);
     };
-    let mut collector = Collector::new(units_per_em);
+    let mut collector = Collector::new(units_per_em, cubic_subdivisions);
     glyph
         .draw(
             DrawSettings::unhinted(Size::unscaled(), LocationRef::default()),
@@ -70,6 +74,7 @@ pub fn glyph_count(font: &FontRef<'_>) -> Result<u16, skrifa::raw::ReadError> {
 
 struct Collector {
     units_per_em: f32,
+    cubic_subdivisions: u8,
     curves: Vec<Quadratic>,
     contour_starts: Vec<u16>,
     first: Option<Point>,
@@ -78,9 +83,10 @@ struct Collector {
 }
 
 impl Collector {
-    fn new(units_per_em: f32) -> Self {
+    fn new(units_per_em: f32, cubic_subdivisions: u8) -> Self {
         Self {
             units_per_em,
+            cubic_subdivisions,
             curves: Vec::new(),
             contour_starts: Vec::new(),
             first: None,
@@ -184,17 +190,26 @@ impl OutlinePen for Collector {
             self.failure = Some(FontOutlineError::InvalidContour);
             return;
         };
-        if !self.reserve_curve(2) {
+        let mut converted = [Quadratic {
+            p0: start,
+            p1: start,
+            p2: start,
+        }; MAX_CUBIC_SUBDIVISIONS];
+        let written = cubic_to_quadratics_into(
+            Cubic {
+                p0: start,
+                p1: self.normalized(first_control_x, first_control_y),
+                p2: self.normalized(second_control_x, second_control_y),
+                p3: self.normalized(x, y),
+            },
+            self.cubic_subdivisions,
+            &mut converted,
+        );
+        if !self.reserve_curve(written) {
             return;
         }
-        let converted = cubic_to_quadratics(Cubic {
-            p0: start,
-            p1: self.normalized(first_control_x, first_control_y),
-            p2: self.normalized(second_control_x, second_control_y),
-            p3: self.normalized(x, y),
-        });
-        self.curves.extend_from_slice(&converted);
-        self.current = Some(converted[1].p2);
+        self.curves.extend_from_slice(&converted[..written]);
+        self.current = Some(converted[written - 1].p2);
     }
 
     fn close(&mut self) {
@@ -213,7 +228,7 @@ impl OutlinePen for Collector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pmndrs_glyph_slug_core::DEFAULT_BAND_COUNT;
+    use pmndrs_glyph_slug_core::{DEFAULT_BAND_COUNT, DEFAULT_CUBIC_SUBDIVISIONS};
 
     const INTER: &[u8] = include_bytes!(
         "../../../../../apps/benchmarks/fixtures/fonts/inter-v4.1/Inter-Regular.ttf"
@@ -226,9 +241,14 @@ mod tests {
     fn reads_complete_inter_identity_and_geometry() {
         let font = FontRef::new(INTER).unwrap();
         assert_eq!(glyph_count(&font).unwrap(), 2937);
-        let geometry = font_glyph_geometry(&font, GlyphId::new(43), DEFAULT_BAND_COUNT)
-            .unwrap()
-            .expect("Inter H outline");
+        let geometry = font_glyph_geometry(
+            &font,
+            GlyphId::new(43),
+            DEFAULT_BAND_COUNT,
+            DEFAULT_CUBIC_SUBDIVISIONS,
+        )
+        .unwrap()
+        .expect("Inter H outline");
         assert!(!geometry.curves.is_empty());
         assert_eq!(geometry.bands.horizontal.len(), 16);
         assert_eq!(geometry.bands.vertical.len(), 16);
@@ -240,9 +260,14 @@ mod tests {
         let font = FontRef::new(DANCING_SCRIPT).unwrap();
         let geometry = (0..glyph_count(&font).unwrap())
             .find_map(|raw_id| {
-                font_glyph_geometry(&font, GlyphId::new(u32::from(raw_id)), DEFAULT_BAND_COUNT)
-                    .unwrap()
-                    .filter(|geometry| geometry.curves.len() > 12)
+                font_glyph_geometry(
+                    &font,
+                    GlyphId::new(u32::from(raw_id)),
+                    DEFAULT_BAND_COUNT,
+                    DEFAULT_CUBIC_SUBDIVISIONS,
+                )
+                .unwrap()
+                .filter(|geometry| geometry.curves.len() > 12)
             })
             .expect("one non-trivial CFF outline");
         assert!(geometry.curves.iter().all(|curve| {

--- a/packages/glyph/src/bakers/slug-validator.ts
+++ b/packages/glyph/src/bakers/slug-validator.ts
@@ -48,6 +48,7 @@ import {
   SLUG_GENERATOR_VERSION,
   SLUG_GLYPH_RECORD_STRIDE,
   SLUG_PLANE_UNITS_PER_EM,
+  SLUG_MAX_CUBIC_SUBDIVISIONS,
   slugDescriptorRasterKey,
   type SlugDescriptor,
 } from '../internal/slug-contract.js';
@@ -274,15 +275,26 @@ async function validateSlugSemantics(
 
 async function validateContext(context: SlugArtifactValidationContext): Promise<void> {
   const descriptor = requireNonArrayObject(context.descriptor, '/descriptor');
+  const cubicSubdivisions = Object.hasOwn(descriptor, 'cubicSubdivisions') ? descriptor.cubicSubdivisions : undefined;
   if (
-    Object.keys(descriptor).length !== 1 ||
+    Object.keys(descriptor).length !== (cubicSubdivisions === undefined ? 1 : 2) ||
     !Object.hasOwn(descriptor, 'generatorVersion') ||
-    descriptor.generatorVersion !== SLUG_GENERATOR_VERSION
+    descriptor.generatorVersion !== SLUG_GENERATOR_VERSION ||
+    (cubicSubdivisions !== undefined &&
+      (typeof cubicSubdivisions !== 'number' ||
+        !Number.isSafeInteger(cubicSubdivisions) ||
+        cubicSubdivisions < 1 ||
+        cubicSubdivisions > SLUG_MAX_CUBIC_SUBDIVISIONS))
   ) {
-    fail('SLUG_DESCRIPTOR', 'descriptor does not match the fixed Slug generator', '/descriptor');
+    fail('SLUG_DESCRIPTOR', 'descriptor does not match the Slug generator', '/descriptor');
   }
-  if (context.rasterKey !== slugDescriptorRasterKey()) {
-    fail('RASTER_KEY', 'expected raster key does not match the fixed descriptor', '/rasterKey');
+  // Re-derive from the descriptor that arrived, so a configured rate validates
+  // against its own key rather than the default one.
+  const expectedRasterKey = slugDescriptorRasterKey(
+    cubicSubdivisions === undefined ? undefined : { cubicSubdivisions: cubicSubdivisions as number },
+  );
+  if (context.rasterKey !== expectedRasterKey) {
+    fail('RASTER_KEY', 'expected raster key does not match the descriptor', '/rasterKey');
   }
   if (!isFingerprint(context.shapingFingerprint)) {
     fail(

--- a/packages/glyph/src/bakers/slug.ts
+++ b/packages/glyph/src/bakers/slug.ts
@@ -16,6 +16,7 @@ import {
   SLUG_FORMAT_VERSION,
   SLUG_KIND,
   slugDescriptor,
+  type SlugOptions,
   type SlugDescriptor,
 } from '../internal/slug-contract.js';
 import { cacheSuccessfulPromise } from '../internal/successful-promise-cache.js';
@@ -24,7 +25,7 @@ import type { Fingerprint, RasterKey } from '../identity.js';
 
 export { slugBakerAbi } from '../generated/slug-baker-abi.js';
 
-export type SlugBakerOptions = undefined;
+export type SlugBakerOptions = SlugOptions | undefined;
 
 export interface SlugBakerRequest {
   readonly sourceFingerprint: Fingerprint;

--- a/packages/glyph/src/internal/slug-contract.ts
+++ b/packages/glyph/src/internal/slug-contract.ts
@@ -10,6 +10,22 @@ export const SLUG_PLANE_UNITS_PER_EM = 2048 as const;
 export const SLUG_DEFAULT_BAND_COUNT = 16 as const;
 export const SLUG_GLYPH_RECORD_STRIDE = 40 as const;
 
+/** Quadratics fitted per CFF cubic. TrueType outlines are already quadratic. */
+export const SLUG_CUBIC_SUBDIVISIONS = 4 as const;
+/** Most quadratics one cubic may become. */
+export const SLUG_MAX_CUBIC_SUBDIVISIONS = 16 as const;
+
+export interface SlugOptions {
+  /**
+   * Quadratics fitted per cubic when the source has CFF outlines. Defaults to 4.
+   *
+   * Straight accuracy for cost: Slug ships these curves to the GPU and the
+   * shader walks every curve in a pixel's band, so raising this grows both the
+   * payload and the per-pixel loop in proportion. TrueType sources ignore it.
+   */
+  readonly cubicSubdivisions?: number;
+}
+
 export interface SlugDescriptor {
   readonly [key: string]: JsonValue;
   readonly generatorVersion: typeof SLUG_GENERATOR_VERSION;
@@ -19,17 +35,47 @@ const descriptor = Object.freeze({
   generatorVersion: SLUG_GENERATOR_VERSION,
 }) satisfies SlugDescriptor;
 
-/** Return the fixed, quality-preserving Slug V0 payload descriptor. */
-export function slugDescriptor(): SlugDescriptor {
-  return descriptor;
+/**
+ * Return the payload-changing Slug V0 descriptor.
+ *
+ * The default rate is omitted rather than written out, so the descriptor — and
+ * the raster key derived from it — is unchanged for every caller who does not
+ * ask for a different one.
+ */
+export function slugDescriptor(options?: SlugOptions): SlugDescriptor {
+  const cubicSubdivisions = normalizeSlugOptions(options)?.cubicSubdivisions;
+  if (cubicSubdivisions === undefined || cubicSubdivisions === SLUG_CUBIC_SUBDIVISIONS) {
+    return descriptor;
+  }
+  return Object.freeze({ cubicSubdivisions, generatorVersion: SLUG_GENERATOR_VERSION });
 }
 
-/** Derive the key shared by the fixed baker and runtime module. */
-export function slugDescriptorRasterKey(): RasterKey {
+/** Derive the key shared by the baker and runtime module. */
+export function slugDescriptorRasterKey(options?: SlugOptions): RasterKey {
   return deriveRasterKey({
-    descriptor,
+    descriptor: slugDescriptor(options),
     extension: SLUG_EXTENSION,
     kind: SLUG_KIND,
     version: SLUG_FORMAT_VERSION,
   });
+}
+
+/** Reject a rate the format cannot carry, naming the axis that is wrong. */
+export function normalizeSlugOptions(value: unknown): SlugOptions | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'object') {
+    throw new TypeError('Slug options must be an object');
+  }
+  const { cubicSubdivisions } = value as SlugOptions;
+  if (cubicSubdivisions === undefined) return undefined;
+  if (
+    !Number.isSafeInteger(cubicSubdivisions) ||
+    cubicSubdivisions < 1 ||
+    cubicSubdivisions > SLUG_MAX_CUBIC_SUBDIVISIONS
+  ) {
+    throw new TypeError(
+      `Slug cubicSubdivisions must be an integer from 1 to ${SLUG_MAX_CUBIC_SUBDIVISIONS}: ${String(cubicSubdivisions)}`,
+    );
+  }
+  return { cubicSubdivisions };
 }

--- a/packages/glyph/src/node/cli.ts
+++ b/packages/glyph/src/node/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import type { MsdfOptions } from '../internal/msdf-contract.js';
+import type { SlugOptions } from '../internal/slug-contract.js';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -249,6 +250,7 @@ interface DirectBakeArguments {
   readonly msdf: boolean;
   readonly msdfOptions?: MsdfOptions;
   readonly slug: boolean;
+  readonly slugOptions?: SlugOptions;
   readonly unicodeRanges?: readonly UnicodeRange[];
   readonly check: boolean;
   readonly split: boolean;
@@ -292,6 +294,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
   let msdf = false;
   let msdfOptions: MsdfOptions | undefined;
   let slug = false;
+  let slugOptions: SlugOptions | undefined;
   let unicodeRanges: readonly UnicodeRange[] | undefined;
   let check = false;
   let json = false;
@@ -332,7 +335,13 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
         msdfOptions = parseMsdfOptions(argv[++index]!);
       }
     } else if (argument === '--slug') {
+      if (slug) throw new TypeError('--slug may be provided only once');
       slug = true;
+      // Optional settings follow the flag exactly as --msdf's do.
+      const nextSlugArgument = argv[index + 1];
+      if (nextSlugArgument !== undefined && !nextSlugArgument.startsWith('-')) {
+        slugOptions = parseSlugOptions(argv[++index]!);
+      }
     } else if (argument === '--unicodes') {
       if (unicodeRanges !== undefined) throw new TypeError('--unicodes may be provided only once');
       unicodeRanges = parseUnicodeSet(valueAfter(argv, ++index, argument));
@@ -384,6 +393,7 @@ function parseBakeArguments(argv: readonly string[]): ParsedBakeArguments {
             msdf,
             ...(msdfOptions === undefined ? {} : { msdfOptions }),
             slug,
+            ...(slugOptions === undefined ? {} : { slugOptions }),
             ...(unicodeRanges === undefined ? {} : { unicodeRanges }),
             check,
             split,
@@ -520,7 +530,7 @@ async function directRasterPlans(options: DirectBakeArguments): Promise<DirectRa
   }
   if (options.slug) {
     const { slugBaker } = await import('../bakers/slug.js');
-    const plan = { baker: slugBaker, packaging, options: undefined };
+    const plan = { baker: slugBaker, packaging, options: options.slugOptions };
     plans.push(plan);
     resolutions.push(resolveRasterBakePlan(plan));
   }
@@ -548,6 +558,30 @@ function parseMsdfOptions(value: string): MsdfOptions {
     else throw new TypeError(`Unknown --msdf setting: ${key}`);
   }
   return options;
+}
+
+function parseSlugOptions(value: string): SlugOptions {
+  const options: { cubicSubdivisions?: number } = {};
+  for (const entry of value.split(',')) {
+    const separator = entry.indexOf('=');
+    if (separator < 1) {
+      throw new TypeError(`--slug settings must be key=value pairs: ${entry}`);
+    }
+    const key = entry.slice(0, separator).trim();
+    const raw = entry.slice(separator + 1).trim();
+    if (key === 'cubic-subdivisions') {
+      options.cubicSubdivisions = boundedInteger(raw, 'cubic-subdivisions', '--slug', 1, 16);
+    } else throw new TypeError(`Unknown --slug setting: ${key}`);
+  }
+  return options;
+}
+
+function boundedInteger(value: string, label: string, flag: string, low: number, high: number): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < low || parsed > high) {
+    throw new TypeError(`${flag} ${label} must be an integer from ${low} to ${high}: ${value}`);
+  }
+  return parsed;
 }
 
 function positiveInteger(value: string, label: string): number {
@@ -645,7 +679,9 @@ Raster options:
   --msdf [settings]      Embed the MSDF raster, optionally configured
                         Settings: em-size (default 64), pixel-range (default 8)
                         Example: --msdf em-size=32,pixel-range=6
-  --slug                 Embed the default Slug raster
+  --slug [settings]      Embed the Slug raster, optionally configured
+                        Settings: cubic-subdivisions (default 4, CFF sources only)
+                        Example: --slug cubic-subdivisions=8
                         With none selected, MSDF is baked
 
 Packaging options:

--- a/packages/glyph/src/raster/slug.ts
+++ b/packages/glyph/src/raster/slug.ts
@@ -5,6 +5,7 @@ import {
   SLUG_KIND,
   slugDescriptor,
   type SlugDescriptor,
+  type SlugOptions,
 } from '../internal/slug-contract.js';
 import {
   defineRasterFormat,
@@ -23,7 +24,10 @@ export {
   SLUG_PLANE_UNITS_PER_EM,
   slugDescriptor,
   slugDescriptorRasterKey,
+  SLUG_CUBIC_SUBDIVISIONS,
+  SLUG_MAX_CUBIC_SUBDIVISIONS,
   type SlugDescriptor,
+  type SlugOptions,
 } from '../internal/slug-contract.js';
 
 const ABSENT_PAGE = 0xffff;
@@ -50,26 +54,31 @@ export interface SlugData {
 }
 
 /** Renderer-neutral Slug identity, decoding, and ownership. */
-export const slug: RasterFormat<RasterFormatId & 'pmndrs.slug', typeof SLUG_KIND, undefined, SlugDescriptor, SlugData> =
-  defineRasterFormat({
-    id: 'pmndrs.slug',
-    kind: SLUG_KIND,
-    extension: SLUG_EXTENSION,
-    version: SLUG_FORMAT_VERSION,
-    textEffects: [],
-    runtimeBaker: () => import('../runtime-bakers/slug.js'),
-    descriptor(): SlugDescriptor {
-      return slugDescriptor();
-    },
-    async decode(font, raster, signal): Promise<SlugData> {
-      signal?.throwIfAborted();
-      const { decodeSlugData } = await import('./internal/slug-decoder.js');
-      const data = await decodeSlugData(font, raster, signal);
-      signal?.throwIfAborted();
-      return data;
-    },
-    dispose() {},
-  });
+export const slug: RasterFormat<
+  RasterFormatId & 'pmndrs.slug',
+  typeof SLUG_KIND,
+  SlugOptions | undefined,
+  SlugDescriptor,
+  SlugData
+> = defineRasterFormat({
+  id: 'pmndrs.slug',
+  kind: SLUG_KIND,
+  extension: SLUG_EXTENSION,
+  version: SLUG_FORMAT_VERSION,
+  textEffects: [],
+  runtimeBaker: () => import('../runtime-bakers/slug.js'),
+  descriptor(options: SlugOptions | undefined): SlugDescriptor {
+    return slugDescriptor(options);
+  },
+  async decode(font, raster, signal): Promise<SlugData> {
+    signal?.throwIfAborted();
+    const { decodeSlugData } = await import('./internal/slug-decoder.js');
+    const data = await decodeSlugData(font, raster, signal);
+    signal?.throwIfAborted();
+    return data;
+  },
+  dispose() {},
+});
 
 import { f32, techniqueProgram, u32 } from '../config/codec-program.js';
 import { id, type CodecBufferId } from '../config/codec.js';

--- a/packages/glyph/src/react/slug.ts
+++ b/packages/glyph/src/react/slug.ts
@@ -1,24 +1,26 @@
 import type { Font } from '../font.js';
 import type { FontFaceSource } from '../font-face.js';
 import { useFont } from '../react.js';
-import { slug } from '../raster/slug.js';
+import { slug, type SlugOptions } from '../raster/slug.js';
 
 /** Slug convenience hook over the shared `useFont` Suspense resource. */
 export interface UseSlug {
-  (input: FontFaceSource): Font<typeof slug>;
+  (input: FontFaceSource, options?: SlugOptions): Font<typeof slug>;
   /** Start the same cached Slug load before a component requests it. */
-  preload(input: FontFaceSource): Promise<void>;
+  preload(input: FontFaceSource, options?: SlugOptions): Promise<void>;
   /** Release the cached Slug lease without invalidating mounted consumers. */
-  clear(input: FontFaceSource): void;
+  clear(input: FontFaceSource, options?: SlugOptions): void;
 }
 
 /** Load one Slug font through the shared React Suspense resource. */
 export const useSlug: UseSlug = Object.assign(
-  function useSlug(input: FontFaceSource): Font<typeof slug> {
-    return useFont(input, { format: slug });
+  function useSlug(input: FontFaceSource, options?: SlugOptions): Font<typeof slug> {
+    return useFont(input, { format: options === undefined ? slug : slug(options) });
   },
   {
-    preload: (input: FontFaceSource) => useFont.preload(input, { format: slug }),
-    clear: (input: FontFaceSource) => useFont.clear(input, { format: slug }),
+    preload: (input: FontFaceSource, options?: SlugOptions) =>
+      useFont.preload(input, { format: options === undefined ? slug : slug(options) }),
+    clear: (input: FontFaceSource, options?: SlugOptions) =>
+      useFont.clear(input, { format: options === undefined ? slug : slug(options) }),
   },
 );

--- a/packages/glyph/src/runtime-bake-worker.ts
+++ b/packages/glyph/src/runtime-bake-worker.ts
@@ -193,7 +193,8 @@ function runtimeMsdfDescriptor(value: JsonValue): MsdfDescriptor {
 function runtimeSlugDescriptor(value: JsonValue): SlugDescriptor {
   const record = jsonRecord(value, 'Slug');
   if (record.generatorVersion !== SLUG_GENERATOR_VERSION) throw new TypeError('invalid runtime Slug descriptor');
-  const descriptor = slugDescriptor();
+  const cubicSubdivisions = optionalNumber(record.cubicSubdivisions, 'Slug cubic subdivisions');
+  const descriptor = slugDescriptor(cubicSubdivisions === undefined ? undefined : { cubicSubdivisions });
   assertCanonicalDescriptor(value, descriptor, 'Slug');
   return descriptor;
 }

--- a/packages/glyph/src/runtime-bakers/slug-worker.ts
+++ b/packages/glyph/src/runtime-bakers/slug-worker.ts
@@ -1,11 +1,7 @@
 /// <reference lib="webworker" />
 
-import slugBaker, { type SlugBakerOptions } from '../bakers/slug.js';
+import slugBaker from '../bakers/slug.js';
 import { startRasterBakeWorker } from '../internal/raster-bake-worker-entry.js';
+import { normalizeSlugOptions } from '../internal/slug-contract.js';
 
 startRasterBakeWorker(slugBaker, normalizeSlugOptions);
-
-function normalizeSlugOptions(value: unknown): SlugBakerOptions {
-  if (value !== undefined) throw new TypeError('Slug runtime baker does not accept options');
-  return undefined;
-}

--- a/packages/glyph/tests/types/r3f-v1-api.test.ts
+++ b/packages/glyph/tests/types/r3f-v1-api.test.ts
@@ -81,12 +81,14 @@ function FontConsumer(): null {
   useMsdf('/fonts/Inter.font.glb') satisfies Font<typeof msdf>;
   useMsdf('/fonts/Inter.font.glb', { emSize: 64, pixelRange: 8 }) satisfies Font<typeof msdf>;
   useSlug('/fonts/Inter.font.glb') satisfies Font<typeof slug>;
+  useSlug('/fonts/Inter.font.glb', { cubicSubdivisions: 8 }) satisfies Font<typeof slug>;
   void loaded;
   useFont('/fonts/Inter.font.glb', { format: bitmap({ strikes: [16] }) }) satisfies Font<typeof bitmap>;
   // @ts-expect-error Bitmap's exact request helper requires bake options.
   bitmap();
-  // @ts-expect-error Slug has no request options.
-  slug({});
+  slug({ cubicSubdivisions: 8 });
+  // @ts-expect-error Slug's only option is the cubic subdivision rate.
+  slug({ emSize: 64 });
   // @ts-expect-error FontFace hooks use the canonical source directly, not the legacy loader request object.
   useFont({ baked: '/fonts/Inter.font.glb' });
   return null;


### PR DESCRIPTION
Two changes from the #114 investigation. Neither makes CFF fonts work — that needs an outline table skera cannot produce. Implementation notes for the real fix are on #114.

## Refuse a font with no outline table

A CFF font reaches the raster bakers with no outline table at all, because subsetting drops `CFF ` outright. Every glyph then resolves to "no outline", which each baker recorded identically to a glyph the coverage set never selected. The artifact came out structurally whole, `missingGlyphCount` 0, and rendered nothing.

Each baker now checks the outline format **once before its glyph loop** and refuses with `InvalidFont` naming the cause. Bitmap, MTSDF and Slug are all affected and all three are fixed.

Covered by a test that strips `glyf`s directory record from Inter and asserts the bake is refused by code and message.

## Slug: configurable cubic subdivision, default 4

Slug fitted a fixed two quadratics to every CFF cubic with no error check. Measured over Dancing Scripts 9,468 cubics:

| subdivision | max err | p99 | mean | max @200px | over 0.5u |
|---|---:|---:|---:|---:|---:|
| 2 (previous) | 8.32u | 2.48u | 0.41u | 1.67 px | 25.2% |
| **4 (new default)** | 1.15u | 0.45u | 0.06u | 0.23 px | 0.7% |
| 8 | 0.14u | 0.06u | 0.01u | 0.03 px | 0.0% |

Slug is resolution independent, so that error grows with render size.

This is a trade, not a free win: Slug ships these curves to the GPU and the fragment shader walks every curve in a pixels band on **both** axes, so twice the curves is twice the payload and twice that inner loop. Hence the knob — `SlugOptions.cubicSubdivisions` in TypeScript, `--slug cubic-subdivisions=N` on the CLI — so a caller can trade the other way.

Only CFF sources reach this code; TrueType outlines are already quadratic and ignore it.

### Nothing existing is rewritten

- No shipped artifact contains CFF-derived curves, because subsetting drops the table (#114). The Inter determinism test is unmoved.
- The default rate stays **absent** from the descriptor, so the default raster key is byte-identical. Both the default and a configured key are now pinned in a Rust test against values derived independently in JavaScript, tying the Rust canonical serializer to the TypeScript one across the ABI. That caught a real bug: `descriptor_raster_key` hard-coded the canonical JSON and would have derived a different key than TS for any configured rate.
- A rate of 2 still reproduces the legacy payload exactly — the half split keeps the original midpoint arithmetic, since `(a + b) * 0.5` and `a + (b - a) * 0.5` are not bit-identical in f32.

## Verification

`cargo test` and `cargo clippy -D warnings` clean on slug-core, slug-fontations, slug-baker, bitmap-baker, mtsdf-baker; `tsc --noEmit` clean; OKF validation 0/0/0.