### PR TITLE
docs(repo): condense comments

### DIFF
--- a/.agents/docs/packages/examples.md
+++ b/.agents/docs/packages/examples.md
@@ -5,7 +5,7 @@ description: Demonstrates matching public imperative Three.js and React Three Fi
 resource: ../../../apps/r3f-hello-world
 workspace_package: '@pmndrs/glyph-examples'
 documentation_type: reference
-source_digest: 'sha256:670e6f8beed4d7052fd870d2314d802826bfabd3a11ab79159f595a791523870'
+source_digest: 'sha256:104e998617fa651bec492485f897ec9fabdc01130e5d4061bcc525ed60b50a2d'
 tags: [package, example, three, react, react-three-fiber, vite]
 sources:
   - id: manifest

--- a/apps/benchmarks/scripts/benchmark-text-engine-kernels.mts
+++ b/apps/benchmarks/scripts/benchmark-text-engine-kernels.mts
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "glyph:kernel-lab-browser",
-  "summary": "Runs the scalar, auto-vectorized, and explicit SIMD retained-engine kernel packet in project Chromium.",
-  "requirements": "Built @pmndrs/glyph and package-local kernel-lab artifacts. Accepts --json.",
-  "writes": "stdout only, or the JSON report path passed to --json"
-} */
+/* @workflow { "name": "glyph:kernel-lab-browser", "summary": "Runs the scalar, auto-vectorized, and explicit SIMD retained-engine kernel packet in project Chromium.", "requirements": "Built @pmndrs/glyph and package-local kernel-lab artifacts. Accepts --json.", "writes": "stdout only, or the JSON report path passed to --json" } */
 import { readFile, writeFile } from 'node:fs/promises';
 import { createServer, type Server } from 'node:http';
 import type { Browser } from 'playwright';

--- a/apps/benchmarks/scripts/capture-browser-reference.mts
+++ b/apps/benchmarks/scripts/capture-browser-reference.mts
@@ -1,12 +1,5 @@
 import { spawn } from 'node:child_process';
-/* @workflow
-{
-  "name": "benchmark:browser-reference",
-  "summary": "Regenerate the authenticated browser-rendered Inter visual reference.",
-  "requirements": "Playwright Chromium and the licensed Inter fixture.",
-  "writes": "Checked-in browser reference PNG and manifest."
-}
-*/
+/* @workflow { "name": "benchmark:browser-reference", "summary": "Regenerate the authenticated browser-rendered Inter visual reference.", "requirements": "Playwright Chromium and the licensed Inter fixture.", "writes": "Checked-in browser reference PNG and manifest." } */
 import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';

--- a/apps/benchmarks/scripts/capture-presentation-workloads.mts
+++ b/apps/benchmarks/scripts/capture-presentation-workloads.mts
@@ -1,11 +1,4 @@
-/* @workflow
-{
-  "name": "benchmark:presentation-screenshots",
-  "summary": "Capture verified Presentation screenshots for every workload and backend.",
-  "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.",
-  "writes": "Ignored apps/benchmarks/.cache/presentation-screenshots files."
-}
-*/
+/* @workflow { "name": "benchmark:presentation-screenshots", "summary": "Capture verified Presentation screenshots for every workload and backend.", "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.", "writes": "Ignored apps/benchmarks/.cache/presentation-screenshots files." } */
 process.env.PRESENTATION_SCREENSHOT_DIR ??= './.cache/presentation-screenshots';
 
 const { runPresentationProbeMatrix } = await import('./support/run-presentation-probe-matrix.mts');

--- a/apps/benchmarks/scripts/capture-slug-external-render-parity.mts
+++ b/apps/benchmarks/scripts/capture-slug-external-render-parity.mts
@@ -1,11 +1,4 @@
-/* @workflow
-{
-  "name": "benchmark:slug-external-parity",
-  "summary": "Regenerate the live external-resource Slug parity evidence.",
-  "requirements": "GPU-enabled Chromium, Vitexec, and runtime package builds.",
-  "writes": "Checked-in Slug external parity evidence and temporary artifacts."
-}
-*/
+/* @workflow { "name": "benchmark:slug-external-parity", "summary": "Regenerate the live external-resource Slug parity evidence.", "requirements": "GPU-enabled Chromium, Vitexec, and runtime package builds.", "writes": "Checked-in Slug external parity evidence and temporary artifacts." } */
 import { spawn } from 'node:child_process';
 import { basename, join, resolve } from 'node:path';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';

--- a/apps/benchmarks/scripts/check-bake-fixtures.mts
+++ b/apps/benchmarks/scripts/check-bake-fixtures.mts
@@ -1,12 +1,4 @@
-/* @workflow
-{
-  "name": "benchmark:bake-check",
-  "summary": "Verify every deterministic benchmark bake and authenticated Japanese subset.",
-  "requirements": "Core toolchain plus the scoped HarfBuzz utilities for the Japanese subset.",
-  "writes": "Temporary build outputs only; checked-in fixtures must remain unchanged.",
-  "args": []
-}
-*/
+/* @workflow { "name": "benchmark:bake-check", "summary": "Verify every deterministic benchmark bake and authenticated Japanese subset.", "requirements": "Core toolchain plus the scoped HarfBuzz utilities for the Japanese subset.", "writes": "Temporary build outputs only; checked-in fixtures must remain unchanged.", "args": [] } */
 
 import { buildRuntimePackages, isMainModule, runNodeScript } from './support/command-cli.mts';
 

--- a/apps/benchmarks/scripts/check-knowledge-base.mts
+++ b/apps/benchmarks/scripts/check-knowledge-base.mts
@@ -1,16 +1,5 @@
-/* @workflow {
-  "name": "docs:check",
-  "summary": "Validate the Open Knowledge Format agent archive under .agents/docs, including every concept source_digest.",
-  "requirements": "Ruby from the root mise toolchain. Run through mise so the interpreter resolves.",
-  "writes": "stdout"
-} */
-/* @workflow {
-  "name": "docs:update",
-  "args": ["--write"],
-  "summary": "Re-pin every package concept source_digest from the working tree, then validate the bundle.",
-  "requirements": "Ruby from the root mise toolchain. Run through mise so the interpreter resolves.",
-  "writes": ".agents/docs/packages/*.md source_digest pins and stdout"
-} */
+/* @workflow { "name": "docs:check", "summary": "Validate the Open Knowledge Format agent archive under .agents/docs, including every concept source_digest.", "requirements": "Ruby from the root mise toolchain. Run through mise so the interpreter resolves.", "writes": "stdout" } */
+/* @workflow { "name": "docs:update", "args": ["--write"], "summary": "Re-pin every package concept source_digest from the working tree, then validate the bundle.", "requirements": "Ruby from the root mise toolchain. Run through mise so the interpreter resolves.", "writes": ".agents/docs/packages/*.md source_digest pins and stdout" } */
 import { execFile } from 'node:child_process';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
@@ -23,26 +12,13 @@ const skillScripts = '../../.agents/skills/open-knowledge-format/scripts';
 const validator = `${skillScripts}/validate_okf.rb`;
 const generator = `${skillScripts}/generate_package_digests.rb`;
 
-/**
- * Validate the repository knowledge bundle, optionally re-pinning it first.
- *
- * A package source or configuration change invalidates the matching concept's `source_digest`, and
- * a stale digest fails this gate. The commit hook that would otherwise re-pin silently no-ops when
- * Ruby is missing from the shell, so `--write` is the reliable way to apply what the gate demands
- * without hand-editing a hash.
- */
+/** Validates the OKF bundle; pass `write: true` to re-pin every `source_digest` first. */
 export async function runKnowledgeBaseCheck(options: { readonly write?: boolean } = {}): Promise<void> {
   if (options.write === true) await repinPackageDigests();
   await run('ruby', [validator, '../../.agents/docs', '--workspace-root', '../..']);
 }
 
-/**
- * Recompute every workspace package digest and rewrite the concept that pins it.
- *
- * The digest covers the package tree as it exists on disk, so this reflects the working tree rather
- * than the index. That is what a contributor wants when reacting to a failed gate; the commit hook
- * is the one that must hash staged content instead.
- */
+/** Hashes package files on disk, not the git index — the commit hook hashes staged content instead. */
 async function repinPackageDigests(): Promise<void> {
   // Captured rather than streamed: the generator reports every workspace package, and echoing
   // that table would bury the one line a contributor needs, which is what actually changed.

--- a/apps/benchmarks/scripts/check-paragraph-contract-fixtures.mts
+++ b/apps/benchmarks/scripts/check-paragraph-contract-fixtures.mts
@@ -84,12 +84,4 @@ function assertEqual(actual: unknown, expected: unknown, label: string): void {
   if (!Object.is(actual, expected)) throw new Error(`${label}: ${String(actual)} !== ${String(expected)}`);
 }
 
-/* @workflow
-{
-  "name": "fixture:paragraph-contracts:check",
-  "summary": "Authenticate retained paragraph contracts, their source fonts, shaping payloads, and independent oracles.",
-  "requirements": "Built runtime packages plus checked-in paragraph fonts, contracts, and shaping oracles.",
-  "writes": "Nothing. Behavioral equivalence is checked by the public paragraph-contracts browser target.",
-  "args": []
-}
-*/
+/* @workflow { "name": "fixture:paragraph-contracts:check", "summary": "Authenticate retained paragraph contracts, their source fonts, shaping payloads, and independent oracles.", "requirements": "Built runtime packages plus checked-in paragraph fonts, contracts, and shaping oracles.", "writes": "Nothing. Behavioral equivalence is checked by the public paragraph-contracts browser target.", "args": [] } */

--- a/apps/benchmarks/scripts/generate-harfbuzz-oracle.mts
+++ b/apps/benchmarks/scripts/generate-harfbuzz-oracle.mts
@@ -130,20 +130,5 @@ if (check) {
 } else {
   await writeFile(resolve(outputPath), output);
 }
-/* @workflow
-{
-  "name": "fixture:harfbuzz-oracle:generate",
-  "summary": "Regenerate the pinned HarfBuzz shaping oracle.",
-  "requirements": "Provisioned HarfBuzz tools and authenticated fonts.",
-  "writes": "Checked-in HarfBuzz oracle fixtures."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:harfbuzz-oracle:check",
-  "summary": "Verify the pinned HarfBuzz shaping oracle.",
-  "requirements": "Provisioned HarfBuzz tools and authenticated fonts.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:harfbuzz-oracle:generate", "summary": "Regenerate the pinned HarfBuzz shaping oracle.", "requirements": "Provisioned HarfBuzz tools and authenticated fonts.", "writes": "Checked-in HarfBuzz oracle fixtures." } */
+/* @workflow { "name": "fixture:harfbuzz-oracle:check", "summary": "Verify the pinned HarfBuzz shaping oracle.", "requirements": "Provisioned HarfBuzz tools and authenticated fonts.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/generate-japanese-showcase-subset.mts
+++ b/apps/benchmarks/scripts/generate-japanese-showcase-subset.mts
@@ -109,20 +109,5 @@ async function run(command: string, arguments_: readonly string[]): Promise<void
     });
   });
 }
-/* @workflow
-{
-  "name": "fixture:japanese-showcase:generate",
-  "summary": "Regenerate the authenticated Japanese showcase subset.",
-  "requirements": "Provisioned HarfBuzz tools and the source CJK font.",
-  "writes": "Checked-in Japanese showcase fixture."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:japanese-showcase:check",
-  "summary": "Verify the authenticated Japanese showcase subset.",
-  "requirements": "Provisioned HarfBuzz tools and the source CJK font.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:japanese-showcase:generate", "summary": "Regenerate the authenticated Japanese showcase subset.", "requirements": "Provisioned HarfBuzz tools and the source CJK font.", "writes": "Checked-in Japanese showcase fixture." } */
+/* @workflow { "name": "fixture:japanese-showcase:check", "summary": "Verify the authenticated Japanese showcase subset.", "requirements": "Provisioned HarfBuzz tools and the source CJK font.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/generate-mtsdf-render-fixture.mts
+++ b/apps/benchmarks/scripts/generate-mtsdf-render-fixture.mts
@@ -182,20 +182,5 @@ function formatBytes(bytes: number): string {
 function formatDuration(milliseconds: number): string {
   return `${(milliseconds / 1_000).toFixed(1)} s`;
 }
-/* @workflow
-{
-  "name": "fixture:mtsdf-render:generate",
-  "summary": "Regenerate the canonical MTSDF render fixture.",
-  "requirements": "Built runtime packages and authenticated Inter.",
-  "writes": "Checked-in MTSDF render fixture."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:mtsdf-render:check",
-  "summary": "Verify the canonical MTSDF render fixture.",
-  "requirements": "Built runtime packages and authenticated Inter.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:mtsdf-render:generate", "summary": "Regenerate the canonical MTSDF render fixture.", "requirements": "Built runtime packages and authenticated Inter.", "writes": "Checked-in MTSDF render fixture." } */
+/* @workflow { "name": "fixture:mtsdf-render:check", "summary": "Verify the canonical MTSDF render fixture.", "requirements": "Built runtime packages and authenticated Inter.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/generate-paragraph-bidi-contract.mts
+++ b/apps/benchmarks/scripts/generate-paragraph-bidi-contract.mts
@@ -193,20 +193,5 @@ function firstDifference(left: string, right: string): number {
   return length;
 }
 
-/* @workflow
-{
-  "name": "fixture:paragraph-bidi:generate",
-  "summary": "Regenerate the public Rust paragraph bidi contract fixture.",
-  "requirements": "Built runtime packages and authenticated checked-in fonts.",
-  "writes": "Checked-in paragraph bidi contract."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:paragraph-bidi:check",
-  "summary": "Verify the public Rust paragraph bidi contract fixture by deterministic regeneration.",
-  "requirements": "Built runtime packages and authenticated checked-in fonts.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:paragraph-bidi:generate", "summary": "Regenerate the public Rust paragraph bidi contract fixture.", "requirements": "Built runtime packages and authenticated checked-in fonts.", "writes": "Checked-in paragraph bidi contract." } */
+/* @workflow { "name": "fixture:paragraph-bidi:check", "summary": "Verify the public Rust paragraph bidi contract fixture by deterministic regeneration.", "requirements": "Built runtime packages and authenticated checked-in fonts.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/generate-paragraph-cjk-contract.mts
+++ b/apps/benchmarks/scripts/generate-paragraph-cjk-contract.mts
@@ -112,20 +112,5 @@ function firstDifference(left: string, right: string): number {
   return length;
 }
 
-/* @workflow
-{
-  "name": "fixture:paragraph-cjk:generate",
-  "summary": "Regenerate the public Rust paragraph CJK contract fixture.",
-  "requirements": "Built runtime packages, the core baker, and authenticated checked-in fonts.",
-  "writes": "Checked-in paragraph CJK contract."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:paragraph-cjk:check",
-  "summary": "Verify the public Rust paragraph CJK contract fixture by deterministic regeneration.",
-  "requirements": "Built runtime packages, the core baker, and authenticated checked-in fonts.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:paragraph-cjk:generate", "summary": "Regenerate the public Rust paragraph CJK contract fixture.", "requirements": "Built runtime packages, the core baker, and authenticated checked-in fonts.", "writes": "Checked-in paragraph CJK contract." } */
+/* @workflow { "name": "fixture:paragraph-cjk:check", "summary": "Verify the public Rust paragraph CJK contract fixture by deterministic regeneration.", "requirements": "Built runtime packages, the core baker, and authenticated checked-in fonts.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/generate-paragraph-conformance-font.mts
+++ b/apps/benchmarks/scripts/generate-paragraph-conformance-font.mts
@@ -36,20 +36,5 @@ try {
   if (temporaryDirectory !== undefined) await rm(temporaryDirectory, { recursive: true, force: true });
 }
 
-/* @workflow
-{
-  "name": "fixture:paragraph-conformance-font:generate",
-  "summary": "Generate the sparse Bitmap font used by public Rust paragraph conformance.",
-  "requirements": "Built runtime packages and authenticated Noto Sans CJK source font.",
-  "writes": "Checked-in sparse paragraph conformance font asset."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:paragraph-conformance-font:check",
-  "summary": "Verify the sparse Bitmap font used by public Rust paragraph conformance.",
-  "requirements": "Built runtime packages and authenticated Noto Sans CJK source font.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:paragraph-conformance-font:generate", "summary": "Generate the sparse Bitmap font used by public Rust paragraph conformance.", "requirements": "Built runtime packages and authenticated Noto Sans CJK source font.", "writes": "Checked-in sparse paragraph conformance font asset." } */
+/* @workflow { "name": "fixture:paragraph-conformance-font:check", "summary": "Verify the sparse Bitmap font used by public Rust paragraph conformance.", "requirements": "Built runtime packages and authenticated Noto Sans CJK source font.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/generate-showcase-raster-fixtures.mts
+++ b/apps/benchmarks/scripts/generate-showcase-raster-fixtures.mts
@@ -160,20 +160,5 @@ try {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }
 }
-/* @workflow
-{
-  "name": "fixture:showcase-rasters:generate",
-  "summary": "Regenerate canonical showcase raster artifacts.",
-  "requirements": "Built runtime packages and authenticated source fonts.",
-  "writes": "Checked-in showcase raster fixtures."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:showcase-rasters:check",
-  "summary": "Verify canonical showcase raster artifacts.",
-  "requirements": "Built runtime packages and authenticated source fonts.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:showcase-rasters:generate", "summary": "Regenerate canonical showcase raster artifacts.", "requirements": "Built runtime packages and authenticated source fonts.", "writes": "Checked-in showcase raster fixtures." } */
+/* @workflow { "name": "fixture:showcase-rasters:check", "summary": "Verify canonical showcase raster artifacts.", "requirements": "Built runtime packages and authenticated source fonts.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/generate-slug-render-fixture.mts
+++ b/apps/benchmarks/scripts/generate-slug-render-fixture.mts
@@ -167,20 +167,5 @@ function formatBytes(bytes: number): string {
 function formatDuration(milliseconds: number): string {
   return `${(milliseconds / 1_000).toFixed(1)} s`;
 }
-/* @workflow
-{
-  "name": "fixture:slug-render:generate",
-  "summary": "Regenerate the canonical Slug render fixture.",
-  "requirements": "Built runtime packages and authenticated Inter.",
-  "writes": "Checked-in Slug render fixture."
-}
-*/
-/* @workflow
-{
-  "name": "fixture:slug-render:check",
-  "summary": "Verify the canonical Slug render fixture.",
-  "requirements": "Built runtime packages and authenticated Inter.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:slug-render:generate", "summary": "Regenerate the canonical Slug render fixture.", "requirements": "Built runtime packages and authenticated Inter.", "writes": "Checked-in Slug render fixture." } */
+/* @workflow { "name": "fixture:slug-render:check", "summary": "Verify the canonical Slug render fixture.", "requirements": "Built runtime packages and authenticated Inter.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/measure-package-sizes.mts
+++ b/apps/benchmarks/scripts/measure-package-sizes.mts
@@ -626,20 +626,5 @@ if (process.argv.includes('--check')) {
   await writeFile(output, serialized);
   process.stdout.write(serialized);
 }
-/* @workflow
-{
-  "name": "release:size:generate",
-  "summary": "Regenerate reviewed package-size evidence.",
-  "requirements": "Built runtime packages and Binaryen.",
-  "writes": "Checked-in package-size evidence."
-}
-*/
-/* @workflow
-{
-  "name": "release:size:check",
-  "summary": "Verify package-size identity and reviewed ceilings.",
-  "requirements": "Built runtime packages and Binaryen.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "release:size:generate", "summary": "Regenerate reviewed package-size evidence.", "requirements": "Built runtime packages and Binaryen.", "writes": "Checked-in package-size evidence." } */
+/* @workflow { "name": "release:size:check", "summary": "Verify package-size identity and reviewed ceilings.", "requirements": "Built runtime packages and Binaryen.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/provision-harfbuzz.mts
+++ b/apps/benchmarks/scripts/provision-harfbuzz.mts
@@ -118,21 +118,5 @@ async function run(command: string, arguments_: readonly string[]): Promise<void
     });
   });
 }
-/* @workflow
-{
-  "name": "fixture:harfbuzz:provision",
-  "summary": "Provision authenticated HarfBuzz command-line tools.",
-  "requirements": "Scoped benchmark mise tools, Meson, Ninja, GLib, and network access.",
-  "writes": "Ignored HarfBuzz tool cache.",
-  "args": ["--version=13.0.0", "--version=14.2.0"]
-}
-*/
-/* @workflow
-{
-  "name": "fixture:harfbuzz:check",
-  "summary": "Verify the provisioned HarfBuzz command-line tools.",
-  "requirements": "Previously provisioned HarfBuzz tools.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "fixture:harfbuzz:provision", "summary": "Provision authenticated HarfBuzz command-line tools.", "requirements": "Scoped benchmark mise tools, Meson, Ninja, GLib, and network access.", "writes": "Ignored HarfBuzz tool cache.", "args": ["--version=13.0.0", "--version=14.2.0"] } */
+/* @workflow { "name": "fixture:harfbuzz:check", "summary": "Verify the provisioned HarfBuzz command-line tools.", "requirements": "Previously provisioned HarfBuzz tools.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/run-live-update-latency-probe.mts
+++ b/apps/benchmarks/scripts/run-live-update-latency-probe.mts
@@ -1,24 +1,12 @@
-/* @workflow {
-  "name": "probe:live-update-latency",
-  "summary": "Measures input-to-visible-frame latency and verifies retained reflow for live text, font-size, layout-width, and viewport changes per raster format.",
-  "requirements": "Playwright Chromium with WebGPU. Set PROBE_BACKEND=webgl2 to measure the fallback backend.",
-  "writes": "stdout only"
-} */
+/* @workflow { "name": "probe:live-update-latency", "summary": "Measures input-to-visible-frame latency and verifies retained reflow for live text, font-size, layout-width, and viewport changes per raster format.", "requirements": "Playwright Chromium with WebGPU. Set PROBE_BACKEND=webgl2 to measure the fallback backend.", "writes": "stdout only" } */
 import { fileURLToPath } from 'node:url';
 import type { Browser, Page } from 'playwright';
 import { createServer } from 'vite';
 
 import { launchProjectChromium } from './support/project-chromium.mts';
 
-/**
- * Answers one question per technique and per kind of change: after the surface receives an input, how many rendered
- * frames pass before the canvas shows the result, and how many distinct frames does the presentation pass through?
- *
- * The signal is the presented canvas rather than harness telemetry. Live stats publish on a 250 ms report interval,
- * which would swamp the latency being measured, and instrumenting the update path would measure the instrumentation.
- * Sampling the canvas once per animation frame measures what a viewer sees. Every run also samples an idle window, so
- * a distinct-frame count can never be read as motion when it is really sampling noise.
- */
+/** Samples the presented canvas per frame, not harness telemetry (its 250 ms interval would swamp this signal).
+ * Every run also samples an idle window so a distinct-frame count is never read as motion that is really noise. */
 
 const root = fileURLToPath(new URL('..', import.meta.url));
 process.chdir(root);
@@ -222,14 +210,8 @@ async function observeControl(
   return observations;
 }
 
-/**
- * Measures how far the presented paragraph lags the paragraph the surface has already committed.
- *
- * The typewriter runs at full reveal speed, faster than one grapheme per frame, and then the window opens on the very
- * task that pauses it. From that instant the source text is fixed, so every further distinct frame is the harness
- * still catching up: queued updates it had not applied, or a glyph transition still travelling toward a layout that
- * settled frames ago. A presentation that keeps pace goes quiet immediately.
- */
+/** Measures how far the presented paragraph lags the committed one: the window opens the instant the
+ * typewriter pauses, so any further distinct frame is the harness still catching up, not new motion. */
 async function observeTypewriter(page: Page): Promise<readonly FrameObservation[]> {
   const observations: FrameObservation[] = [];
   for (let step = 0; step < stepCount; step += 1) {
@@ -261,10 +243,7 @@ async function setRangeValue(control: ReturnType<Page['getByLabel']>, value: str
   }, value);
 }
 
-/**
- * Installs the per-frame canvas sampler as a page global so both the idle baseline and the input measurement run the
- * identical code path, with the input applied inside the same task that requests the first sampled frame.
- */
+/** Installs the sampler as a page global so the idle baseline and the input measurement share the identical code path. */
 function installCanvasProbe(): void {
   window.liveUpdateCanvasProbe = {
     observe(windowMs: number, input?: HTMLElement, value = '') {

--- a/apps/benchmarks/scripts/run-mobile-probe.mts
+++ b/apps/benchmarks/scripts/run-mobile-probe.mts
@@ -1,11 +1,4 @@
-/* @workflow
-{
-  "name": "benchmark:responsive",
-  "summary": "Verify phone, tablet, and desktop benchmark layouts in a real browser.",
-  "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.",
-  "writes": "Temporary screenshots under /tmp."
-}
-*/
+/* @workflow { "name": "benchmark:responsive", "summary": "Verify phone, tablet, and desktop benchmark layouts in a real browser.", "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.", "writes": "Temporary screenshots under /tmp." } */
 import { fileURLToPath } from 'node:url';
 import type { Browser, Page } from 'playwright';
 import { createServer } from 'vite';

--- a/apps/benchmarks/scripts/run-presentation-demo-matrix.mts
+++ b/apps/benchmarks/scripts/run-presentation-demo-matrix.mts
@@ -1,11 +1,4 @@
-/* @workflow
-{
-  "name": "benchmark:demo",
-  "summary": "Run the complete timed Presentation demo on WebGPU and WebGL2.",
-  "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.",
-  "writes": "Ignored browser caches only."
-}
-*/
+/* @workflow { "name": "benchmark:demo", "summary": "Run the complete timed Presentation demo on WebGPU and WebGL2.", "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.", "writes": "Ignored browser caches only." } */
 import { runPresentationProbeMatrix } from './support/run-presentation-probe-matrix.mts';
 
 await runPresentationProbeMatrix({

--- a/apps/benchmarks/scripts/run-presentation-workload-matrix.mts
+++ b/apps/benchmarks/scripts/run-presentation-workload-matrix.mts
@@ -1,11 +1,4 @@
-/* @workflow
-{
-  "name": "benchmark:presentation",
-  "summary": "Render every workload through Bitmap, MTSDF, and Slug on WebGPU and WebGL2.",
-  "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.",
-  "writes": "Ignored browser caches only."
-}
-*/
+/* @workflow { "name": "benchmark:presentation", "summary": "Render every workload through Bitmap, MTSDF, and Slug on WebGPU and WebGL2.", "requirements": "GPU-enabled Chromium and authenticated benchmark fixtures.", "writes": "Ignored browser caches only." } */
 import { runPresentationProbeMatrix } from './support/run-presentation-probe-matrix.mts';
 
 const backends = ['webgpu', 'webgl2'] as const;

--- a/apps/benchmarks/scripts/run-presentation-workload-probe.mts
+++ b/apps/benchmarks/scripts/run-presentation-workload-probe.mts
@@ -236,12 +236,8 @@ try {
   await server.close();
 }
 
-/**
- * Waits until the named workload owns the viewport at its authored configuration and is publishing frames.
- *
- * `requireZoomBuildUp` is the one condition that is not a mount invariant: Zoom text only reaches its reported scale
- * part-way through its own cycle, so the settled-mount sample must not wait for it.
- */
+/** Waits until the named workload owns the viewport at its authored configuration and is publishing frames.
+ * `requireZoomBuildUp` is excluded from settle-on-mount: Zoom text reaches its reported scale mid-cycle. */
 async function waitForSettledWorkload(
   page: Page,
   workload: (typeof workloads)[number],
@@ -277,10 +273,7 @@ async function waitForSettledWorkload(
   );
 }
 
-/**
- * Draw and glyph counts are the batching evidence for one cell: the renderer issues one draw per packed glyph run, so
- * a change in batch topology shows up here and nowhere else in the probe output.
- */
+/** Draw/glyph counts are the batching evidence for one cell — the renderer issues one draw per packed glyph run. */
 async function readBatching(page: Page): Promise<{ readonly drawCount: number; readonly glyphCount: number }> {
   return page.evaluate(() => {
     const viewport = document.querySelector<HTMLElement>('[data-testid="comparison-live-viewport"]');

--- a/apps/benchmarks/scripts/run-raster-technique-compare.mts
+++ b/apps/benchmarks/scripts/run-raster-technique-compare.mts
@@ -1,11 +1,4 @@
-/* @workflow
-{
-  "name": "benchmark:raster-comparison",
-  "summary": "Verify retained MSDF/Slug comparison and exclusive finite-capture recovery on both backends.",
-  "requirements": "GPU-enabled Chromium and Vitexec.",
-  "writes": "Ignored browser caches only."
-}
-*/
+/* @workflow { "name": "benchmark:raster-comparison", "summary": "Verify retained MSDF/Slug comparison and exclusive finite-capture recovery on both backends.", "requirements": "GPU-enabled Chromium and Vitexec.", "writes": "Ignored browser caches only." } */
 import { runVitexec } from './support/command-cli.mts';
 
 const paths = [

--- a/apps/benchmarks/scripts/sync-amiri-fixture.mts
+++ b/apps/benchmarks/scripts/sync-amiri-fixture.mts
@@ -29,20 +29,5 @@ await syncImmutableFixture({
   directory,
   files,
 });
-/* @workflow
-{
-  "name": "font:amiri:sync",
-  "summary": "Synchronize the authenticated Amiri fixture.",
-  "requirements": "Network access to the pinned source.",
-  "writes": "Checked-in font, metadata, and license."
-}
-*/
-/* @workflow
-{
-  "name": "font:amiri:check",
-  "summary": "Verify the authenticated Amiri fixture.",
-  "requirements": "Checked-in authenticated fixture.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "font:amiri:sync", "summary": "Synchronize the authenticated Amiri fixture.", "requirements": "Network access to the pinned source.", "writes": "Checked-in font, metadata, and license." } */
+/* @workflow { "name": "font:amiri:check", "summary": "Verify the authenticated Amiri fixture.", "requirements": "Checked-in authenticated fixture.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/sync-cjk-fixture.mts
+++ b/apps/benchmarks/scripts/sync-cjk-fixture.mts
@@ -23,20 +23,5 @@ await syncImmutableFixture({
     },
   ],
 });
-/* @workflow
-{
-  "name": "font:cjk:sync",
-  "summary": "Synchronize the authenticated Noto CJK fixture.",
-  "requirements": "Network access to the pinned source.",
-  "writes": "Checked-in font, metadata, and license."
-}
-*/
-/* @workflow
-{
-  "name": "font:cjk:check",
-  "summary": "Verify the authenticated Noto CJK fixture.",
-  "requirements": "Checked-in authenticated fixture.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "font:cjk:sync", "summary": "Synchronize the authenticated Noto CJK fixture.", "requirements": "Network access to the pinned source.", "writes": "Checked-in font, metadata, and license." } */
+/* @workflow { "name": "font:cjk:check", "summary": "Verify the authenticated Noto CJK fixture.", "requirements": "Checked-in authenticated fixture.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/sync-dancing-script-fixture.mts
+++ b/apps/benchmarks/scripts/sync-dancing-script-fixture.mts
@@ -23,20 +23,5 @@ await syncImmutableFixture({
     },
   ],
 });
-/* @workflow
-{
-  "name": "font:dancing-script:sync",
-  "summary": "Synchronize the authenticated Dancing Script fixture.",
-  "requirements": "Network access to the pinned source.",
-  "writes": "Checked-in font, metadata, and license."
-}
-*/
-/* @workflow
-{
-  "name": "font:dancing-script:check",
-  "summary": "Verify the authenticated Dancing Script fixture.",
-  "requirements": "Checked-in authenticated fixture.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "font:dancing-script:sync", "summary": "Synchronize the authenticated Dancing Script fixture.", "requirements": "Network access to the pinned source.", "writes": "Checked-in font, metadata, and license." } */
+/* @workflow { "name": "font:dancing-script:check", "summary": "Verify the authenticated Dancing Script fixture.", "requirements": "Checked-in authenticated fixture.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/sync-devanagari-fixture.mts
+++ b/apps/benchmarks/scripts/sync-devanagari-fixture.mts
@@ -28,20 +28,5 @@ await syncImmutableFixture({
     },
   ],
 });
-/* @workflow
-{
-  "name": "font:devanagari:sync",
-  "summary": "Synchronize the authenticated Devanagari fixture.",
-  "requirements": "Network access to the pinned source.",
-  "writes": "Checked-in font, metadata, and license."
-}
-*/
-/* @workflow
-{
-  "name": "font:devanagari:check",
-  "summary": "Verify the authenticated Devanagari fixture.",
-  "requirements": "Checked-in authenticated fixture.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "font:devanagari:sync", "summary": "Synchronize the authenticated Devanagari fixture.", "requirements": "Network access to the pinned source.", "writes": "Checked-in font, metadata, and license." } */
+/* @workflow { "name": "font:devanagari:check", "summary": "Verify the authenticated Devanagari fixture.", "requirements": "Checked-in authenticated fixture.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/sync-font-awesome-icons.mts
+++ b/apps/benchmarks/scripts/sync-font-awesome-icons.mts
@@ -64,20 +64,5 @@ if (check) {
 } else {
   await writeFile(OUTPUT, generated);
 }
-/* @workflow
-{
-  "name": "font:icons:sync",
-  "summary": "Synchronize the authenticated Font Awesome icon fixture.",
-  "requirements": "Network access to the pinned source.",
-  "writes": "Checked-in font, icon catalog, metadata, and license."
-}
-*/
-/* @workflow
-{
-  "name": "font:icons:check",
-  "summary": "Verify the authenticated Font Awesome icon fixture.",
-  "requirements": "Checked-in authenticated fixture.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "font:icons:sync", "summary": "Synchronize the authenticated Font Awesome icon fixture.", "requirements": "Network access to the pinned source.", "writes": "Checked-in font, icon catalog, metadata, and license." } */
+/* @workflow { "name": "font:icons:check", "summary": "Verify the authenticated Font Awesome icon fixture.", "requirements": "Checked-in authenticated fixture.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/sync-japanese-showcase-fixture.mts
+++ b/apps/benchmarks/scripts/sync-japanese-showcase-fixture.mts
@@ -28,20 +28,5 @@ await syncImmutableFixture({
     },
   ],
 });
-/* @workflow
-{
-  "name": "font:japanese-showcase:sync",
-  "summary": "Synchronize the Japanese showcase source fixture.",
-  "requirements": "Authenticated source CJK font.",
-  "writes": "Checked-in showcase fixture and metadata."
-}
-*/
-/* @workflow
-{
-  "name": "font:japanese-showcase:check",
-  "summary": "Verify the Japanese showcase source fixture.",
-  "requirements": "Checked-in authenticated fixture.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "font:japanese-showcase:sync", "summary": "Synchronize the Japanese showcase source fixture.", "requirements": "Authenticated source CJK font.", "writes": "Checked-in showcase fixture and metadata." } */
+/* @workflow { "name": "font:japanese-showcase:check", "summary": "Verify the Japanese showcase source fixture.", "requirements": "Checked-in authenticated fixture.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/sync-source-serif-fixture.mts
+++ b/apps/benchmarks/scripts/sync-source-serif-fixture.mts
@@ -23,20 +23,5 @@ await syncImmutableFixture({
     },
   ],
 });
-/* @workflow
-{
-  "name": "font:source-serif:sync",
-  "summary": "Synchronize the authenticated Source Serif fixture.",
-  "requirements": "Network access to the pinned source.",
-  "writes": "Checked-in font, metadata, and license."
-}
-*/
-/* @workflow
-{
-  "name": "font:source-serif:check",
-  "summary": "Verify the authenticated Source Serif fixture.",
-  "requirements": "Checked-in authenticated fixture.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "font:source-serif:sync", "summary": "Synchronize the authenticated Source Serif fixture.", "requirements": "Network access to the pinned source.", "writes": "Checked-in font, metadata, and license." } */
+/* @workflow { "name": "font:source-serif:check", "summary": "Verify the authenticated Source Serif fixture.", "requirements": "Checked-in authenticated fixture.", "writes": "Nothing.", "args": ["--check"] } */

--- a/apps/benchmarks/scripts/verify-v1-bitmap.mts
+++ b/apps/benchmarks/scripts/verify-v1-bitmap.mts
@@ -1,12 +1,5 @@
 import { spawn } from 'node:child_process';
-/* @workflow
-{
-  "name": "benchmark:v1-bitmap",
-  "summary": "Render the Rust command-buffer path for Three Bitmap/MTSDF/Slug and a custom material on WebGPU and WebGL2.",
-  "requirements": "Playwright Chromium, WebGPU, WebGL2, and baked Inter fixtures. Pass --typegpu to exercise /three/typegpu.",
-  "writes": "No repository files."
-}
-*/
+/* @workflow { "name": "benchmark:v1-bitmap", "summary": "Render the Rust command-buffer path for Three Bitmap/MTSDF/Slug and a custom material on WebGPU and WebGL2.", "requirements": "Playwright Chromium, WebGPU, WebGL2, and baked Inter fixtures. Pass --typegpu to exercise /three/typegpu.", "writes": "No repository files." } */
 import { fileURLToPath } from 'node:url';
 
 import { launchProjectChromium } from './support/project-chromium.mts';

--- a/apps/benchmarks/src/benchmark/low-level/raster/mtsdf-cpu-reference.ts
+++ b/apps/benchmarks/src/benchmark/low-level/raster/mtsdf-cpu-reference.ts
@@ -32,10 +32,7 @@ export interface Rgba8CoverageDifference {
   readonly severeErrorPixels: number;
 }
 
-/**
- * Pure-CPU comparison of opaque grayscale coverage frames. Red marks candidate-only coverage,
- * cyan marks reference-only coverage, and black marks agreement.
- */
+/** Pure-CPU comparison of grayscale coverage frames; heatmap marks candidate-favored red, reference-favored cyan, agreement black. */
 export function compareRgba8Coverage(
   candidate: Uint8Array,
   reference: Uint8Array,
@@ -97,16 +94,7 @@ export interface FlatMtsdfCpuReferenceOptions {
   readonly fill?: readonly [number, number, number, number];
 }
 
-/**
- * Reconstructs the fixed, flat MTSDF specimen without invoking Canvas text,
- * Three.js materials, texture sampling, or browser font rendering.
- *
- * The sampler deliberately reads the same immutable RGBA8 base-level page
- * texels carried by the decoded technique data, in the top-down page space the
- * glyph records address. It is suitable for an axis-aligned, untransformed fill
- * specimen; outlines, shadows, mip selection, and arbitrary object transforms
- * belong in separate conformance cases.
- */
+/** Reconstructs the flat MTSDF specimen by CPU-sampling page texels directly; axis-aligned fill only, no outlines/shadows/mip/transforms. */
 export function renderFlatMtsdfCpuReference(
   data: MtsdfData,
   layout: GlyphLayout,

--- a/apps/benchmarks/src/benchmark/low-level/raster/slug-cpu-reference.ts
+++ b/apps/benchmarks/src/benchmark/low-level/raster/slug-cpu-reference.ts
@@ -69,10 +69,7 @@ export interface FlatSlugCpuReferenceOptions {
   readonly fill?: readonly [number, number, number, number];
 }
 
-/**
- * Reconstruct the fixed flat Slug specimen on the CPU from exact decoded curve, header,
- * and reference resources without invoking Three.js, TSL, or browser fonts.
- */
+/** Reconstructs the flat Slug specimen on the CPU from decoded curve/header/reference data, without Three.js, TSL, or browser fonts. */
 export function renderFlatSlugCpuReference(
   data: SlugCpuReferenceData,
   layout: GlyphLayout,

--- a/apps/benchmarks/src/benchmark/low-level/raster/source-outline-reference.ts
+++ b/apps/benchmarks/src/benchmark/low-level/raster/source-outline-reference.ts
@@ -61,12 +61,7 @@ export interface SourceOutlineTransform {
   readonly f: number;
 }
 
-/**
- * Renders the pinned source font through browser Canvas2D at the exact physical
- * size and paragraph baselines used by the candidate. Canvas owns glyph
- * rasterization and shaping here; the candidate pipeline contributes only the
- * line boundaries and positions needed to compare the same authored specimen.
- */
+/** Renders the pinned source font via Canvas2D at the candidate's physical size and baselines; Canvas owns shaping and rasterization, the candidate only supplies line positions. */
 export async function captureSourceOutlineFidelity(
   options: SourceOutlineReferenceOptions,
 ): Promise<SourceOutlineFidelityCapture> {

--- a/apps/benchmarks/src/benchmark/probes/comparison-workload-preview.ts
+++ b/apps/benchmarks/src/benchmark/probes/comparison-workload-preview.ts
@@ -7,10 +7,7 @@ import {
 } from '../../surfaces/benchmark/scenes/comparison-workload';
 import { createPersistentRenderHost } from '../../renderer/persistent-render-host';
 
-/**
- * Measurement-only adapter for probes that need an isolated canvas. The retained
- * workload scene remains renderer-agnostic; this adapter owns the host lifecycle.
- */
+/** Measurement-only adapter for probes needing an isolated canvas; owns the render-host lifecycle while the retained scene stays renderer-agnostic. */
 export interface ComparisonWorkloadPreview {
   dispose(): Promise<void>;
   panBy(deltaX: number, deltaY: number): { readonly deltaX: number; readonly deltaY: number } | void;

--- a/apps/benchmarks/src/benchmark/scenarios.ts
+++ b/apps/benchmarks/src/benchmark/scenarios.ts
@@ -1,20 +1,5 @@
 import type { BenchmarkScenario } from './contracts';
 import { ADVANCED_SHAPING_CASES } from '../workloads/advanced-shaping/scene';
-// Re-pinned once when the integer F26.6 line fit became authoritative: the
-// timeline's sub-pixel origins settle on quantized boundaries while every
-// authored count (709 glyphs, 625 rendered, 68 frames, 17,362 bytes) held.
-// Re-pinned when the line-terminating word space began to hang (D-257). Every
-// structural pin held exactly across the change -- 5 cases, 68 frames, 709 glyphs,
-// 625 rendered, 0 missing, 17,362 layout bytes, 63 draws -- so only the composed
-// position hash moved, which is the signature of a pure geometry shift.
-// Re-pinned for the RTL hung-space fix: an RTL line no longer shifts by the width of the
-// terminating space it hangs. Only glyph POSITIONS moved -- every structural metric this
-// matrix asserts is unchanged (709 glyphs, 625 rendered, 63 draws, 17,362 output bytes,
-// 68 frames, zero missing), and `a_hung_terminating_space_does_not_move_rtl_ink` pins the
-// LTR pen as unmoved, so the delta is confined to the RTL and mixed-direction cases.
-// Re-pinned when line composition moved to wide F16.16 accumulation and exact justified
-// remainder distribution. Every structural pin below stayed unchanged, so this remains a
-// pure geometry hash rather than a shaping, draw-count, or publication-lifecycle change.
 const ADVANCED_SHAPING_HASH = 'ae66ee48';
 const UPDATED_EXTERNAL_RASTER_GLYPHS = 13;
 
@@ -201,9 +186,7 @@ function slugTextValidation(values: readonly import('./contracts').BenchmarkMeas
       !finitePositive(metrics.slugHeaderBytes) ||
       !finitePositive(metrics.slugReferenceBytes) ||
       !finitePositive(metrics.slugResourceBytes) ||
-      // The technique reports what it decoded and the Three targets report what they uploaded, so a renderer that
-      // retains less than the decoded pages has lost a page rather than merely repacked one. Comparing the decoded
-      // subtotals against their own sum would only restate the app's arithmetic, so that check is gone.
+      // GPU bytes below the decoded resource total means the renderer dropped a page rather than repacking one.
       !finitePositive(metrics.slugGpuBytes) ||
       metrics.slugGpuBytes < metrics.slugResourceBytes ||
       metrics.renderTargetGpuBytes !== value.outputBytes ||
@@ -324,9 +307,7 @@ function paragraphContractsValidation(values: readonly import('./contracts').Ben
       value.metrics?.bidiLayoutCount !== 2 ||
       value.metrics.policyLayoutCount !== 9 ||
       value.metrics.cjkLayoutCount !== 12 ||
-      // One natural measurement per customLayouting() plus twenty-five constrained
-      // probes: intrinsic widths ride the natural pass instead of a second zero-width
-      // query, which is exactly the saving the Text measurement path exists for.
+      // 24 measure() calls: 1 natural (inside customLayouting) + 3 explicit probes + 20 repeated atMost calls.
       value.metrics.uikitMeasurementCount !== 24 ||
       value.metrics.uikitLayoutCount !== 1
     ) {
@@ -366,23 +347,8 @@ function advancedShapingValidation(values: readonly import('./contracts').Benchm
   return `${values.length}/${values.length} exact advanced-shaping timelines · ${frameCount} frames/sample`;
 }
 
-/**
- * The composed paragraph's exact span evidence.
- *
- * Each pin answers one question that the others cannot. Glyph-id changes prove the shaper honoured a span; origin
- * changes with unchanged ids prove a span altered metrics without altering selection; the line-count and first-break
- * pins prove a size span reached line breaking rather than only advances; the slot pins prove a font span reached the
- * shaper's font selection; and the `.notdef` pin proves the fallback span is what resolved the Devanagari at all.
- */
+/** Composed paragraph's span evidence: glyph ids prove span honoring, origins prove metric-only spans, line/break pins prove size reached layout, slots prove font selection, `.notdef` proves fallback resolution. */
 const RICH_TEXT_SPAN_EVIDENCE = {
-  // The hash alone re-pinned when the integer F26.6 fit became authoritative:
-  // every structural pin below — selection, line counts, and both first-line
-  // break positions — held while the composed origins quantized. Re-pinned again
-  // for the hanging terminating space (D-257), where only `lineThroughCount`
-  // moved among the structural pins, for the reason recorded beside it.
-  // Re-pinned for the F16.16 layout-unit migration. All structural evidence below
-  // remains exact; the digest changed because its per-case x origins intentionally
-  // retain sub-unit precision that F26.6 previously quantized away.
   hash: 'd666d3ac',
   glyphCount: 175,
   renderedGlyphCount: 149,
@@ -405,25 +371,13 @@ const RICH_TEXT_SPAN_EVIDENCE = {
   tintPaintGlyphs: 3,
   paragraphPaintGlyphs: 114,
   nestedGlyphCount: 9,
-  // One instance per continuous decorating box per line (D-248): the emphasis span underlines as a single
-  // run, while line-through covers the tint span once and the accent span once.
-  // Re-pinned from 3 when the line-terminating word space began to hang (D-257). Every
-  // pin declared above this one held exactly -- including `lineCount`, `accentPaintGlyphs`,
-  // and both first-break positions -- so the paragraph still wraps into the same three
-  // lines over the same glyphs. The recovered measure keeps the struck-through accent
-  // phrase off a line boundary, so it needs one decorating box instead of two.
+  // One instance per continuous decorating box per line: underline covers the emphasis span once,
+  // line-through covers the tint span once and the accent span once.
   underlineCount: 1,
   lineThroughCount: 2,
 } as const;
 
-/**
- * Glyphs the nested style-only span loses to the paragraph paint instead of inheriting from the span that encloses it.
- *
- * This was 9 while paint resolved by taking the innermost covering span's `paint` whole, so a span stating no paint
- * fell through to the paragraph paint rather than to the span enclosing it — contradicting the README. It reached `0`
- * when one span cascade began resolving every property by containment for both shaping and paint, and those nine
- * glyphs moved from `paragraphPaintGlyphs` into `accentPaintGlyphs`. Keep the pin: a regression would raise it again.
- */
+/** Glyphs the nested style-only span loses to the paragraph paint instead of inheriting from its enclosing span; expected 0. */
 const NESTED_SPAN_PAINT_CASCADE_DELTA = 0;
 
 function richTextSpanValidation(values: readonly import('./contracts').BenchmarkMeasurement[]): string {

--- a/apps/benchmarks/src/benchmark/targets/conformance/raster/contracts.ts
+++ b/apps/benchmarks/src/benchmark/targets/conformance/raster/contracts.ts
@@ -15,10 +15,7 @@ export interface RasterSourceOutlineCapture {
   readonly renderSubmitMs: number;
 }
 
-/**
- * Raster-format-private resources stay in the selected target module. The target owns
- * this session's warm load, capture, and disposal lifecycle without owning a renderer.
- */
+/** Owns its session's warm load, capture, and disposal lifecycle; does not own a renderer. */
 export interface RasterConformanceSession {
   load(input: BenchmarkInput, controls: BenchmarkControls, context?: BenchmarkExecutionContext): Promise<void>;
   captureSampling(

--- a/apps/benchmarks/src/benchmark/targets/conformance/raster/slug-capture.ts
+++ b/apps/benchmarks/src/benchmark/targets/conformance/raster/slug-capture.ts
@@ -702,11 +702,7 @@ async function loadConformanceSlugFont(
   return { font: loaded.loaded, data: loaded.data };
 }
 
-/**
- * The public loader publishes no fetch hook, so the only way to observe which URLs one external artifact touches
- * is to own `globalThis.fetch` for the duration of that load. The swap is scoped to this call and restored
- * unconditionally; the embedded fixture of a parity run has already finished loading before it is installed.
- */
+/** No public fetch hook exists, so this owns `globalThis.fetch` for the call's duration to observe artifact URLs; restored unconditionally in `finally`. */
 async function loadExternalSlugFont(
   artifactUrl: string,
   fetcher: typeof fetch,

--- a/apps/benchmarks/src/benchmark/targets/conformance/raster/slug-role-scenes.ts
+++ b/apps/benchmarks/src/benchmark/targets/conformance/raster/slug-role-scenes.ts
@@ -47,10 +47,7 @@ export interface SlugProjectionZoomSceneDefinition {
   readonly zooms: readonly [1, 8];
 }
 
-/**
- * Focused physical-pixel scenes for Slug's release role. Keeping dimensions,
- * ppem, and origins physical makes the same scene comparable at DPR 1 and 2.
- */
+/** Physical-pixel scenes: keeping dimensions, ppem, and origins physical makes the same scene comparable at DPR 1 and 2. */
 export const SLUG_ROLE_SCENES: readonly SlugRoleSceneDefinition[] = [
   {
     id: 'large-source-serif',

--- a/apps/benchmarks/src/benchmark/targets/conformance/rich-text-spans.ts
+++ b/apps/benchmarks/src/benchmark/targets/conformance/rich-text-spans.ts
@@ -24,31 +24,20 @@ import { createBenchmarkThreeRoot, disposeBenchmarkThreeRoot } from '../../../th
 
 type BitmapFormat = typeof bitmap;
 
-/**
- * One measure and one body size for every case.
- *
- * 700 CSS px is not arbitrary: it is the measure at which dropping the emphasis span's size back to the body size
- * changes the paragraph from three lines to two. A case that only moved advances would leave line breaking as an open
- * question, so the pinned measure is the one that closes it.
- */
+/** 700 CSS px: the measure where dropping the emphasis span's size to body size changes the paragraph from three lines to two. */
 const CONTENT_WIDTH = 700;
 const BODY_FONT_SIZE = 16;
 const UTF8_ENCODER = new TextEncoder();
 const BITMAP_COLOR_ATTRIBUTE = codecAttributeName(bitmapSchema.buffers.color.id);
 const DECORATION_RECT_ATTRIBUTE = codecAttributeName(hashId.buffer('glyph-three/decoration/rect'));
 const DECORATION_PACKED_ATTRIBUTE = codecAttributeName(hashId.buffer('glyph-three/decoration/packed'));
-// Decoration gather convention (D-248): buffer 2 packs [color, flags | style << 8] per instance. The bit values are
-// the shaper ABI's `engine.decorationFlags` / `engine.decorationStyles`, pinned here because a silent renumbering
-// must fail this lane rather than shift what the probe counts.
+// Buffer 2 packs [color, flags | style << 8] per instance; bit values are the shaper ABI's engine.decorationFlags / engine.decorationStyles.
 const DECORATION_UNDERLINE_FLAG = 0b0001;
 const DECORATION_LINE_THROUGH_FLAG = 0b0100;
 const DECORATION_SOLID_STYLE = 1;
 const bitmapRaster: RasterFormatInput<BitmapFormat> = bitmap({ strikes: [16] });
 
-/**
- * Each control removes exactly one span property from the composed paragraph, so the difference it makes is
- * attributable to that property alone. `composed` is the paragraph the live workload renders.
- */
+/** Each case id removes exactly one span property from the composed paragraph so its effect is attributable; `composed` is what the live workload renders. */
 type RichTextCaseId =
   | 'composed'
   | 'no-small-caps'
@@ -121,9 +110,8 @@ export function createRichTextSpansConformanceTarget(): BenchmarkTarget {
         if (body === undefined || foreign === undefined || emphasis === undefined) {
           throw new Error('rich text conformance did not load its three fixtures');
         }
-        // Decoration-metrics probe: every baked font this workload touches must expose the
-        // underline and strikeout values the artifact bakes from `post` and `OS/2`, so a
-        // regression in the bake or decode path fails this lane before any renderer work.
+        // Every baked font must expose the underline/strikeout metrics baked from post/OS2, so a
+        // bake or decode regression fails here before any renderer work.
         for (const loadedFont of [body, foreign, emphasis]) {
           const { underlinePosition, underlineThickness, strikeoutPosition, strikeoutSize } = loadedFont.metrics;
           const values = [underlinePosition, underlineThickness, strikeoutPosition, strikeoutSize];
@@ -202,13 +190,8 @@ export function createRichTextSpansConformanceTarget(): BenchmarkTarget {
       const accentPaintGlyphs = countColor(composed, accentColor);
       const tintPaintGlyphs = countColor(composed, tintColor);
       const paragraphPaintGlyphs = countColor(composed, paragraphColor);
-      /*
-       * The nested style-only span states no paint of its own, so the README's cascade requires every one of its glyphs
-       * to keep the paint of the span that encloses it. Counting accent glyphs with and without the nesting isolates
-       * that: the two counts are equal when the inner range inherits, and differ by exactly the nested glyph count when
-       * it resets to the paragraph paint instead. A count is used rather than per-glyph attribution because draws are
-       * grouped by raster resource, so drawn instance order is not paragraph order and cannot address a cluster.
-       */
+      /* Counts accent glyphs with/without nesting: equal when the nested span inherits paint, differ by its glyph
+       * count when it resets to paragraph paint (a count, not per-glyph, since draws group by raster resource). */
       const nestedGlyphCount = glyphsInRange(composed, nested).length;
       const nestedPaintDelta = countColor(noNesting, accentColor) - accentPaintGlyphs;
 
@@ -223,9 +206,8 @@ export function createRichTextSpansConformanceTarget(): BenchmarkTarget {
 
       const hashes = CASE_IDS.map((caseId) => {
         const value = required(evidence, caseId);
-        // Glyph selection and topology remain exact. Positions are public f32 values, so the semantic digest quantizes
-        // below a visible hundredth of a pixel; paint is explicitly a multiset because resource batching may reorder
-        // draws without changing the paragraph's resolved colors.
+        // Positions are public f32, so the digest quantizes to a visible hundredth of a pixel; paint is a sorted
+        // multiset since batching may reorder draws.
         return [
           caseId,
           value.glyphIds.join(','),
@@ -343,14 +325,7 @@ function measureCase(
   }
 }
 
-/**
- * Reads the paint the packer actually resolved, not the paint the author stated.
- *
- * Bitmap publishes one instance colour per drawn glyph into the batch storage its draws share, and each draw records
- * where its run begins, so walking the draws recovers the resolved colour of every rendered glyph. Draws are grouped by
- * raster resource rather than by paragraph position, so the result is the paragraph's multiset of resolved colours and
- * not a per-cluster mapping — which is why the paint evidence is expressed as counts and differences between cases.
- */
+/** Reads the paint the packer resolved (not what spans state) by walking draws; grouped by raster resource, so results are per-color counts, not per-glyph. */
 function readEvidence(scene: THREE.Scene, root: ThreeRoot, layout: GlyphLayout): CaseEvidence {
   const colors: string[] = [];
   let drawCount = 0;

--- a/apps/benchmarks/src/benchmark/targets/product/react-text.ts
+++ b/apps/benchmarks/src/benchmark/targets/product/react-text.ts
@@ -28,10 +28,7 @@ const TEXT_ACCENT = 'AVATAR';
 const TEXT_SUFFIX = ' café — ffi, kerning, marks, and wrapping.';
 const NARROW_WIDTH = 360;
 const BITMAP_COLOR_ATTRIBUTE = codecAttributeName(bitmapSchema.buffers.color.id);
-/**
- * Target v1 merges a Text update into the state it already holds, so omitting constraints would keep the previous
- * width instead of restoring natural measurement. The unconstrained axis has to be stated.
- */
+/** Target v1 merges updates into existing state, so omitting constraints would keep the previous width; the unconstrained axis must be stated explicitly. */
 const NATURAL_CONSTRAINTS: Constraints = { width: { mode: 'unconstrained' } };
 const fontInput = bitmapFontUrl;
 const fontOptions = { strikes: [16] } as const;
@@ -43,10 +40,7 @@ function createBitmapFontFace() {
 type BitmapFontFace = ReturnType<typeof createBitmapFontFace>;
 type BitmapFontSelection = BitmapFontFace['bitmap'];
 
-/**
- * Target v1 reports batch failures through `onError` rather than a rejected readiness promise, so the run records the
- * first failure and fails on it instead of hashing whatever partial frame survived.
- */
+/** Target v1 reports failures via `onError`, not a rejected promise, so this records the first failure instead of hashing a partial frame. */
 interface ReactTextFailures {
   error: unknown;
 }

--- a/apps/benchmarks/src/benchmark/targets/shared/direct-wasm.ts
+++ b/apps/benchmarks/src/benchmark/targets/shared/direct-wasm.ts
@@ -1,9 +1,4 @@
-/**
- * Direct Wasm ABI dependencies are intentionally isolated from the application entry graph.
- *
- * Selected measurement and conformance targets opt into these module and asset imports only
- * after an operator chooses an ABI-level benchmark. Product demos use public loader surfaces.
- */
+/** Isolated from the application entry graph; only ABI-level benchmark targets opt into these imports, while product demos use public loader surfaces. */
 export interface DirectWasmDependencies {
   readonly createFontBaker: typeof import('../../../../../../packages/glyph/src/font-baker/index').createFontBaker;
   readonly bakerWasmUrl: string;

--- a/apps/benchmarks/src/components/presentation-control-dock.tsx
+++ b/apps/benchmarks/src/components/presentation-control-dock.tsx
@@ -22,10 +22,7 @@ import {
   type AdvancedShapingFrame,
   type AdvancedShapingState,
 } from '../workloads/advanced-shaping/scene';
-/*
- * The dock intentionally consumes the same typed control state as the main panel.
- * shadcn/Base UI owns interaction semantics; this component only maps state to a compact presentation.
- */
+/* Shares the main panel's typed control state; shadcn/Base UI owns interaction semantics, this component only maps state to a compact presentation. */
 import type { GraphicsBackend, RasterFormatName } from '../benchmark/url-state';
 import { logarithmicRangePosition, logarithmicRangeValue } from './range-values';
 import { Button } from '@/components/ui/button';

--- a/apps/benchmarks/src/components/runtime-controls.tsx
+++ b/apps/benchmarks/src/components/runtime-controls.tsx
@@ -45,10 +45,7 @@ export type RuntimeControlsProps = Omit<
 /** How long the workload amount must hold still before the scene rebuilds for it. */
 const WORKLOAD_AMOUNT_SETTLE_MS = 120;
 
-/**
- * Calls `callback` once the caller stops producing values. A dragged range control emits one value per pointer move,
- * and the ones in the middle of a drag describe a scene nobody asked to look at.
- */
+/** Calls `callback` once the caller stops producing values; a dragged range control emits one value per pointer move, most of which are noise. */
 function useDebouncedCallback<Value>(callback: (value: Value) => void, delayMs: number): (value: Value) => void {
   const latest = useRef(callback);
   const pending = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -81,9 +78,8 @@ export function RuntimeControls({ onBeforeShowGrid, onRuntimeControl, ...props }
     change();
     onRuntimeControl();
   };
-  // Workload amount is the one control whose every intermediate value rebuilds the scene from nothing, so a drag
-  // across it queues a rebuild per step. Settling the input drops the values nobody asked to see, which costs nothing,
-  // rather than letting the scene merge updates it was asked to perform and then report the cost of the survivors.
+  // Workload amount rebuilds the scene from nothing on every intermediate value, so a drag would queue one
+  // rebuild per step; settling drops the values the pointer never held on.
   const debouncedWorkloadAmount = useDebouncedCallback((workloadAmount: number) => {
     changed(() => world.set(RuntimeLayoutControls, { workloadAmount }));
   }, WORKLOAD_AMOUNT_SETTLE_MS);

--- a/apps/benchmarks/src/renderer/retained-font-fixture.ts
+++ b/apps/benchmarks/src/renderer/retained-font-fixture.ts
@@ -23,16 +23,9 @@ export interface RetainedFontFixtureController<Asset extends RetainedFontFixture
   readonly current: RetainedFontFixtureState<Asset>;
   /** Whether `commit` can build a generation on `fixture` in the caller's own turn, with nothing left to fetch. */
   has(fixture: BenchmarkFontFixture): boolean;
-  /**
-   * Fetches and decodes a replacement fixture behind the visible one. This is the only genuinely asynchronous step in
-   * a live update, and staging it here is what lets a fixture swap load without tearing down the text on screen.
-   */
+  /** Fetches and decodes a replacement fixture behind the visible one — the only async step, letting a fixture swap load without tearing down the text on screen. */
   load(fixture: BenchmarkFontFixture, load: RetainedFontFixtureLoader<Asset>): Promise<void>;
-  /**
-   * Builds one generation against `fixture` and, once `apply` returns, adopts it and releases the fixture it replaced.
-   * Synchronous by construction: a fixture with no completed `load` is a caller error rather than something to await.
-   * A throwing `apply` leaves the visible fixture and its asset exactly as they were.
-   */
+  /** Builds one generation against `fixture` and adopts it once `apply` returns; `fixture` must already be loaded (else throws), and a throwing `apply` leaves state unchanged. */
   commit<Result>(fixture: BenchmarkFontFixture, apply: (asset: Asset) => Result): Result;
   dispose(): void;
 }

--- a/apps/benchmarks/src/renderer/webgpu-renderer.ts
+++ b/apps/benchmarks/src/renderer/webgpu-renderer.ts
@@ -71,12 +71,7 @@ export async function createConfiguredRenderer(options: RendererOptions): Promis
   }
 }
 
-/**
- * Disposes a configured renderer only after WebKit has acknowledged WebGL
- * context loss. Three.js disposal is synchronous even though context release
- * is not; admitting a replacement renderer before this event can exhaust the
- * browser's context budget during rapid surface changes.
- */
+/** Disposes only after WebKit acknowledges WebGL context loss; Three.js disposal is synchronous but context release is not, and skipping this wait can exhaust the browser's context budget. */
 export async function disposeConfiguredRenderer(renderer: THREE.WebGPURenderer): Promise<void> {
   const contextLoss = monitorWebGlContextLoss(renderer);
   try {

--- a/apps/benchmarks/src/surfaces/benchmark/bitmap-text-viewport.tsx
+++ b/apps/benchmarks/src/surfaces/benchmark/bitmap-text-viewport.tsx
@@ -32,14 +32,7 @@ interface LiveTextUpdateHandlers {
   readonly onError: (error: unknown) => void;
 }
 
-/**
- * Applies one authored configuration to the live scene and returns a cancel function for React's cleanup.
- *
- * The update is committed in this turn whenever the scene already holds the requested fixture, which is every change
- * but a fixture swap. Only fetching and decoding a replacement fixture is awaited, and nothing coalesces or defers the
- * shaping itself: a queue in front of `update` would drop work during continuous animation and quietly present text
- * that lags the state the surface is already rendering from.
- */
+/** Applies one configuration to the live scene, returning a cancel function; commits synchronously unless the fixture changed (then awaits load), never queuing or coalescing updates. */
 function applyLiveTextUpdate(
   scene: BitmapTextPersistentScene,
   update: RetainedLiveTextUpdate,

--- a/apps/benchmarks/src/surfaces/benchmark/scenes/comparison-workload.ts
+++ b/apps/benchmarks/src/surfaces/benchmark/scenes/comparison-workload.ts
@@ -344,11 +344,7 @@ async function createComparisonWorkloadRuntime(
   const canvasSurface = createCanvasSurface(renderer, width, height, configuration.showGrid);
   const rendererInitMs = persistentContext.rendererInitMs;
   let font: LoadedFormatFont | undefined;
-  /**
-   * Companion fixtures stay resident once loaded, keyed by fixture rather than held in one slot: the routes that need a
-   * companion do not all need the same one, and a Text that a previous workload published still holds a font lease, so
-   * releasing a companion at a workload switch would invalidate a font the outgoing scene has not finished with.
-   */
+  /** Companion fixtures stay resident once loaded, keyed by fixture: a previous workload's Text may still hold a lease, so switching workloads must not invalidate a font it hasn't finished with. */
   const companionFonts = new Map<BenchmarkFontFixture, LoadedFormatFont>();
   let selectedFontController: RetainedFontFixtureController<LoadedFormatFont> | undefined;
   let entries: readonly WorkloadEntry[] = [];
@@ -465,10 +461,7 @@ async function createComparisonWorkloadRuntime(
     const activeSelectedFont = selectedFontController;
     const activeFont = (): LoadedFormatFont => activeSelectedFont.current.asset;
     const loadedFontsScratch: LoadedFormatFont[] = [];
-    /**
-     * The selected fixture and a companion fixture can resolve to the same registered font, so residency is deduplicated
-     * by the loaded handle rather than by the asset wrapper — counting one font twice would double its reported bytes.
-     */
+    /** Selected and companion fixtures can resolve to the same registered font, so residency dedupes by loaded handle, not asset wrapper — else reported bytes double-count. */
     const loadedFonts = (): readonly LoadedFormatFont[] => {
       loadedFontsScratch.length = 0;
       loadedFontsScratch.push(activeFont());
@@ -491,9 +484,8 @@ async function createComparisonWorkloadRuntime(
       }
       return cachedBitmapAtlasPages;
     };
-    // Icon Grid renders its cells from the companion fixture, so that fixture owns the reported density there. Every
-    // other workload — including a composed one that only reaches its companion through a span — keeps the selected
-    // font as its density source, so a retained companion never becomes the visible configuration after navigation.
+    // Icon Grid reports density from its companion fixture; every other workload (even composed, reaching a
+    // companion only via a span) reports from the selected font.
     const statsFont = (): LoadedFormatFont =>
       configuration.workload === 'icon-grid' ? (residentCompanionFont('icon-grid') ?? activeFont()) : activeFont();
     let fontFixtureSwitching = false;
@@ -868,9 +860,8 @@ async function createComparisonWorkloadRuntime(
       ) {
         iconGridInstance?.suspend();
       }
-      // Queued, never merged. Collapsing a superseded configuration into its successor made a dragged control report
-      // the cost of the two updates that survived rather than of the twenty it requested, which is a measurement of
-      // the queue and not of the workload. Callers debounce their own input; whatever arrives here is applied.
+      // Queued, never merged: collapsing configurations would measure the queue's cost instead of the workload's.
+      // Callers debounce their own input.
       return new Promise<void>((resolve, reject) => {
         pendingUpdates.push({ configuration: next, viewportChanged, waiters: [{ resolve, reject }] });
         startUpdateDrain();
@@ -1181,11 +1172,7 @@ async function createComparisonWorkloadRuntime(
   }
 }
 
-/**
- * Multi-instance workloads mount under one shared `TextGroup`, so their Texts prepare and pack into a single paragraph
- * batch that owns one set of GPU resources. A single-paragraph workload gets a plain Group and keeps its own implicit
- * batch of one, which is what it already was.
- */
+/** Multi-instance workloads share one `TextGroup` batch (one set of GPU resources); a single-paragraph workload gets a plain Group, its own implicit batch of one. */
 function createBatchRoot(root: ThreeRoot, workload: ComparisonWorkloadId): THREE.Object3D {
   if (comparisonWorkloadDefinition(workload).batching === 'standalone') return new THREE.Group();
   return root.createTextGroup();
@@ -1291,13 +1278,7 @@ export function comparisonWorkloadRequiresIconWindowSuspension(
   return registryRequiresIconWindowSuspension(previous, next);
 }
 
-/**
- * Swaps the font fixture behind every retained Text and commits the whole set in one publication.
- *
- * The replacement `Font` is already resolved, so there is no readiness window to roll back: either the single
- * `updateMatrixWorld` commits every Text onto the new fixture or it throws with none of them published, and the caller
- * releases the candidate owner.
- */
+/** Swaps the font fixture behind every retained Text, committing the whole set in one publication: the single `updateMatrixWorld` either commits all Texts or throws with none published. */
 export function applyRetainedTextFontFixture(
   root: THREE.Object3D,
   entries: readonly WorkloadEntry[],
@@ -1312,9 +1293,7 @@ export function applyRetainedTextWidths(texts: readonly WorkloadText[], widths: 
   applyRetainedTextLayout(texts, widths, undefined);
 }
 
-/**
- * `set` replaces a property group wholesale, so each update carries forward the unaffected style or constraints.
- */
+/** `set` replaces a property group wholesale, so each update carries forward the unaffected style or constraints. */
 function applyRetainedTextLayout(
   texts: readonly WorkloadText[],
   widths: ArrayLike<number> | undefined,

--- a/apps/benchmarks/src/surfaces/benchmark/sdf-text-viewports.tsx
+++ b/apps/benchmarks/src/surfaces/benchmark/sdf-text-viewports.tsx
@@ -23,23 +23,14 @@ function loadSlugTextRenderer() {
   return import('../../techniques/slug/persistent-scene');
 }
 
-/**
- * The retained live-update surface shared by both SDF raster-format scenes.
- */
+/** The retained live-update surface shared by both SDF raster-format scenes. */
 interface SdfLiveTextScene {
   hasFontFixture(fixture: LiveTextConfiguration['fontFixture']): boolean;
   loadFontFixture(fixture: LiveTextConfiguration['fontFixture']): Promise<void>;
   update(update: RetainedLiveTextUpdate): GlyphOriginPresentation;
 }
 
-/**
- * Applies one authored configuration to the live scene and returns a cancel function for React's cleanup.
- *
- * The update is committed in this turn whenever the scene already holds the requested fixture, which is every change
- * but a fixture swap. Only fetching and decoding a replacement fixture is awaited, and nothing coalesces or defers the
- * shaping itself: a queue in front of `update` would drop work during continuous animation and quietly present text
- * that lags the state the surface is already rendering from.
- */
+/** Applies one configuration to the live scene, returning a cancel function; commits synchronously unless the fixture changed (then awaits load), never queuing or coalescing updates. */
 function applySdfLiveTextUpdate(
   scene: SdfLiveTextScene,
   update: RetainedLiveTextUpdate,

--- a/apps/benchmarks/src/surfaces/conformance/scenes/raster-format-comparison.ts
+++ b/apps/benchmarks/src/surfaces/conformance/scenes/raster-format-comparison.ts
@@ -86,11 +86,7 @@ interface ComparisonShaping {
   readonly direction: 'ltr' | 'rtl';
 }
 
-/**
- * Keeps candidate rendering and comparison on the GPU. The two raster-format scenes
- * render into equal RGBA8 targets; a fullscreen TSL pass samples both targets
- * directly to display signed coverage error without readback or CPU composition.
- */
+/** Keeps candidate rendering and comparison on the GPU: both raster-format scenes render into equal RGBA8 targets, and a fullscreen TSL pass samples both directly, no readback or CPU composition. */
 export async function createRasterFormatComparison(options: {
   readonly backend: RendererBackend;
   readonly canvas: HTMLCanvasElement;
@@ -454,11 +450,7 @@ async function compileComparison(resources: ComparisonResources): Promise<void> 
   });
 }
 
-/**
- * Both publications occur in one JavaScript task. Candidate target rendering stays paused until both lines commit, so
- * a later frame can never sample one new generation beside one old generation. Returns the first line error, if any,
- * so a caller can roll the pair back together rather than leaving one panel ahead of the other.
- */
+/** Commits both lines in one task so a frame never mixes generations; returns the first error, if any, so the caller can roll the pair back together. */
 function publishComparisonLines(resources: ComparisonResources): unknown {
   resources.mtsdfLine.updateMatrixWorld(true);
   resources.slugLine.updateMatrixWorld(true);
@@ -557,10 +549,7 @@ function comparisonLineView(viewport: PersistentRenderViewport, zoom: number): C
   };
 }
 
-/**
- * `set` replaces whole property groups, so every update restates the fixture's shaping context. Dropping it would
- * silently reshape the specimen the moment the viewer zoomed.
- */
+/** `set` replaces whole property groups, so every update must restate the fixture's shaping context — dropping it would silently reshape the specimen on zoom. */
 function lineViewUpdate(
   shaping: ComparisonShaping,
   view: ComparisonLineView,

--- a/apps/benchmarks/src/techniques/bitmap/conformance-line.ts
+++ b/apps/benchmarks/src/techniques/bitmap/conformance-line.ts
@@ -8,10 +8,7 @@ import { LIVE_TEXT_LINE_HEIGHT } from '../../workloads/shared/text-style';
 /** White, so every rendered channel carries the atlas coverage the exact CPU reference composites. */
 const CONFORMANCE_TEXT_COLOR = '#ffffff';
 
-/**
- * One committed target-v1 Bitmap paragraph, measured. The exact conformance oracle compares GPU bytes against a CPU
- * compositor that reads the same layout, so the layout has to be readable without re-running it.
- */
+/** One committed target-v1 Bitmap paragraph, measured; the layout is exposed so a CPU compositor can compare GPU bytes against it without re-running it. */
 export interface BitmapConformanceLine {
   readonly object: Text<typeof bitmap>;
   readonly layout: GlyphLayout;
@@ -24,11 +21,7 @@ export interface BitmapConformanceLine {
   readonly strikePpem: number;
 }
 
-/**
- * Builds one target-v1 paragraph under `parent` and commits it. `Text` reconciles during `updateMatrixWorld` and only
- * while it is parented, so attaching before committing — rather than awaiting a readiness promise — is what makes the
- * layout and its draws observable, and lets a preparation failure surface as a thrown error instead of an empty frame.
- */
+/** Builds one target-v1 paragraph under `parent` and commits it; `Text` reconciles during `updateMatrixWorld` only while parented, so attaching before committing surfaces preparation failures as thrown errors instead of an empty frame. */
 export function createBitmapConformanceLine(
   scene: THREE.Scene,
   root: ThreeRoot,

--- a/apps/benchmarks/src/techniques/bitmap/persistent-scene.ts
+++ b/apps/benchmarks/src/techniques/bitmap/persistent-scene.ts
@@ -162,12 +162,7 @@ export interface BitmapTextPersistentScene extends PersistentRenderScene {
   hasFontFixture(fixture: BenchmarkFontFixture): boolean;
   /** Fetches and decodes a replacement fixture behind the visible text. The only asynchronous step a live update has. */
   loadFontFixture(fixture: BenchmarkFontFixture): Promise<void>;
-  /**
-   * Applies and shapes one generation in the caller's own turn. Nothing here is deferred: an ordinary text, font-size,
-   * layout-width, anchor, or DPR change is visible on the next frame the host draws, which is the contract this
-   * harness exists to demonstrate. Only a fixture the scene has not loaded is refused, and `loadFontFixture` is how
-   * that is resolved.
-   */
+  /** Applies and shapes one generation synchronously — visible on the next frame drawn. Refuses a fixture that `loadFontFixture` has not resolved. */
   update(options: BitmapTextSceneUpdate): BitmapTextSceneSnapshot;
 }
 

--- a/apps/benchmarks/src/techniques/mtsdf/persistent-scene.ts
+++ b/apps/benchmarks/src/techniques/mtsdf/persistent-scene.ts
@@ -148,12 +148,7 @@ export interface MtsdfTextPersistentScene extends PersistentRenderScene {
   hasFontFixture(fixture: BenchmarkFontFixture): boolean;
   /** Fetches and decodes a replacement fixture behind the visible text. The only asynchronous step a live update has. */
   loadFontFixture(fixture: BenchmarkFontFixture): Promise<void>;
-  /**
-   * Applies and shapes one generation in the caller's own turn. Nothing here is deferred: an ordinary text, font-size,
-   * layout-width, anchor, or DPR change is visible on the next frame the host draws, which is the contract this
-   * harness exists to demonstrate. Only a fixture the scene has not loaded is refused, and `loadFontFixture` is how
-   * that is resolved.
-   */
+  /** Applies and shapes one generation synchronously — visible on the next frame drawn. Refuses a fixture that `loadFontFixture` has not resolved. */
   update(update: MtsdfTextSceneUpdate): GlyphOriginPresentation;
 }
 

--- a/apps/benchmarks/src/techniques/slug/metadata.ts
+++ b/apps/benchmarks/src/techniques/slug/metadata.ts
@@ -1,10 +1,6 @@
 import type { SlugCpuReferenceData } from '../../benchmark/low-level/raster/slug-cpu-reference';
 
-/**
- * Renderer-neutral Slug page allocation. Every byte figure counts decoded resource bytes the technique retains, not
- * GPU residency: a renderer repacks the 16-bit reference table before upload, so only the renderer can report what it
- * actually holds. Read retained GPU bytes from `Text.gpuBytes` or `TextGroup.gpuBytes` instead.
- */
+/** Renderer-neutral Slug page allocation: counts decoded resource bytes, not GPU residency (a renderer repacks the reference table before upload). Read actual GPU bytes from `Text.gpuBytes`/`TextGroup.gpuBytes`. */
 export interface SlugRasterConfiguration {
   readonly planeUnitsPerEm: number;
   readonly pageCount: number;

--- a/apps/benchmarks/src/techniques/slug/persistent-scene.ts
+++ b/apps/benchmarks/src/techniques/slug/persistent-scene.ts
@@ -167,12 +167,7 @@ export interface SlugTextPersistentScene extends PersistentRenderScene {
   hasFontFixture(fixture: BenchmarkFontFixture): boolean;
   /** Fetches and decodes a replacement fixture behind the visible text. The only asynchronous step a live update has. */
   loadFontFixture(fixture: BenchmarkFontFixture): Promise<void>;
-  /**
-   * Applies and shapes one generation in the caller's own turn. Nothing here is deferred: an ordinary text, font-size,
-   * layout-width, anchor, or DPR change is visible on the next frame the host draws, which is the contract this
-   * harness exists to demonstrate. Only a fixture the scene has not loaded is refused, and `loadFontFixture` is how
-   * that is resolved.
-   */
+  /** Applies and shapes one generation synchronously — visible on the next frame drawn. Refuses a fixture that `loadFontFixture` has not resolved. */
   update(update: SlugTextSceneUpdate): GlyphOriginPresentation;
 }
 

--- a/apps/benchmarks/src/v1-compose-proof.ts
+++ b/apps/benchmarks/src/v1-compose-proof.ts
@@ -24,10 +24,7 @@ interface TargetV1ComposeResult {
   readonly canonicalGreenPixels: number;
 }
 
-/**
- * The composed program keeps the canonical position and coverage and tints only the resolved colour. Preserving the
- * canonical glyph footprint while changing the paint is what proves it reuses the exported technique shader.
- */
+/** Composed material keeps canonical position/coverage, tinting only color — proving it reuses the exported technique shader rather than reimplementing it. */
 const composedMaterial = defineTextMaterial((context) => {
   if (context.kind !== 'glyph' || context.format !== bitmap.id) {
     return context.createDefaultMaterial();

--- a/apps/benchmarks/src/workloads/advanced-shaping/scene.ts
+++ b/apps/benchmarks/src/workloads/advanced-shaping/scene.ts
@@ -179,13 +179,7 @@ export const ADVANCED_SHAPING_PRESENTATION_CYCLE_DURATION_MS = Math.ceil(
     1_000,
 );
 
-/**
- * Who advances the case: the operator, or the timed demo.
- *
- * Only the automated presentation capture cycles cases on its own. An interactive
- * benchmark run holds the selected case until the operator changes it, so a case
- * under investigation stays on screen instead of scrolling past.
- */
+/** Who advances the case: 'manual' holds the operator's selection until they change it; 'auto' is the timed presentation-capture cycle. */
 export type AdvancedShapingCaseCycle = 'manual' | 'auto';
 
 export function initialAdvancedShapingState(caseCycle: AdvancedShapingCaseCycle): AdvancedShapingState {

--- a/apps/benchmarks/src/workloads/benchmark-ipsum/scene.ts
+++ b/apps/benchmarks/src/workloads/benchmark-ipsum/scene.ts
@@ -2,13 +2,7 @@ import type { BenchmarkFontFixture } from '../../benchmark/font-fixtures';
 
 import type { LiveTextScene } from '../shared/live-text-scene';
 
-/**
- * Stable Benchmark Ipsum workload corpus for native-strike rendering checks.
- *
- * Keep each concern on its own line so a visual failure can be localized without
- * changing the corpus. Missing fixture coverage is reported rather than hidden by
- * substituting different text.
- */
+/** Stable corpus for native-strike checks: one concern per line so a visual failure localizes; don't substitute text to hide missing fixture coverage. */
 export const BENCHMARK_IPSUM_CONFORMANCE_LINES = [
   'Lorem ipsum dolor sit amet.',
   'Hamburgefontsiv 0123456789.',
@@ -19,13 +13,7 @@ export const BENCHMARK_IPSUM_CONFORMANCE_LINES = [
 
 export const BENCHMARK_IPSUM_CONFORMANCE_TEXT = BENCHMARK_IPSUM_CONFORMANCE_LINES.join('\n');
 
-/**
- * Paragraph-scale Latin workload for the continuously rendered benchmark surface.
- *
- * This is intentionally meaningful enough to inspect while retaining repeated
- * kerning pairs, ligature candidates, numerals, punctuation, and mathematics.
- * Complex-script universality remains in its separately pinned fixture corpus.
- */
+/** Paragraph-scale Latin workload for the continuously rendered surface; retains kerning pairs, ligatures, numerals, punctuation, and math. Complex-script coverage lives in its own pinned fixture corpus. */
 export const BENCHMARK_IPSUM_PARAGRAPHS = [
   'Typography is a moving system. AVATAR To Wa Yo repeat familiar kerning pairs while a responsive panel changes the space around them. The quick visual check is useful, but the benchmark records the cost of shaping, layout, upload, and every rendered frame.',
   'A practical interface mixes prose with 0123456789, prices such as 24.50, ranges from 8–512 px, and punctuation—“quotes”, (parentheses), brackets, commas, and semicolons. Repeated office, affine, difficult, and shuffle words retain ff, fi, fl, ffi, and ffl candidates without claiming that every font substitutes them.',

--- a/apps/benchmarks/src/workloads/catalog.ts
+++ b/apps/benchmarks/src/workloads/catalog.ts
@@ -27,10 +27,7 @@ import type { BenchmarkWorkloadDefinition } from './shared/definition';
 /** Every runnable live example, including the two retained single-paragraph scenes. */
 export type BenchmarkWorkloadId = 'benchmark-ipsum' | 'advanced-shaping' | ComparisonWorkloadId;
 
-/**
- * The one complete route catalog. Each value is declared beside the authored
- * workload scene; this file only preserves application order and lookup.
- */
+/** The one complete route catalog; each value is declared beside its authored workload scene, this file only preserves application order and lookup. */
 export const BENCHMARK_WORKLOADS = {
   'benchmark-ipsum': benchmarkIpsumDefinition,
   'advanced-shaping': advancedShapingDefinition,

--- a/apps/benchmarks/src/workloads/comparison/contracts.ts
+++ b/apps/benchmarks/src/workloads/comparison/contracts.ts
@@ -39,14 +39,7 @@ export interface ComparisonWorkloadConfiguration {
 export type ComparisonWorkloadUpdateKind = 'rebuild' | 'retained';
 export type WorkloadCameraKind = 'orthographic' | 'perspective';
 
-/**
- * How the host parents a workload's Texts.
- *
- * `group` mounts them under one shared `TextGroup`, so every Text in the workload prepares and packs into a single
- * paragraph batch. `standalone` leaves each Text to bind its own implicit batch of one, which is what a lone
- * large-body paragraph already is; keeping that lane standalone also keeps its telemetry directly comparable to the
- * merged-v0 scene it replaces.
- */
+/** How the host parents a workload's Texts: 'group' shares one `TextGroup` batch; 'standalone' keeps each Text's own implicit batch of one. */
 export type ComparisonWorkloadBatching = 'group' | 'standalone';
 
 /** App-private inputs made available to a workload's layout hook. */
@@ -59,11 +52,7 @@ export interface ComparisonWorkloadLayoutContext {
 /** App-private inputs made available to a workload's scene factory. */
 export interface ComparisonWorkloadCreateContext extends ComparisonWorkloadLayoutContext {
   readonly animationElapsedMs: number;
-  /**
-   * The further fixtures the route's font policy named, already resident in the host's shared registry and supplied in
-   * the order the policy declares them. Icon Grid renders its icons from its one companion; a composed workload
-   * selects its companions from spans for ranges its primary face either cannot or should not shape.
-   */
+  /** Fixtures the route's font policy named, already resident, in policy-declared order; Icon Grid's icons use its one companion, a composed workload picks companions per span. */
   readonly companionFonts: readonly WorkloadFont[];
   readonly dpr: number;
   readonly font: WorkloadFont;
@@ -81,10 +70,7 @@ export interface ComparisonWorkloadAnimationScratch {
   readonly zoomText: { phraseIndex: number; phraseRevision: number; progress: number };
 }
 
-/**
- * App-private workload policy and scene hooks. The retained host remains responsible for renderer,
- * scene activation, cancellation, telemetry, and transactional Text publication.
- */
+/** App-private workload policy and scene hooks; the retained host owns renderer, scene activation, cancellation, telemetry, and transactional Text publication. */
 export interface ComparisonWorkloadDefinition {
   readonly batching: ComparisonWorkloadBatching;
   readonly cameraKind: WorkloadCameraKind;

--- a/apps/benchmarks/src/workloads/comparison/registry.ts
+++ b/apps/benchmarks/src/workloads/comparison/registry.ts
@@ -9,11 +9,7 @@ import { textLadderWorkload } from '../text-ladder/scene';
 import { zoomTextWorkload } from '../zoom-text/scene';
 import type { ComparisonWorkloadConfiguration, ComparisonWorkloadDefinition, ComparisonWorkloadId } from './contracts';
 
-/**
- * The one complete map from a comparison workload ID to its canonical example.
- * Keep host ownership outside this registry: a workload may define scene content
- * without being allowed to allocate a renderer, canvas, RAF loop, or telemetry.
- */
+/** The one complete map from workload ID to its canonical example; a workload defines scene content only, never a renderer, canvas, RAF loop, or telemetry. */
 export const COMPARISON_WORKLOADS = {
   'text-ladder': textLadderWorkload,
   'zoom-text': zoomTextWorkload,

--- a/apps/benchmarks/src/workloads/font-assets/contracts.ts
+++ b/apps/benchmarks/src/workloads/font-assets/contracts.ts
@@ -65,10 +65,7 @@ interface CommonBenchmarkFontAsset {
   readonly metrics: FontDeliveryMetrics;
 }
 
-/**
- * One fixture loaded once through the shared Glyph font graph. `loaded` is the canonical Font lease; `data` is a CPU-oracle view
- * reconstructed from the same compiled binding and portable payloads consumed by renderer integrations.
- */
+/** One fixture loaded once through the shared font graph: `loaded` is the canonical Font lease, `data` is a CPU-oracle view reconstructed from the same compiled binding and portable payloads. */
 export type BenchmarkFontAsset =
   | (CommonBenchmarkFontAsset & {
       readonly technique: 'bitmap';

--- a/apps/benchmarks/src/workloads/font-assets/library.ts
+++ b/apps/benchmarks/src/workloads/font-assets/library.ts
@@ -9,13 +9,7 @@ import {
 
 import { benchmarkFontArtifactByteLimit } from './limits';
 
-/**
- * Application-lifetime cache for benchmark fonts.
- *
- * Raster-format scenes are intentionally short-lived; transport and decoded font backings are not.
- * The custom fetch presents checked-in gzip fixtures as their decoded GLB response, which lets the
- * library use the artifact URL as its stable cache identity without retaining a second byte cache.
- */
+/** Application-lifetime font cache; the custom fetch presents checked-in gzip fixtures as their decoded GLB response, so the artifact URL alone serves as stable cache identity. */
 export const benchmarkFontLibrary = createFontLibrary({
   fetch: fetchBenchmarkFont,
   maxArtifactBytes: benchmarkFontArtifactByteLimit,

--- a/apps/benchmarks/src/workloads/font-assets/runtime.ts
+++ b/apps/benchmarks/src/workloads/font-assets/runtime.ts
@@ -55,10 +55,7 @@ export function createFontDeliveryMetrics(delivery: FontDelivery): FontDeliveryM
   };
 }
 
-/**
- * Records the source size, duration, and artifact size of one core bake. The baker is per load because its measurements
- * belong to one asset; a loader-wide baker could not attribute concurrent label and icon loads to separate metrics.
- */
+/** Records source size, duration, and artifact size of one core bake; per-load so concurrent loads (e.g. label vs icon) attribute to separate metrics. */
 export function measuredRuntimeFontBake(
   metrics: FontDeliveryMetrics,
   onProgress?: BakeProgressListener,
@@ -90,10 +87,7 @@ export async function loadBakedFont<Format extends RasterFormatMetadata>({
   return loadThroughBenchmarkLibrary({ baked: artifact }, raster, signal);
 }
 
-/**
- * Keeps one application-lifetime owner for a baked fixture. Short-lived scenes still acquire and dispose their own
- * Font leases, while the retained owner keeps the decoded source and raster variant warm across technique switches.
- */
+/** Keeps one application-lifetime owner for a baked fixture; short-lived scenes still acquire/dispose their own leases, while this owner keeps the decoded source and raster variant warm across technique switches. */
 export async function preloadBakedFont<Format extends RasterFormatMetadata>({
   artifact,
   raster,

--- a/apps/benchmarks/src/workloads/icon-grid/scene.ts
+++ b/apps/benchmarks/src/workloads/icon-grid/scene.ts
@@ -273,10 +273,7 @@ export interface IconGridViewport {
   readonly width: number;
 }
 
-/**
- * The renderer owns Text readiness, scene attachment, and disposal. Icon Grid owns which of those retained Texts
- * represent the current virtual window, including its scroll, recycling, and metrics state.
- */
+/** The renderer owns Text readiness, scene attachment, and disposal; Icon Grid owns which retained Texts represent the current virtual window (scroll, recycling, metrics). */
 export interface IconGridEntryPool {
   entries(): readonly ComparisonWorkloadEntry[];
   resize(poolCapacity: number, iconSize: number, layout: IconGridLayout): Promise<void>;

--- a/apps/benchmarks/src/workloads/rich-text/scene.ts
+++ b/apps/benchmarks/src/workloads/rich-text/scene.ts
@@ -11,40 +11,13 @@ import {
   type WorkloadTextFactoryContext,
 } from '../shared/scene-entry';
 
-/**
- * Composed-span content shaped like a film title sequence: one body face carrying per-range variation.
- *
- * Every clause exists to make one span obligation observable in a committed `ParagraphLayout`, and each obligation
- * fails in a different way, so a single colour comparison could not tell them apart:
- *
- * - `properNoun` states a face *and* an OpenType feature, so the shaper must select different glyph ids over that
- *   range while leaving every other glyph id untouched — the strongest available proof that a span reaches shaping;
- * - `tracked` states only letter spacing, the exact inverse: glyph ids must stay identical while origins move;
- * - `emphasis` states only a size, so it must inherit the surrounding face while re-measuring — its advances, and the
- *   line it breaks on, must move relative to the same paragraph composed at one size;
- * - `face` selects a second face for a range the body face *can* shape, which is an authoring choice rather than a
- *   fallback, and must move that range to another font slot;
- * - `foreign` selects a third face for a range the body face cannot shape at all, which is fallback, and must resolve
- *   without `.notdef`;
- * - `accent` states color and size together while `nested` sits inside it stating only a size, so the inner range must
- *   inherit the enclosing face and color while overriding the enclosing size;
- * - `tint` states only color, so it must leave the shaped result identical.
- *
- * Small caps need a face that carries an `smcp` table. Of the repository fixtures only Source Serif 4 does, so the
- * proper-noun span names it explicitly rather than depending on whichever face the harness has selected.
- */
+/** Composed-span content: each span isolates one shaping/paint obligation (glyph selection, tracking, resize, font-slot, fallback, paint inheritance) a single check couldn't otherwise distinguish. */
 export const RICH_TEXT_PARAGRAPH_COLOR = LIVE_TEXT_COLOR_CSS;
 export const RICH_TEXT_ACCENT_COLOR = '#ff8800';
 export const RICH_TEXT_TINT_COLOR = '#00c8ff';
 export const RICH_TEXT_SMALL_CAPS_FEATURE = 'smcp';
 
-/**
- * Companion faces the composed content selects by span, in the order the route's font policy declares them.
- *
- * `emphasis` is the deliberate authoring choice — the repository carries no italic fixture, so a serif standing beside
- * a sans body face is the available stand-in for the italic emphasis a title sequence would use. `foreign` is the
- * fallback: no Latin fixture can shape Devanagari at all.
- */
+/** Companion faces the composed content selects by span, in font-policy order: `emphasis` stands in for italic (no italic fixture exists), `foreign` is the actual fallback (no Latin face shapes Devanagari). */
 export interface RichTextCompanionFonts {
   readonly emphasis: Font<RasterFormatMetadata>;
   readonly foreign: Font<RasterFormatMetadata>;
@@ -55,22 +28,14 @@ export interface RichTextComposition {
   readonly bodyFontSize: number;
   readonly emphasisFontSize: number;
   readonly letterSpacing: number;
-  /**
-   * Whether the accent span encloses a nested style-only span. Composing the same words without that wrapper is the
-   * control that isolates what the nesting itself costs, so it is a composition input rather than a size of `0`.
-   */
+  /** Whether the accent span encloses a nested style-only span; a composition input (not a size of `0`) so composing without it isolates what nesting itself costs. */
   readonly nested: boolean;
   readonly nestedFontSize: number;
   readonly smallCaps: boolean;
   readonly tintColor: string;
 }
 
-/**
- * Which authored span occupies each index of the composed literal, with its exact UTF-16 range.
- *
- * `txt` derives these ranges from the template, so pinning them here turns an edit to the prose into a loud failure
- * instead of a silent re-attribution of every piece of per-glyph evidence that reads back through them.
- */
+/** Which authored span occupies each index of the composed literal, with its exact UTF-16 range; pinning these turns a prose edit into a loud failure instead of silent re-attribution. */
 export const RICH_TEXT_SPANS = [
   { end: 25, name: 'properNoun', start: 19 },
   { end: 66, name: 'tracked', start: 61 },
@@ -160,11 +125,7 @@ export function assertRichTextSpans(
 const RICH_TEXT_PARAGRAPH_GAP = 18;
 const RICH_TEXT_MINIMUM_PARAGRAPHS = 1;
 const RICH_TEXT_MAXIMUM_PARAGRAPHS = 6;
-/**
- * A span size change is shaping input, so the animation advances on its own cadence instead of every frame. The live
- * cost this workload reports is the cost of composed reflow, and sampling it at a fixed rate keeps that cost comparable
- * across technique and backend lanes rather than proportional to whichever lane presents frames fastest.
- */
+/** Reshapes on a fixed cadence, not every frame: this workload measures composed reflow cost, which must stay comparable across technique/backend lanes rather than scale with frame rate. */
 const RICH_TEXT_RESHAPE_INTERVAL_MS = 125;
 
 export function richTextParagraphCount(amount: number): number {
@@ -248,10 +209,7 @@ export function richTextCompanionFonts(companions: readonly WorkloadFont[]): Ric
   return { emphasis, foreign };
 }
 
-/**
- * Bitmap rejects outline and shadow and Slug V0 omits them, so the composed style only reaches for them on MTSDF —
- * the same technique gate the paint-effects lane already encodes.
- */
+/** Bitmap rejects outline/shadow and Slug V0 omits them, so composed style only reaches for them on MTSDF — the same gate the paint-effects lane uses. */
 function richTextParagraphPaint(
   technique: RasterFormatName,
   fontSize: number,
@@ -338,10 +296,7 @@ export function layoutRichTextEntries(
   }
 }
 
-/**
- * Republishes every paragraph's composed literal. A span size change is shaping input, so this deliberately reaches the
- * reshape path rather than the paint-only path: that reshape is the cost this workload exists to measure.
- */
+/** Republishes every paragraph's composed literal; a span size change is shaping input, so this deliberately takes the reshape path — that reshape cost is what this workload measures. */
 export function animateRichTextEntries(
   entries: readonly ComparisonWorkloadEntry[],
   configuration: Pick<ComparisonWorkloadConfiguration, 'animationEnabled' | 'animationSpeed' | 'fontSize'>,
@@ -399,10 +354,7 @@ export function applyRichTextRetainedConfiguration(
   }
 }
 
-/**
- * Reads the immutable companion leases retained beside the entry. `Text` intentionally does not expose the command
- * compiler's generated span records as mutable public state.
- */
+/** Reads the immutable companion leases retained beside the entry; `Text` intentionally doesn't expose the compiler's generated span records as mutable public state. */
 function retainedCompanionFonts(entry: ComparisonWorkloadEntry): RichTextCompanionFonts {
   const fonts = entry.richTextCompanionFonts;
   if (fonts === undefined) throw new Error('rich text paragraph lost its retained companion fonts');

--- a/apps/benchmarks/src/workloads/shared/definition.ts
+++ b/apps/benchmarks/src/workloads/shared/definition.ts
@@ -66,14 +66,7 @@ export type WorkloadFontPolicy =
 
 const NO_COMPANION_FIXTURES: readonly BenchmarkFontFixture[] = Object.freeze([]);
 
-/**
- * The further concrete fixtures a route needs resident beside its selected font, in declaration order.
- *
- * Icon Grid renders its icons from its one companion while its labels come from the selection; a composed route names
- * the faces its spans select for ranges the selection either cannot shape or should not shape. Both are the same host
- * obligation — load further fixtures into the shared registry — so both answer through one accessor rather than
- * through separate host branches. Order is the contract: a composed scene reads its companions positionally.
- */
+/** Further concrete fixtures a route needs resident beside its selected font, in declaration order — order is the contract, since a composed scene reads its companions positionally. */
 export function workloadCompanionFontFixtures(policy: WorkloadFontPolicy): readonly BenchmarkFontFixture[] {
   if (policy.kind === 'icon-grid') return [policy.iconFixture];
   if (policy.kind === 'composed') return policy.companionFixtures;

--- a/apps/benchmarks/src/workloads/shared/formatted-ranges.ts
+++ b/apps/benchmarks/src/workloads/shared/formatted-ranges.ts
@@ -6,10 +6,7 @@ export interface StyledTextRange {
   readonly style: SpanStyle;
 }
 
-/**
- * Adapt the benchmark's mutable, disjoint paint ranges to Glyph's structural `txt`/`span` input.
- * The numeric ranges remain app-private animation state and never become a public Text update.
- */
+/** Adapts the benchmark's mutable, disjoint paint ranges to Glyph's structural `txt`/`span` input; the numeric ranges stay app-private animation state, never a public Text update. */
 export function formatStyledRanges(source: string, ranges: readonly StyledTextRange[]): TextLiteral<never> {
   const values: Array<string | TextSpanFragment<never>> = [];
   let cursor = 0;

--- a/apps/benchmarks/src/workloads/shared/live-text-scene.ts
+++ b/apps/benchmarks/src/workloads/shared/live-text-scene.ts
@@ -4,12 +4,7 @@ import type { BenchmarkFontFixture } from '../../benchmark/font-fixtures';
 
 import type { LiveTextAnchor } from './text-style';
 
-/**
- * Authored Text input for one retained live benchmark scene.
- *
- * Renderer adapters consume this data, but do not define it: this keeps the
- * example a direct record of the public Text properties it intends to exercise.
- */
+/** Authored Text input for one retained live benchmark scene; renderer adapters consume this but do not define it, keeping the example a direct record of the public Text properties it exercises. */
 export interface LiveTextScene {
   readonly anchor: LiveTextAnchor;
   readonly direction: 'ltr' | 'rtl';

--- a/apps/benchmarks/src/workloads/shared/scene-entry.ts
+++ b/apps/benchmarks/src/workloads/shared/scene-entry.ts
@@ -2,11 +2,7 @@ import type { Font, ParagraphLayoutSummary, RasterFormatMetadata } from '@pmndrs
 import { TextGroup, type Text, type ThreeRoot } from '@pmndrs/glyph/three';
 import type * as THREE from 'three/webgpu';
 
-/**
- * Comparison workloads are technique-generic by construction: the host resolves one concrete technique per lane and
- * hands every scene the same renderer-neutral metadata view, so a single `ComparisonWorkloadDefinition` can serve
- * Bitmap, MTSDF, and Slug without recovering format-specific decoded data.
- */
+/** Technique-generic by construction: the host resolves one concrete technique per lane and hands every scene the same renderer-neutral view, so one `ComparisonWorkloadDefinition` serves Bitmap, MTSDF, and Slug. */
 export type WorkloadFont = Font<RasterFormatMetadata>;
 export type WorkloadText = Text<RasterFormatMetadata>;
 export type WorkloadTextGroup = TextGroup;
@@ -24,10 +20,7 @@ export interface MutablePaintSpan {
   readonly style: MutableSpanPaint;
 }
 
-/**
- * Shared host-facing entry data. Workload factories own construction; the host
- * only uses this structural view for scene attachment, disposal, and telemetry.
- */
+/** Shared host-facing entry data; workload factories own construction, the host only uses this structural view for scene attachment, disposal, and telemetry. */
 export interface ComparisonWorkloadEntry {
   readonly node: THREE.Object3D;
   sourceText: string;
@@ -61,13 +54,7 @@ export interface WorkloadTextFactoryContext {
   readonly root: ThreeRoot;
 }
 
-/**
- * Commits every pending Text edit beneath `root` and reports the first failure.
- *
- * Target-v1 has no per-Text readiness promise. A `TextGroup` — and a standalone `Text` that has a parent — reconciles,
- * shapes, lays out, and packs synchronously inside `updateMatrixWorld`, so this call is exactly the point at which an
- * explicit retained-Rust measurement can observe the committed revision and `error` becomes meaningful.
- */
+/** Commits every pending Text edit beneath `root` synchronously via `updateMatrixWorld` and reports the first failure — the exact point a retained-Rust measurement can observe the committed revision. */
 export function publishWorkloadTexts(root: THREE.Object3D, entries: readonly ComparisonWorkloadEntry[]): void {
   root.updateMatrixWorld(true);
   if (root instanceof TextGroup && root.error !== undefined) throw root.error;
@@ -90,10 +77,7 @@ export function paintColor(value: number): string {
   return `#${value.toString(16).padStart(6, '0')}`;
 }
 
-/**
- * Width is always an exact constraint: `at-most` resolves the line box to the measured text rather than the requested
- * measure, which silently collapses centre and end alignment onto the start edge.
- */
+/** Width is always an exact constraint: `at-most` resolves the line box to the measured text, which silently collapses center/end alignment onto the start edge. */
 export function exactWidth(size: number): { readonly mode: 'exact'; readonly size: number } {
   if (!Number.isFinite(size) || size <= 0) throw new RangeError('workload content width must be positive');
   return { mode: 'exact', size };

--- a/apps/benchmarks/src/workloads/shared/text-style.ts
+++ b/apps/benchmarks/src/workloads/shared/text-style.ts
@@ -1,9 +1,6 @@
 /** Raster-format-invariant visual inputs shared by benchmark workload examples and renderer adapters. */
 export const LIVE_TEXT_COLOR = 0xffffff;
-/**
- * The same colour target-v1 `paint` accepts. Numeric and CSS hex resolve through one transfer function, so a scene
- * that migrates from merged-v0 `color` to `paint.color` keeps its pixels rather than only its intent.
- */
+/** The same color `LIVE_TEXT_COLOR` resolves to; numeric and CSS hex resolve through the same transfer function, so both produce identical pixels. */
 export const LIVE_TEXT_COLOR_CSS = '#ffffff';
 export const LIVE_TEXT_LINE_HEIGHT = 1.25;
 export const BENCHMARK_CONTENT_INSET = 24;

--- a/apps/benchmarks/vitexec/external-raster-proof.probe.ts
+++ b/apps/benchmarks/vitexec/external-raster-proof.probe.ts
@@ -88,12 +88,4 @@ for (const [targetId, backendMetric] of [
 }
 
 export {};
-/* @workflow
-{
-  "name": "benchmark:external-raster",
-  "summary": "Prove the published third-party raster and baker extension contract in a browser.",
-  "requirements": "GPU-enabled Chromium and Vitexec.",
-  "writes": "Ignored browser caches only.",
-  "args": ["--gpu"]
-}
-*/
+/* @workflow { "name": "benchmark:external-raster", "summary": "Prove the published third-party raster and baker extension contract in a browser.", "requirements": "GPU-enabled Chromium and Vitexec.", "writes": "Ignored browser caches only.", "args": ["--gpu"] } */

--- a/apps/benchmarks/vitexec/paragraph-stress-timing.probe.ts
+++ b/apps/benchmarks/vitexec/paragraph-stress-timing.probe.ts
@@ -95,16 +95,4 @@ function percentile(values: readonly number[], ratio: number): number {
   return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)]!;
 }
 
-/* @workflow
-{
-  "name": "benchmark:paragraph-stress-timing",
-  "summary": "Attribute Paragraph Stress reflow and frame time through User Timing spans.",
-  "requirements": "GPU-enabled Chromium and Vitexec.",
-  "writes": "Standard output; optional caller-owned CPU and performance traces.",
-  "args": [
-    "--gpu",
-    "--path",
-    "/presentation?mode=benchmark&technique=mtsdf&backend=webgpu&delivery=baked&dpr=2&font=inter&workload=paragraph-stress&textTimings=1"
-  ]
-}
-*/
+/* @workflow { "name": "benchmark:paragraph-stress-timing", "summary": "Attribute Paragraph Stress reflow and frame time through User Timing spans.", "requirements": "GPU-enabled Chromium and Vitexec.", "writes": "Standard output; optional caller-owned CPU and performance traces.", "args": ["--gpu", "--path", "/presentation?mode=benchmark&technique=mtsdf&backend=webgpu&delivery=baked&dpr=2&font=inter&workload=paragraph-stress&textTimings=1"] } */

--- a/apps/benchmarks/vitexec/presentation-framerate-sweep.probe.ts
+++ b/apps/benchmarks/vitexec/presentation-framerate-sweep.probe.ts
@@ -204,16 +204,4 @@ for (const format of rasterFormats) {
   }
 }
 console.log('presentation-fps-sweep-ready', JSON.stringify(results));
-/* @workflow
-{
-  "name": "benchmark:presentation-performance",
-  "summary": "Measure the complete Presentation workload cadence on hardware WebGPU.",
-  "requirements": "GPU-enabled Chromium and Vitexec.",
-  "writes": "Standard output only.",
-  "args": [
-    "--gpu",
-    "--path",
-    "/presentation?mode=benchmark&technique=bitmap&backend=webgpu&delivery=baked&dpr=2&font=inter&workload=benchmark-ipsum"
-  ]
-}
-*/
+/* @workflow { "name": "benchmark:presentation-performance", "summary": "Measure the complete Presentation workload cadence on hardware WebGPU.", "requirements": "GPU-enabled Chromium and Vitexec.", "writes": "Standard output only.", "args": ["--gpu", "--path", "/presentation?mode=benchmark&technique=bitmap&backend=webgpu&delivery=baked&dpr=2&font=inter&workload=benchmark-ipsum"] } */

--- a/apps/benchmarks/vitexec/presentation-technique-switch.probe.ts
+++ b/apps/benchmarks/vitexec/presentation-technique-switch.probe.ts
@@ -94,16 +94,4 @@ console.log(
   }),
 );
 
-/* @workflow
-{
-  "name": "benchmark:technique-switch",
-  "summary": "Measure repeated Presentation technique switches and report font transport reuse.",
-  "requirements": "Running benchmark server, GPU-enabled Chromium, and Vitexec.",
-  "writes": "Standard output only.",
-  "args": [
-    "--gpu",
-    "--path",
-    "/presentation?mode=benchmark&technique=slug&backend=webgpu&delivery=baked&dpr=2&font=inter&workload=paragraph-stress"
-  ]
-}
-*/
+/* @workflow { "name": "benchmark:technique-switch", "summary": "Measure repeated Presentation technique switches and report font transport reuse.", "requirements": "Running benchmark server, GPU-enabled Chromium, and Vitexec.", "writes": "Standard output only.", "args": ["--gpu", "--path", "/presentation?mode=benchmark&technique=slug&backend=webgpu&delivery=baked&dpr=2&font=inter&workload=paragraph-stress"] } */

--- a/apps/benchmarks/vitexec/render-technique-three-lab.probe.ts
+++ b/apps/benchmarks/vitexec/render-technique-three-lab.probe.ts
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "benchmark:render-technique-lab",
-  "summary": "Measure generic and first-party Three plan realization and retained updates.",
-  "requirements": "Built Glyph and glyph-example packages, project Chromium, and the authenticated Inter fixture.",
-  "writes": "stdout only"
-} */
+/* @workflow { "name": "benchmark:render-technique-lab", "summary": "Measure generic and first-party Three plan realization and retained updates.", "requirements": "Built Glyph and glyph-example packages, project Chromium, and the authenticated Inter fixture.", "writes": "stdout only" } */
 const labPath = '/src/benchmark/labs/render-technique-three.ts';
 const { runRenderTechniqueThreeLab } = await import(/* @vite-ignore */ labPath);
 const report = await runRenderTechniqueThreeLab();

--- a/apps/benchmarks/vitexec/render-technique-typegpu-lab.probe.ts
+++ b/apps/benchmarks/vitexec/render-technique-typegpu-lab.probe.ts
@@ -1,10 +1,4 @@
-/* @workflow {
-  "name": "benchmark:render-technique-typegpu",
-  "summary": "Render and update the external example technique through TypeGPU and WebGPU pixel readback.",
-  "args": ["--gpu", "--path", "/reference.html"],
-  "requirements": "Built Glyph and glyph-example packages, project Chromium with WebGPU, and the authenticated Inter fixture.",
-  "writes": "stdout only"
-} */
+/* @workflow { "name": "benchmark:render-technique-typegpu", "summary": "Render and update the external example technique through TypeGPU and WebGPU pixel readback.", "args": ["--gpu", "--path", "/reference.html"], "requirements": "Built Glyph and glyph-example packages, project Chromium with WebGPU, and the authenticated Inter fixture.", "writes": "stdout only" } */
 const labPath = '/src/benchmark/labs/render-technique-typegpu.ts';
 const { runRenderTechniqueTypeGpuLab } = await import(/* @vite-ignore */ labPath);
 const report = await runRenderTechniqueTypeGpuLab();

--- a/apps/benchmarks/vitexec/runtime-fallback-parity.probe.ts
+++ b/apps/benchmarks/vitexec/runtime-fallback-parity.probe.ts
@@ -29,12 +29,4 @@ for (const technique of ['bitmap', 'mtsdf', 'slug'] as const) {
 }
 
 console.log('runtime-fallback-parity-probe-ready');
-/* @workflow
-{
-  "name": "benchmark:runtime-fallback",
-  "summary": "Verify exact Bitmap, MTSDF, and Slug baked/runtime delivery parity on hardware WebGPU.",
-  "requirements": "GPU-enabled Chromium and Vitexec; runs a cold source-font core and raster bake per technique.",
-  "writes": "Ignored browser caches only.",
-  "args": ["--gpu", "--path", "/?runner=probe"]
-}
-*/
+/* @workflow { "name": "benchmark:runtime-fallback", "summary": "Verify exact Bitmap, MTSDF, and Slug baked/runtime delivery parity on hardware WebGPU.", "requirements": "GPU-enabled Chromium and Vitexec; runs a cold source-font core and raster bake per technique.", "writes": "Ignored browser caches only.", "args": ["--gpu", "--path", "/?runner=probe"] } */

--- a/apps/benchmarks/vitexec/source-outline-fidelity.probe.ts
+++ b/apps/benchmarks/vitexec/source-outline-fidelity.probe.ts
@@ -28,12 +28,4 @@ for (const dpr of [1, 2] as const) {
 }
 
 console.log('source-outline-fidelity-probe-ready');
-/* @workflow
-{
-  "name": "benchmark:source-outline",
-  "summary": "Verify cross-technique source-outline fidelity on hardware WebGPU.",
-  "requirements": "GPU-enabled Chromium and Vitexec.",
-  "writes": "Ignored browser caches only.",
-  "args": ["--gpu", "--path", "/?runner=probe"]
-}
-*/
+/* @workflow { "name": "benchmark:source-outline", "summary": "Verify cross-technique source-outline fidelity on hardware WebGPU.", "requirements": "GPU-enabled Chromium and Vitexec.", "writes": "Ignored browser caches only.", "args": ["--gpu", "--path", "/?runner=probe"] } */

--- a/apps/r3f-hello-world/scripts/live-check.mts
+++ b/apps/r3f-hello-world/scripts/live-check.mts
@@ -8,11 +8,7 @@ import { fileURLToPath } from 'node:url';
 // actually use: WebGPU on a machine that has it, WebGL2 on a runner that does not. The probe
 // reports which one it got, so the choice is stated rather than assumed.
 
-/**
- * `vitexec` prints a browser exception and still exits 0, so a throwing probe passes the gate it
- * exists to enforce. The probe reports success by printing this marker as its last statement;
- * requiring it turns "the probe ran" into "the probe succeeded".
- */
+/** `vitexec` exits 0 even after a browser exception, so each probe must print its `marker` as the last statement to prove success rather than mere completion. */
 const applicationRoot = fileURLToPath(new URL('..', import.meta.url));
 const probes = [
   { file: './scripts/live-check.probe.ts', marker: 'r3f-hello-world-live-ok', path: '/?example=r3f' },

--- a/packages/glyph-example-raster/src/raster.ts
+++ b/packages/glyph-example-raster/src/raster.ts
@@ -30,10 +30,7 @@ export interface GlyphExampleData {
   readonly glyphCount: number;
 }
 
-/**
- * A third-party portable raster format. It owns identity, decoding, and resource lifetime and never mentions a
- * renderer; its shader subpaths consume the Codec's named buffers and supplied geometry contract.
- */
+/** A third-party portable raster format: owns identity, decoding, and resource lifetime, with no renderer dependency. */
 export const glyphExample: RasterFormat<
   RasterFormatId & 'studio.glyph-example',
   typeof GLYPH_EXAMPLE_KIND,

--- a/packages/glyph-example-raster/tests/runtime-bake-routing.test.ts
+++ b/packages/glyph-example-raster/tests/runtime-bake-routing.test.ts
@@ -17,12 +17,7 @@ interface BakeFontRequest {
 
 type WorkerMessageListener = (event: Readonly<{ data: unknown }>) => void;
 
-/**
- * The published external contract, end to end: an external raster format
- * loads through FontFace and bakes host-side through the baker its own
- * declaration names. A successful load proves the core Worker accepted only
- * its built-in work before Glyph attached and decoded the external raster.
- */
+/** Proves the external-format contract end to end: FontFace loads `glyphExample` and bakes it host-side, while the core Worker only ever handles built-in bake-font messages. */
 test('the example raster format bakes host-side while the Worker plan stays first-party', async () => {
   const source = await readFile(new URL('Inter-Regular.ttf', fixtureDirectory));
   const fontBaker = await createFontBaker(await readFile(new URL(fontBakerWasmUrl)));

--- a/packages/glyph-example-renderer/src/codec.ts
+++ b/packages/glyph-example-renderer/src/codec.ts
@@ -1,9 +1,4 @@
-/**
- * The example renderer's own Codec, authored through the root GlyphConfig vocabulary.
- *
- * A host supplies its own system lanes and compiles the shared portable technique body
- * into validated Codec bytes.
- */
+/** This renderer's Codec: compiles the shared portable technique body plus this host's own system lanes into Codec bytes. */
 import { type CodecIdFactory, type CodecBufferId, type CodecCapabilitySet, type CodecDescriptor } from '@pmndrs/glyph';
 import { compileCodec, id } from '@pmndrs/glyph/config/codec';
 import { createRasterCodecProgram } from '@pmndrs/glyph/config/raster';

--- a/packages/glyph-example-renderer/src/draw-list.ts
+++ b/packages/glyph-example-renderer/src/draw-list.ts
@@ -33,10 +33,7 @@ export type ExamplePrimitiveRecord = Readonly<
 /** One resolved portable resource selected by the config. */
 export type ExampleResourceRecord = ExampleResolvedResource;
 
-/**
- * Accepted renderer state. The hierarchy is walked while borrowed; only renderer bindings
- * and the scalar draw contract are retained after publication.
- */
+/** Accepted renderer state: the hierarchy is walked while borrowed, but only renderer bindings and the scalar draw contract are retained after publication. */
 export interface ExampleDrawList {
   readonly engineRevision: number;
   readonly revision: number;

--- a/packages/glyph-example-renderer/src/index.ts
+++ b/packages/glyph-example-renderer/src/index.ts
@@ -1,10 +1,4 @@
-/**
- * A custom renderer built only from the public root GlyphConfig vocabulary.
- *
- * It exists to keep the engine-integration surface honest: if a second renderer cannot
- * be written against the root GlyphConfig surface without reaching into package internals, this package
- * stops compiling. See `.agents/docs/planning/example-renderer.md`.
- */
+/** A custom renderer built only from the public root GlyphConfig vocabulary — a compile-time canary that the surface is sufficient without reaching into package internals. */
 export type { ExampleDraw, ExampleDrawList, ExamplePrimitiveRecord, ExampleResourceRecord } from './draw-list.js';
 export {
   ExampleText,

--- a/packages/glyph/scripts/bake-ci.mts
+++ b/packages/glyph/scripts/bake-ci.mts
@@ -1,12 +1,4 @@
-/* @workflow
-{
-  "name": "glyph:bake-check",
-  "summary": "Verify generated Unicode data, test vectors, Wasm artifacts, and the native MTSDF oracle.",
-  "requirements": "The core Node, stable Rust, and Binaryen toolchain.",
-  "writes": "Temporary build outputs only; checked-in evidence must remain unchanged.",
-  "args": []
-}
-*/
+/* @workflow { "name": "glyph:bake-check", "summary": "Verify generated Unicode data, test vectors, Wasm artifacts, and the native MTSDF oracle.", "requirements": "The core Node, stable Rust, and Binaryen toolchain.", "writes": "Temporary build outputs only; checked-in evidence must remain unchanged.", "args": [] } */
 
 import { isMainModule, runNode } from './support/command.mts';
 

--- a/packages/glyph/scripts/benchmark-engine-kernels.mts
+++ b/packages/glyph/scripts/benchmark-engine-kernels.mts
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "glyph:kernel-lab",
-  "summary": "Compares scalar, auto-vectorized, and explicit SIMD retained-engine kernels over real paragraph arrays.",
-  "requirements": "Built package and glyph:kernel-lab-build artifacts. Accepts --json.",
-  "writes": "stdout only, or the JSON report path passed to --json"
-} */
+/* @workflow { "name": "glyph:kernel-lab", "summary": "Compares scalar, auto-vectorized, and explicit SIMD retained-engine kernels over real paragraph arrays.", "requirements": "Built package and glyph:kernel-lab-build artifacts. Accepts --json.", "writes": "stdout only, or the JSON report path passed to --json" } */
 import { readFile, writeFile } from 'node:fs/promises';
 import { brotliCompressSync, constants as zlibConstants } from 'node:zlib';
 

--- a/packages/glyph/scripts/benchmark-paragraph-layout.mts
+++ b/packages/glyph/scripts/benchmark-paragraph-layout.mts
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "glyph:layout-benchmark",
-  "summary": "Measures public TextGroup updates externally through Rust text_update and Three render-plan application.",
-  "requirements": "Built package: pnpm --filter @pmndrs/glyph build. Accepts --glyphs, --reps, --warmup, --case, --json.",
-  "writes": "stdout only, or the JSON report path passed to --json"
-} */
+/* @workflow { "name": "glyph:layout-benchmark", "summary": "Measures public TextGroup updates externally through Rust text_update and Three render-plan application.", "requirements": "Built package: pnpm --filter @pmndrs/glyph build. Accepts --glyphs, --reps, --warmup, --case, --json.", "writes": "stdout only, or the JSON report path passed to --json" } */
 import { writeFile } from 'node:fs/promises';
 import { setFlagsFromString } from 'node:v8';
 import { runInNewContext } from 'node:vm';
@@ -15,19 +10,8 @@ import {
   paragraphTextForGlyphs,
 } from './support/paragraph-benchmark-fixture.mts';
 
-/**
- * Answers one question: how long does a paragraph batch take to reach uploadable instance data, per glyph, at the sizes
- * an editorial page actually reaches.
- *
- * Every number here is a median of repetitions taken after the measured code has been warmed, because a first call
- * measures the optimizing compiler rather than the algorithm. The report carries the relative standard deviation beside
- * each median so a reader can tell a real change from sampling noise. This outside-only workflow deliberately owns one
- * host timer around the complete public update. `benchmark:paragraph-stress-timing` owns browser phase attribution.
- *
- * The cases are kept apart rather than averaged. They invalidate different caches: a size change reuses the shaped run
- * and recomputes every measurement, a width change reuses shaping and measurement and replans lines, and a text change
- * reshapes. Averaging them would hide whichever one is slow.
- */
+/** Measures per-glyph cost of one full public paragraph update via a single host timer around the call;
+ * `benchmark:paragraph-stress-timing` owns browser phase attribution. Cases are kept separate, not averaged. */
 
 const budget60 = 1000 / 60;
 const budget120 = 1000 / 120;
@@ -241,10 +225,7 @@ function parseArguments(argv: readonly string[]) {
   };
 }
 
-/**
- * Allocation per update is only meaningful against a collected heap, and the workflow runner cannot pass a node flag
- * ahead of the script. Enabling the flag in-process avoids a respawn while keeping the measurement honest.
- */
+/** Enables gc in-process since the workflow runner can't pass `--expose-gc` ahead of the script; toggling the flag avoids a respawn while keeping the measurement honest. */
 function exposeGarbageCollection(): () => void {
   if (typeof globalThis.gc === 'function') return globalThis.gc;
   setFlagsFromString('--expose-gc');

--- a/packages/glyph/scripts/benchmark-retained-batch.mts
+++ b/packages/glyph/scripts/benchmark-retained-batch.mts
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "glyph:retained-batch-benchmark",
-  "summary": "Measures same-frame updates and draw batching across many retained Text instances in nested Three TextGroups.",
-  "requirements": "Built package: pnpm --filter @pmndrs/glyph build. Accepts --texts, --reps, and --warmup.",
-  "writes": "stdout only"
-} */
+/* @workflow { "name": "glyph:retained-batch-benchmark", "summary": "Measures same-frame updates and draw batching across many retained Text instances in nested Three TextGroups.", "requirements": "Built package: pnpm --filter @pmndrs/glyph build. Accepts --texts, --reps, and --warmup.", "writes": "stdout only" } */
 import * as THREE from 'three/webgpu';
 
 import { loadParagraphBenchmarkFixture } from './support/paragraph-benchmark-fixture.mts';

--- a/packages/glyph/scripts/benchmark-rust-layout-engine.mjs
+++ b/packages/glyph/scripts/benchmark-rust-layout-engine.mjs
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "glyph:rust-layout-benchmark",
-  "summary": "Measures the complete retained Rust text_update path with real font data and render-plan publication.",
-  "requirements": "Built @pmndrs/glyph and @pmndrs/glyph/bake packages. Accepts --glyphs, --reps, --warmup, --case, --technique, --corpus, --allocation, --wasm, --json, and --samples.",
-  "writes": "stdout and the optional JSON report path"
-} */
+/* @workflow { "name": "glyph:rust-layout-benchmark", "summary": "Measures the complete retained Rust text_update path with real font data and render-plan publication.", "requirements": "Built @pmndrs/glyph and @pmndrs/glyph/bake packages. Accepts --glyphs, --reps, --warmup, --case, --technique, --corpus, --allocation, --wasm, --json, and --samples.", "writes": "stdout and the optional JSON report path" } */
 import { createHash } from 'node:crypto';
 import { readFile, writeFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';

--- a/packages/glyph/scripts/build-engine-kernel-lab.mjs
+++ b/packages/glyph/scripts/build-engine-kernel-lab.mjs
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "glyph:kernel-lab-build",
-  "summary": "Build scalar, auto-vectorized, and explicit SIMD Wasm artifacts for the retained-engine kernel lab.",
-  "requirements": "Pinned Rust and Binaryen toolchains through mise.",
-  "writes": "packages/glyph/rust/shaper/target/kernel-lab"
-} */
+/* @workflow { "name": "glyph:kernel-lab-build", "summary": "Build scalar, auto-vectorized, and explicit SIMD Wasm artifacts for the retained-engine kernel lab.", "requirements": "Pinned Rust and Binaryen toolchains through mise.", "writes": "packages/glyph/rust/shaper/target/kernel-lab" } */
 import { spawn } from 'node:child_process';
 import { mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';

--- a/packages/glyph/scripts/build.mjs
+++ b/packages/glyph/scripts/build.mjs
@@ -351,12 +351,7 @@ if (process.platform !== 'win32') {
 }
 await publishStagedDistribution();
 
-/**
- * Swap the staged distribution into place. The previous tree is renamed aside first so
- * the window in which `dist/` does not exist spans two renames rather than a build, and
- * is then removed. A failed swap leaves the superseded tree on disk under its own name
- * rather than deleting a working distribution.
- */
+/** Publishes via two renames (old tree aside, then staging in); a failed swap leaves the old tree intact rather than deleted. */
 async function publishStagedDistribution() {
   const startedAt = Date.now();
   for (let attempt = 0; ; attempt += 1) {
@@ -391,11 +386,7 @@ async function publishStagedDistribution() {
   }
 }
 
-/**
- * Remove staging and superseded trees left by builds that died before their exit handler
- * ran, so a crashed or killed build cannot accumulate trees inside the cache. A
- * tree is only removed once its owning process is gone, so a concurrent build is safe.
- */
+/** Removes staging/superseded dirs from crashed builds; a dir is removed only once its owning process is dead, so concurrent builds stay safe. */
 async function reclaimAbandonedBuildDirectories() {
   const entries = await readdir(buildCacheDirectory, { withFileTypes: true }).catch(() => []);
   await Promise.all(

--- a/packages/glyph/scripts/fixtures.mts
+++ b/packages/glyph/scripts/fixtures.mts
@@ -1,12 +1,4 @@
-/* @workflow
-{
-  "name": "glyph:bitmap-fixture:generate",
-  "summary": "Regenerate the canonical Bitmap artifact through the public baker.",
-  "requirements": "Stable Rust, Binaryen, and the @pmndrs/glyph package build.",
-  "writes": "The checked-in canonical Bitmap fixture.",
-  "args": ["bitmap"]
-}
-*/
+/* @workflow { "name": "glyph:bitmap-fixture:generate", "summary": "Regenerate the canonical Bitmap artifact through the public baker.", "requirements": "Stable Rust, Binaryen, and the @pmndrs/glyph package build.", "writes": "The checked-in canonical Bitmap fixture.", "args": ["bitmap"] } */
 
 import { commandArguments, isMainModule, runNode, runPnpm } from './support/command.mts';
 

--- a/packages/glyph/scripts/font-baker/font-fixtures.mts
+++ b/packages/glyph/scripts/font-baker/font-fixtures.mts
@@ -1,21 +1,5 @@
-/* @workflow
-{
-  "name": "font-baker:shaping-oracle",
-  "summary": "Generate shaping oracle output for a supplied font and corpus.",
-  "requirements": "Stable Rust and the package oracle feature.",
-  "writes": "The caller-selected oracle output.",
-  "args": ["shaping-oracle"]
-}
-*/
-/* @workflow
-{
-  "name": "font-baker:inspect-font",
-  "summary": "Inspect one font fixture through the package oracle tooling.",
-  "requirements": "Stable Rust and the package oracle feature.",
-  "writes": "Standard output only.",
-  "args": ["inspect"]
-}
-*/
+/* @workflow { "name": "font-baker:shaping-oracle", "summary": "Generate shaping oracle output for a supplied font and corpus.", "requirements": "Stable Rust and the package oracle feature.", "writes": "The caller-selected oracle output.", "args": ["shaping-oracle"] } */
+/* @workflow { "name": "font-baker:inspect-font", "summary": "Inspect one font fixture through the package oracle tooling.", "requirements": "Stable Rust and the package oracle feature.", "writes": "Standard output only.", "args": ["inspect"] } */
 
 import { commandArguments, isMainModule, runCargo } from '../support/command.mts';
 

--- a/packages/glyph/scripts/font-baker/fuzz.mts
+++ b/packages/glyph/scripts/font-baker/fuzz.mts
@@ -1,39 +1,7 @@
-/* @workflow
-{
-  "name": "font-baker:fuzz-validator",
-  "summary": "Run the JavaScript artifact-validator fuzzer.",
-  "requirements": "Repository-pinned Node.js and a built package.",
-  "writes": "Ignored local fuzz evidence.",
-  "args": ["validator"]
-}
-*/
-/* @workflow
-{
-  "name": "font-baker:fuzz-rust",
-  "summary": "Run the package-owned Rust cargo-fuzz target.",
-  "requirements": "The nested dated nightly and cargo-fuzz toolchain.",
-  "writes": "Ignored fuzz corpus and crash artifacts.",
-  "args": ["rust"]
-}
-*/
-/* @workflow
-{
-  "name": "font-baker:fuzz-mtsdf",
-  "summary": "Run the MTSDF outline cargo-fuzz target.",
-  "requirements": "The nested dated nightly and cargo-fuzz toolchain.",
-  "writes": "Ignored fuzz corpus and crash artifacts.",
-  "args": ["mtsdf"]
-}
-*/
-/* @workflow
-{
-  "name": "font-baker:fuzz-mutation",
-  "summary": "Run deterministic Rust mutation fuzzing.",
-  "requirements": "Stable Rust.",
-  "writes": "Ignored local fuzz evidence.",
-  "args": ["mutation"]
-}
-*/
+/* @workflow { "name": "font-baker:fuzz-validator", "summary": "Run the JavaScript artifact-validator fuzzer.", "requirements": "Repository-pinned Node.js and a built package.", "writes": "Ignored local fuzz evidence.", "args": ["validator"] } */
+/* @workflow { "name": "font-baker:fuzz-rust", "summary": "Run the package-owned Rust cargo-fuzz target.", "requirements": "The nested dated nightly and cargo-fuzz toolchain.", "writes": "Ignored fuzz corpus and crash artifacts.", "args": ["rust"] } */
+/* @workflow { "name": "font-baker:fuzz-mtsdf", "summary": "Run the MTSDF outline cargo-fuzz target.", "requirements": "The nested dated nightly and cargo-fuzz toolchain.", "writes": "Ignored fuzz corpus and crash artifacts.", "args": ["mtsdf"] } */
+/* @workflow { "name": "font-baker:fuzz-mutation", "summary": "Run deterministic Rust mutation fuzzing.", "requirements": "Stable Rust.", "writes": "Ignored local fuzz evidence.", "args": ["mutation"] } */
 
 import { commandArguments, isMainModule, runNode } from '../support/command.mts';
 

--- a/packages/glyph/scripts/generate-mtsdf-oracle-evidence.mjs
+++ b/packages/glyph/scripts/generate-mtsdf-oracle-evidence.mjs
@@ -1,21 +1,5 @@
-/* @workflow
-{
-  "name": "glyph:mtsdf-oracle:generate",
-  "summary": "Regenerate native msdfgen comparison evidence for the production MTSDF kernel.",
-  "requirements": "Stable Rust, CMake, a C++ compiler, tar, and network access to the pinned msdfgen source.",
-  "writes": "Checked-in native MTSDF oracle evidence and an ignored pinned-tool cache.",
-  "args": []
-}
-*/
-/* @workflow
-{
-  "name": "glyph:mtsdf-oracle:check",
-  "summary": "Verify the production MTSDF kernel against checked-in native oracle evidence.",
-  "requirements": "Stable Rust and the checked-in native oracle evidence.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "glyph:mtsdf-oracle:generate", "summary": "Regenerate native msdfgen comparison evidence for the production MTSDF kernel.", "requirements": "Stable Rust, CMake, a C++ compiler, tar, and network access to the pinned msdfgen source.", "writes": "Checked-in native MTSDF oracle evidence and an ignored pinned-tool cache.", "args": [] } */
+/* @workflow { "name": "glyph:mtsdf-oracle:check", "summary": "Verify the production MTSDF kernel against checked-in native oracle evidence.", "requirements": "Stable Rust and the checked-in native oracle evidence.", "writes": "Nothing.", "args": ["--check"] } */
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';

--- a/packages/glyph/scripts/generate-mtsdf-quality-evidence.mjs
+++ b/packages/glyph/scripts/generate-mtsdf-quality-evidence.mjs
@@ -1,21 +1,5 @@
-/* @workflow
-{
-  "name": "glyph:mtsdf-quality:generate",
-  "summary": "Regenerate reconstructed-coverage quality evidence for the production MTSDF kernel.",
-  "requirements": "Stable Rust and the authenticated font fixtures.",
-  "writes": "Checked-in MTSDF reconstruction quality evidence.",
-  "args": []
-}
-*/
-/* @workflow
-{
-  "name": "glyph:mtsdf-quality:check",
-  "summary": "Verify reconstructed MTSDF coverage against checked-in ground-truth quality evidence.",
-  "requirements": "Stable Rust and the authenticated font fixtures.",
-  "writes": "Nothing.",
-  "args": ["--check"]
-}
-*/
+/* @workflow { "name": "glyph:mtsdf-quality:generate", "summary": "Regenerate reconstructed-coverage quality evidence for the production MTSDF kernel.", "requirements": "Stable Rust and the authenticated font fixtures.", "writes": "Checked-in MTSDF reconstruction quality evidence.", "args": [] } */
+/* @workflow { "name": "glyph:mtsdf-quality:check", "summary": "Verify reconstructed MTSDF coverage against checked-in ground-truth quality evidence.", "requirements": "Stable Rust and the authenticated font fixtures.", "writes": "Nothing.", "args": ["--check"] } */
 
 // The native msdfgen oracle answers "does the kernel agree with msdfgen". It cannot answer "is the
 // glyph the shader reconstructs actually the glyph": a faithfully reproduced artifact is still an
@@ -39,12 +23,7 @@ const EM_SIZE = 64;
 const PIXEL_RANGE = 8;
 const ZOOM = 8;
 
-/**
- * Glyphs chosen for the failure modes that distinguish a correct multi-channel field from a
- * flattened one: right-angle stems, diagonal junctions, tight counters, and the pinch points of a
- * doubled bowl. `o` carries no corner at all and is the control — error correction never engages,
- * so its numbers must not move when correction changes.
- */
+/** Covers right-angle, diagonal, and pinch-point failure modes; `o` is the no-correction control. */
 const CORPUS = [
   { font: 'inter-v4.1/Inter-Regular.ttf', characters: 'IHnoMA48&' },
   { font: 'source-serif-4.005/SourceSerif4-Regular.ttf', characters: 'AMweg8' },

--- a/packages/glyph/scripts/measure-mtsdf-admission-size.mjs
+++ b/packages/glyph/scripts/measure-mtsdf-admission-size.mjs
@@ -1,9 +1,4 @@
-/* @workflow {
-  "name": "glyph:mtsdf-admission-size",
-  "summary": "Verify or refresh the feature-minimal MTSDF generator size evidence.",
-  "requirements": "Pinned Rust and Binaryen toolchains through mise. Pass --write to refresh same-host evidence.",
-  "writes": "stdout only, or rust/mtsdf-admission/evidence/size-v0.json with --write"
-} */
+/* @workflow { "name": "glyph:mtsdf-admission-size", "summary": "Verify or refresh the feature-minimal MTSDF generator size evidence.", "requirements": "Pinned Rust and Binaryen toolchains through mise. Pass --write to refresh same-host evidence.", "writes": "stdout only, or rust/mtsdf-admission/evidence/size-v0.json with --write" } */
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';

--- a/packages/glyph/scripts/measure-mtsdf-generator.mjs
+++ b/packages/glyph/scripts/measure-mtsdf-generator.mjs
@@ -1,12 +1,4 @@
-/* @workflow
-{
-  "name": "glyph:mtsdf-generator-profile",
-  "summary": "Measure compile, initialization, cold-corpus, and warm-corpus MTSDF generator cost.",
-  "requirements": "A built Glyph package.",
-  "writes": "Standard output only.",
-  "args": []
-}
-*/
+/* @workflow { "name": "glyph:mtsdf-generator-profile", "summary": "Measure compile, initialization, cold-corpus, and warm-corpus MTSDF generator cost.", "requirements": "A built Glyph package.", "writes": "Standard output only.", "args": [] } */
 
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';

--- a/packages/glyph/scripts/profile-mtsdf-baker.mjs
+++ b/packages/glyph/scripts/profile-mtsdf-baker.mjs
@@ -1,12 +1,4 @@
-/* @workflow
-{
-  "name": "glyph:mtsdf-baker-profile",
-  "summary": "Profile native, direct, and worker MTSDF baker phases against accepted evidence.",
-  "requirements": "Stable Rust, the profiling feature, and built Text and Font Baker packages.",
-  "writes": "Standard output, or checked-in phase evidence when passed --write.",
-  "args": []
-}
-*/
+/* @workflow { "name": "glyph:mtsdf-baker-profile", "summary": "Profile native, direct, and worker MTSDF baker phases against accepted evidence.", "requirements": "Stable Rust, the profiling feature, and built Text and Font Baker packages.", "writes": "Standard output, or checked-in phase evidence when passed --write.", "args": [] } */
 
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';

--- a/packages/glyph/scripts/support/paragraph-benchmark-fixture.mts
+++ b/packages/glyph/scripts/support/paragraph-benchmark-fixture.mts
@@ -11,12 +11,7 @@ export const paragraphBenchmarkSource = [
   'Scientific copy adds x2+y2~z2, 0<=a<=1, and pi. Arrows point both ways. These symbols expose missing coverage, uneven baselines, bad advances, and atlas placement errors that plain alphabet samples can hide.',
 ].join('\n');
 
-/**
- * Simplified and Japanese copy carrying the punctuation that drives UAX #14 LB16/LB17 -- fullwidth
- * comma, ideographic full stop, and bracket pairs. Latin prose reaches those rules rarely; CJK reaches
- * them on most characters, which is the only reason the quadratic scan in `class_after_spaces` stayed
- * invisible for so long. Every scalar here is covered by the pinned CJK contract strike.
- */
+/** CJK punctuation driving UAX #14 LB16/LB17 (fullwidth comma, ideographic stop, brackets); every scalar here is covered by the pinned CJK contract strike. */
 export const paragraphBenchmarkSourceCjk = [
   '简体中文段落没有空格，需要在合法边界换行，并保持（标点）与、完整。',
   '日本語の段落も空白を使わず、句読点や括弧（例）で行を折り返します。',

--- a/packages/glyph/scripts/unicode.mts
+++ b/packages/glyph/scripts/unicode.mts
@@ -1,39 +1,7 @@
-/* @workflow
-{
-  "name": "glyph:unicode-data:generate",
-  "summary": "Regenerate the Rust Unicode script, bidi, and line-break tables.",
-  "requirements": "Repository-pinned Node.js.",
-  "writes": "Generated Rust Unicode data.",
-  "args": ["generate-data"]
-}
-*/
-/* @workflow
-{
-  "name": "glyph:unicode-data:check",
-  "summary": "Verify Unicode script and bidi tables without writing.",
-  "requirements": "Repository-pinned Node.js.",
-  "writes": "Nothing.",
-  "args": ["check-data"]
-}
-*/
-/* @workflow
-{
-  "name": "glyph:unicode-tests:sync",
-  "summary": "Synchronize official Unicode conformance vectors.",
-  "requirements": "Network access to the pinned Unicode sources.",
-  "writes": "Authenticated Unicode test fixtures.",
-  "args": ["sync-tests"]
-}
-*/
-/* @workflow
-{
-  "name": "glyph:unicode-tests:check",
-  "summary": "Verify official Unicode conformance vectors without downloading.",
-  "requirements": "Checked-in authenticated fixtures.",
-  "writes": "Nothing.",
-  "args": ["check-tests"]
-}
-*/
+/* @workflow { "name": "glyph:unicode-data:generate", "summary": "Regenerate the Rust Unicode script, bidi, and line-break tables.", "requirements": "Repository-pinned Node.js.", "writes": "Generated Rust Unicode data.", "args": ["generate-data"] } */
+/* @workflow { "name": "glyph:unicode-data:check", "summary": "Verify Unicode script and bidi tables without writing.", "requirements": "Repository-pinned Node.js.", "writes": "Nothing.", "args": ["check-data"] } */
+/* @workflow { "name": "glyph:unicode-tests:sync", "summary": "Synchronize official Unicode conformance vectors.", "requirements": "Network access to the pinned Unicode sources.", "writes": "Authenticated Unicode test fixtures.", "args": ["sync-tests"] } */
+/* @workflow { "name": "glyph:unicode-tests:check", "summary": "Verify official Unicode conformance vectors without downloading.", "requirements": "Checked-in authenticated fixtures.", "writes": "Nothing.", "args": ["check-tests"] } */
 
 import { commandArguments, isMainModule, runNode } from './support/command.mts';
 

--- a/packages/glyph/src/config/codec-program.ts
+++ b/packages/glyph/src/config/codec-program.ts
@@ -5,13 +5,7 @@ import type { CodecBufferDeclaration, TechniqueSchemaMetadata } from './schema.j
 import { isTechniqueSchema } from './schema.js';
 import { normalizeCodecProgramSystemBuffers, recordTechniqueCodecBody } from '../internal/codec-program-contract.js';
 
-/**
- * Expression DSL over the codec-program register machine. Authors reference named
- * values instead of register numbers; `compile()` lowers the expression graph to the
- * same forward-only `CodecOperation` records the hand-numbered form produced,
- * allocating registers automatically and failing loudly on exhaustion. The wire
- * format, validator, and interpreter are untouched — this is authoring only.
- */
+/** Expression DSL over the codec-program register machine; `compile()` lowers it to the same forward-only `CodecOperation` records as the hand-numbered form. Wire format, validator, and interpreter are unaffected. */
 
 const MAX_REGISTERS = 32;
 
@@ -62,13 +56,7 @@ function nodeOf(value: CodecF32Value | CodecU32Value): Node {
   return node;
 }
 
-/**
- * A loaded value's input index only means something inside the program that
- * created it; storing it elsewhere would silently read a different field.
- * Provenance is stamped at construction and combined in O(1) per node, so
- * shared expression DAGs never require a graph walk: constants stay
- * scope-free, and mixing two authoring scopes fails at the combinator itself.
- */
+/** Authoring scope is stamped at construction and combined in O(1) here — never a graph walk. Mixing two scopes throws immediately. */
 function combinedAuthoringScope(left: Node, right: Node): object | undefined {
   if (
     left.authoringScope !== undefined &&

--- a/packages/glyph/src/config/glyph.ts
+++ b/packages/glyph/src/config/glyph.ts
@@ -345,10 +345,7 @@ export interface DisplayListChanges<Bindings extends GlyphBindingSet> {
   readonly retirements: BorrowedCommandSequence<Retirement<Bindings['resource'], Bindings['buffer']>>;
 }
 
-/**
- * One phase-structured retained display-list update. Every reference is already a typed
- * binding; numeric engine IDs and the trusted wire representation remain private.
- */
+/** One phase-structured retained display-list update; references are typed bindings — numeric engine IDs and the wire representation stay private. */
 export interface CommandBufferView<Bindings extends GlyphBindingSet> {
   readonly delivery: 'borrowed-command-buffer';
   readonly engineRevision: number;

--- a/packages/glyph/src/config/raster-format.ts
+++ b/packages/glyph/src/config/raster-format.ts
@@ -24,11 +24,7 @@ declare const rasterFormatRequestBrand: unique symbol;
 /** Stable public identity for one portable raster format. */
 export type RasterFormatId = string & { readonly [rasterFormatIdBrand]: true };
 
-/**
- * Stable raster-authored identity for one renderer resource realization.
- * Equal IDs must describe the same format, schema role, companion set, metadata,
- * and bytes. Mint a new ID whenever any part of that realization changes.
- */
+/** Raster-authored identity for one renderer resource realization. Equal IDs must describe the same format, schema role, companion set, metadata, and bytes — mint a new ID whenever any part changes. */
 export type RasterResourceId = string & { readonly [rasterResourceIdBrand]: true };
 
 /** Text effects a raster format and its shader can render. */

--- a/packages/glyph/src/config/raster.ts
+++ b/packages/glyph/src/config/raster.ts
@@ -52,11 +52,7 @@ export type RasterCodecBodyFactory<Schema extends TechniqueSchemaMetadata = Tech
   capabilities: CodecCapabilitySet,
 ) => CompiledCodecProgramBody<Schema>;
 
-/**
- * Portable output of cold font compilation: renderer-neutral binding bytes plus
- * retained portable resources. No renderer program or GPU object crosses this
- * boundary, and every retained resource is linked to its declared schema name.
- */
+/** Portable output of cold font compilation: renderer-neutral binding bytes plus retained portable resources. No renderer program or GPU object crosses this boundary. */
 export interface CompiledRasterFont {
   readonly binding: Uint8Array;
   readonly resources: ReadonlyMap<RasterResourceId, PortableResource>;
@@ -125,12 +121,7 @@ export type RasterFontBinding<Binding extends TechniqueBindingDeclaration> = {
 export interface RasterCodecFontCompiler<Format extends RasterFormatMetadata, Schema extends TechniqueSchemaMetadata> {
   readonly font: RasterCodecFont<Format>;
   readonly compile: (binding: RasterFontBinding<Schema['binding']>) => CompiledRasterFont;
-  /**
-   * Retain one immutable portable payload under a schema-declared resource name
-   * and its stable raster-format-authored key. Retaining an undeclared name,
-   * repeating a name or key, or breaking the declared payload contract rejects
-   * the compiled result.
-   */
+  /** Retain one immutable payload under a schema-declared resource name and stable key. An undeclared name, a repeated name/key, or a broken payload contract rejects the compiled result. */
   readonly retain: <Name extends SchemaResourceName<Schema>>(
     name: Name,
     key: RasterResourceId,
@@ -251,10 +242,7 @@ export function compileRasterFont<Format extends RasterFormatMetadata>(
   });
 }
 
-/**
- * Read named binding fields and portable resources without exposing raster-format-owned decoded data.
- * The view borrows `compiled`; mutating its public byte or payload arrays invalidates later reads.
- */
+/** Reads named binding fields and portable resources without exposing raster-format-owned decoded data. The view borrows `compiled` — mutating its public byte or payload arrays invalidates later reads. */
 export function readCompiledRasterFont<Format extends RasterFormatMetadata, Schema extends TechniqueSchemaMetadata>(
   compiled: CompiledRasterFont,
   codec: RasterCodec<Format, Schema> & { readonly raster: Format; readonly schema: Schema },

--- a/packages/glyph/src/config/resources.ts
+++ b/packages/glyph/src/config/resources.ts
@@ -1,12 +1,4 @@
-/**
- * The constrained portable resource vocabulary a compiled font may retain.
- *
- * A payload is immutable data — bytes plus the typed measure a renderer needs to
- * realize it — never a GPU object, shader-language node, or renderer callback.
- * The union is deliberately small: it describes only what the shipped raster formats
- * actually retain, not a universal GPU object model. A mismatched texture size,
- * index, accessor, or draw range is rejected before any device is touched.
- */
+/** Constrained portable resource vocabulary: immutable data (bytes + typed measure), never a GPU object, shader node, or callback. A mismatched size/index/accessor/draw range is rejected before any device is touched. */
 
 export type PortableComponentType = 'f32' | 'u32' | 'i16' | 'u16' | 'u8';
 
@@ -59,10 +51,7 @@ export interface PortableBufferView {
   readonly length: number;
 }
 
-/**
- * One typed element stream over a buffer view: `count` elements of
- * `components` scalars each, starting `offset` bytes into the view.
- */
+/** One typed element stream over a buffer view: `count` elements of `components` scalars each, starting `offset` bytes into the view. */
 export interface PortableAccessor {
   readonly componentType: PortableComponentType;
   readonly components: 1 | 2 | 3 | 4;
@@ -123,12 +112,7 @@ export interface PortableTextureArrayPayload {
   readonly bytes: Uint8Array;
 }
 
-/**
- * GLB-like geometry: immutable bytes plus typed accessors and semantic
- * attributes over internal buffer views, optional indices, topology, draw
- * range — never a renderer geometry object. The command buffer's record span is the
- * sole instance-count authority; per-record data belongs in codec buffers.
- */
+/** GLB-like geometry: immutable bytes plus typed accessors and attributes over buffer views, optional indices/topology/draw range — never a renderer geometry object. */
 export interface PortableGeometryPayload {
   readonly kind: 'geometry';
   readonly topology: PortableTopology;
@@ -167,10 +151,7 @@ export function definePortableVertexSemantic<const Semantic extends string>(
   return semantic as PortableCustomVertexSemantic & Semantic;
 }
 
-/**
- * Validate one caller-owned payload against its declared resource kind. This is
- * structural validation only; `retain` is the boundary that validates and copies reserved payloads.
- */
+/** Validates one caller-owned payload against its declared resource kind — structural only; `retain` is the boundary that validates and copies reserved payloads. */
 export function assertPortableResource(
   kind: PortableResourceKind,
   name: string,
@@ -506,11 +487,7 @@ function isTopology(value: unknown): value is PortableTopology {
   return value === 'triangle-list' || value === 'triangle-strip';
 }
 
-/**
- * Array.isArray without collapsing a typed readonly array's element type to
- * `any`: the built-in guard narrows through a mutable `any[]`, which erases
- * declared payload types this module still needs.
- */
+/** Array.isArray without collapsing a typed readonly array's element type to `any` — the built-in guard narrows through `any[]`, erasing declared payload types. */
 function isPortableList<T>(value: unknown): value is readonly T[] {
   return Array.isArray(value);
 }

--- a/packages/glyph/src/config/schema.ts
+++ b/packages/glyph/src/config/schema.ts
@@ -1,11 +1,4 @@
-/**
- * The single authority for a Codec program family's physical shape. A schema declares —
- * once, colocated with the technique — the buffer ids, scalar kinds, and lane
- * meanings that its codec programs produce and its shader realizations consume,
- * plus the portable render contract: named resources and declared geometry.
- * Codec stores, binding compilers, command-buffer projectors, and shader interfaces all
- * derive from the declaration; none of them restate it.
- */
+/** Single authority for a Codec program family's physical shape — buffer ids, scalar kinds, lane meanings, and the portable render contract. Codec stores, binding compilers, projectors, and shader interfaces all derive from it. */
 
 import type { RasterFormatId } from './raster-format.js';
 import {
@@ -35,12 +28,7 @@ export type CodecBufferDeclarations = Readonly<Record<string, CodecBufferDeclara
 const techniqueSchemaBrand: unique symbol = Symbol('glyph.technique-schema');
 const techniqueSchemaInstances = new WeakSet<object>();
 
-/**
- * Validate and freeze a named buffer set: nonzero unique ids, at least one lane
- * each. The result is an owned, deeply frozen copy — caller input is never
- * mutated (rejection leaves it untouched), and caller accessors are read once
- * here so they can never change a validated width afterwards.
- */
+/** Validates and freezes a named buffer set (nonzero unique ids, at least one lane each) into an owned, deep-frozen copy — caller input is never mutated. */
 export function defineCodecBuffers<const Buffers extends CodecBufferDeclarations>(buffers: Buffers): Buffers {
   if (!isNonArrayObject(buffers)) throw new TypeError('codec buffers need a declaration object');
   const seen = new Set<number>();
@@ -126,10 +114,7 @@ export interface TechniqueResourceGroupDeclaration {
   readonly cardinality?: 'one' | 'many';
 }
 
-/**
- * One declared logical resource from the constrained portable payload
- * vocabulary. Renderer-specific or opaque payloads cannot cross this boundary.
- */
+/** One declared logical resource from the constrained portable payload vocabulary — renderer-specific or opaque payloads cannot cross this boundary. */
 export type TechniqueResourceDeclaration =
   | TechniqueBufferResourceDeclaration
   | TechniqueTextureResourceDeclaration
@@ -140,14 +125,7 @@ export type TechniqueResourceDeclaration =
 export type TechniqueResourceDeclarations = Readonly<Record<string, TechniqueResourceDeclaration>>;
 type NoTechniqueResources = Readonly<Record<never, never>>;
 
-/**
- * Portable geometry kinds, deliberately disjoint from the wire
- * `enginePrimitive` command enum (`glyph`, `decoration`, …): a wire primitive
- * is a record-span command, while this vocabulary says what geometry one draw
- * realizes. `synthetic-quad` is the implicit generated unit quad and needs no
- * resource; every other kind — `quad` today, technique kinds such as `hull`
- * later — supplies an explicit geometry resource.
- */
+/** Portable geometry kinds, deliberately disjoint from the wire `enginePrimitive` command enum. `synthetic-quad` is the implicit unit quad needing no resource; every other kind supplies an explicit geometry resource. */
 declare const techniqueGeometryKindBrand: unique symbol;
 
 /** A named supplied shape beyond the built-in quad and hull vocabulary. */
@@ -227,19 +205,7 @@ export interface TechniqueSchemaDeclaration<
   readonly resources?: Resources;
   /** The portable render contract: declared geometry and its resource linkage; absent means synthetic-quad. */
   readonly render?: TechniqueRenderDeclaration<keyof Resources & string, GeometryResourceNames<Resources>>;
-  /**
-   * Opt-in glyph-origin metadata: names the declared f32 buffer whose first two
-   * lanes carry the glyph's position. Renderers that augment glyph origins
-   * (animation retargeting) consult this instead of assuming a measure;
-   * raster formats without it are never augmented.
-   *
-   * The lanes are deliberately NOT required to be in any particular space. All
-   * three shipping raster formats differ: MSDF and Slug pack the ink box's top-left
-   * corner, and Bitmap stores the origin plus the baked strike's raster bearing.
-   * An augmenting renderer works in displacement from the rest value the Codec
-   * wrote, which is space-independent, so no technique has to describe its
-   * packing to be animatable.
-   */
+  /** Opt-in glyph-origin metadata: names the f32 buffer whose first two lanes carry glyph position. Lanes need not share a space — augmenting renderers work in displacement from the Codec's rest value, so packing is space-independent. */
   readonly glyphOrigin?: { readonly buffer: GlyphOriginBufferNames<Buffers> };
 }
 
@@ -547,11 +513,7 @@ function defineVertexInputs(value: unknown, resource: string, technique: string)
   );
 }
 
-/**
- * Validate and freeze the geometry declaration. `synthetic-quad` is the
- * no-resource path; every supplied kind must name a declared geometry resource
- * and state its coordinate convention.
- */
+/** Validates and freezes the geometry declaration. `synthetic-quad` is the no-resource path; every supplied kind must name a declared geometry resource and its coordinate convention. */
 function defineGeometryDeclaration(
   geometry: TechniqueGeometryDeclaration,
   technique: string,
@@ -629,10 +591,7 @@ function isNonArrayObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/**
- * Derive the wire buffer list a technique's programs publish, in declaration
- * order — the schema is the only witness to ids, scalar kinds, and widths.
- */
+/** Derives the wire buffer list a technique's programs publish, in declaration order — the schema is the only witness to ids, scalar kinds, and widths. */
 export function schemaCodecBuffers<const Schema extends TechniqueSchemaMetadata>(schema: Schema): CodecBuffer[] {
   return Object.values(schema.buffers).map((buffer) => ({
     id: buffer.id,

--- a/packages/glyph/src/engine-encoding.ts
+++ b/packages/glyph/src/engine-encoding.ts
@@ -10,12 +10,7 @@ import type {
 } from './internal/frame-wire.js';
 import type { HandleIdFactory, ParagraphId, StyleId } from './internal/glyph-id.js';
 
-/**
- * The single implementation of the Text-to-engine encodings shared by every host.
- * Every GlyphConfig integration compiles constraints, regions, styles, limits, and
- * incremental text edits through these functions so hosts cannot drift in what they
- * ask the engine to flow.
- */
+/** Single implementation of the Text-to-engine encodings shared by every host — every GlyphConfig integration compiles through these functions so hosts cannot drift. */
 
 export function normalizedColumns(
   layout: ParagraphLayout | undefined,
@@ -225,17 +220,7 @@ function engineDecoration(decoration: NonNullable<TextStyle['decoration']>, styl
   };
 }
 
-/**
- * The spans that state a style over text, in authored order.
- *
- * An empty span covers no cluster and so states nothing, but the engine's style resolution walks
- * the text offset by offset and cannot advance across a zero-width scope, so one reaching it fails
- * the whole frame (`style_state.rs`, `resolve`). Cluster resolution produces an empty span whenever
- * an edit hands a span's last cluster to the span before it, and keeps it in `Text.spans` so the
- * loss is visible and later indices do not shift; dropping it here is what keeps that record from
- * costing the paragraph. Style ids stay contiguous from the emitted order because the removal pass
- * that trims a shrunken style list counts on it.
- */
+/** Drops only empty spans (start === end) — the engine's style resolution can't advance across a zero-width scope and fails the frame otherwise (`style_state.rs::resolve`); style ids must stay contiguous with the emitted order. */
 export function styledSpans<Span extends ParagraphSpan<RasterFormatMetadata>>(
   spans: readonly Span[] | undefined,
 ): readonly Span[] {
@@ -287,12 +272,7 @@ function linearColorBytes(color: readonly number[]): readonly [number, number, n
   return [srgbByte(color[0]!), srgbByte(color[1]!), srgbByte(color[2]!), Math.round(color[3]! * 255)];
 }
 
-/**
- * Replacement text carries its own formatting: a literal brings its spans and a
- * plain string brings none. Retaining the previous spans would reinterpret them
- * against unrelated text, so an update that replaces text without stating spans
- * clears the ones it replaced.
- */
+/** Replacing text without stating spans clears the previous spans — retaining them would reinterpret old formatting against unrelated text. */
 export function replacedContent<Update extends { readonly text?: unknown; readonly spans?: unknown }>(
   update: Update,
 ): Update {

--- a/packages/glyph/src/font-face.ts
+++ b/packages/glyph/src/font-face.ts
@@ -320,13 +320,7 @@ export function isFontFaceSelection(selection: unknown): selection is FontFaceSe
   return state !== undefined && !state.face.owner.disposed;
 }
 
-/**
- * @internal Acquire an independent immutable Font lease without a configured handle.
- *
- * A configured renderer may resolve an omitted or string format through its own format table.
- * A caller outside a handle has no such config, so it must provide a selection whose declared format
- * resolves to an imported raster format. The caller owns and must dispose the returned lease.
- */
+/** @internal Acquires an independent immutable Font lease without a configured handle; the selection's format must resolve on its own. The caller owns and must dispose the returned lease. */
 export function acquireLoadedFontFaceSelection<const Selection extends FontFaceSelection>(
   selection: Selection,
 ): Font<FontFaceRasterOf<Selection>>;

--- a/packages/glyph/src/formatted-text.ts
+++ b/packages/glyph/src/formatted-text.ts
@@ -31,36 +31,10 @@ export interface TextSpanFragment<
   readonly properties: Properties;
 }
 
-/**
- * The join rule `compose` below applies, re-exported for the React `<Text>` compiler.
- *
- * `flattenText` is the second implementation of the same compiler and must resolve its joins by the
- * same rule; it reaches that rule through this module because the adapter layers do not import from
- * `internal/`. Neither compiler restates the rule, and neither is allowed to drift from the other.
- */
+/** Re-exported so `flattenText` (the React `<Text>` compiler) can resolve joins by the same rule as `compose` below — adapter layers don't import `internal/`, and the two must never drift. */
 export { resolveRangesToClusters } from './internal/graphemes.js';
 
-/**
- * Resolve every span boundary onto the extended grapheme cluster grid of `text`.
- *
- * The engine resolves exactly one style per extended grapheme cluster and rejects a whole frame
- * whose styles split one (`cluster_state.rs`, `build`), reporting a numeric status that names no
- * span. `Text` therefore resolves span offsets through this function before any of them reach the
- * engine, so the rule a caller sees is the constructive one -- a cluster takes the style of its
- * base -- rather than a deferred rejection.
- *
- * `txt`/`span` and the React `<Text>` tree compile a document that states no offsets at all, and each
- * resolves the boundaries it derives at its own concatenation joins
- * (`resolveRangesToClusters`), so a compiled paragraph arrives here already on the cluster grid and
- * this call finds nothing to move.
- *
- * It stays module-local to the structural compilers and engine adapter; applications never author the
- * resulting offset records.
- *
- * Text that is not well-formed UTF-16 has no cluster grid to resolve against and is the engine's to
- * reject; its spans are returned untouched so that the presence of a span cannot decide whether a
- * lone surrogate is accepted.
- */
+/** Resolves span boundaries onto the grapheme-cluster grid before the engine sees them — it rejects any frame whose styles split a cluster (`cluster_state.rs::build`). Malformed UTF-16 has no grid; spans pass through untouched for the engine to reject. */
 export function alignSpansToClusters<Span extends ClusterAlignableRange>(
   text: string,
   spans: readonly Span[],
@@ -131,16 +105,7 @@ export function span<Format extends RasterFormatMetadata>(
   return createSpanTag<Format, typeof properties>(properties) as SpanTag<Format> | UnboundSpanTag;
 }
 
-/**
- * Compile one fragment tree into the `(text, spans)` pair the engine consumes.
- *
- * The tree states no offsets. Every boundary below is derived at a concatenation JOIN -- `start` is
- * the length before a fragment's text is appended, `end` the length after -- and concatenation can
- * fuse the tail of one fragment with the head of the next into a single extended grapheme cluster,
- * naming an offset that is not a boundary of the text just produced. `resolveRangesToClusters`
- * settles those joins against the finished text under the one rule `flattenText` uses on the React
- * tree: the fused cluster takes the style of its base, which is the earlier fragment's.
- */
+/** Compiles a fragment tree into `(text, spans)`; boundaries are concatenation joins (`start`/`end` = length before/after append) that may land mid-cluster. `resolveRangesToClusters` settles them under the same rule as `flattenText` — the fused cluster takes its earlier base's style. */
 function compose<Format extends RasterFormatMetadata>(
   strings: TemplateStringsArray,
   values: readonly TextTemplateValue<Format>[],

--- a/packages/glyph/src/glyph-engine.ts
+++ b/packages/glyph/src/glyph-engine.ts
@@ -226,12 +226,7 @@ class GlyphEngineImpl implements GlyphEngine {
     return state;
   }
 
-  /**
-   * Teardown is total: every stage runs even if an earlier one fails, so a single bad
-   * font cannot strand the shaper instance and its Wasm memory. Failures are reported
-   * rather than thrown, because this runs from `finally` blocks and unmount paths that
-   * are frequently already unwinding an earlier error.
-   */
+  /** Teardown is total — every stage runs even if an earlier one fails, so one bad font can't strand the Wasm memory. Failures are reported, not thrown, since this often runs while already unwinding. */
   dispose(): void {
     if (this.#disposed || this.#disposing) return;
     if (this.#borrowedPlanActive) {

--- a/packages/glyph/src/glyph-placement.ts
+++ b/packages/glyph/src/glyph-placement.ts
@@ -1,35 +1,9 @@
 import type { LayoutBox, GlyphLayoutInspection } from './layout.js';
 
-/**
- * The one coordinate space every position and box in a `GlyphPlacements` snapshot is expressed in:
- * paragraph-local units, origin at the paragraph box's top-left corner, positive X right and
- * positive Y down. It is the space the engine positioned the glyphs in and the space
- * `GlyphLayout` reports.
- *
- * It is a stated field rather than a convention because renderer records may encode their origin
- * differently. The internal committed-display view normalizes every value into paragraph space;
- * a position that could not be read is named by `GlyphPlacements.incomplete` rather than silently
- * substituted.
- */
+/** Coordinate space for every position/box in a `GlyphPlacements` snapshot: paragraph-local units, origin top-left, +X right, +Y down — the space the engine positions glyphs in. */
 export type GlyphSpace = 'paragraph';
 
-/**
- * Identity of one glyph within a paragraph, owned by this package.
- *
- * **It survives a reflow that moves glyphs. It does not survive a reflow that reshapes them.**
- *
- * The key is the font, the shaped glyph id, the source cluster, and the occurrence index that
- * separates otherwise identical glyphs. So a change to the content box, the font size, the anchor,
- * the device pixel ratio, or the paragraph's transform keeps every key: the same glyphs moved. A
- * change to the text, the font, the language, the direction, or the feature set does not: those
- * replace or reorder the glyph stream, and a key that happened to match across one would interpolate
- * a glyph along a path it never travelled.
- *
- * The engine's `glyphStableIds` deliberately does not appear here. A stable id identifies a record
- * within one committed layout, which is what the GPU write path needs and what a reflow discards.
- * The one real consumer of the previous API discovered this and built this key itself; owning it
- * here is the point.
- */
+/** Identity of one glyph within a paragraph. Survives a reflow that moves glyphs (content box, size, anchor, DPR, transform); does not survive one that reshapes them (text, font, language, direction, features). */
 export type GlyphKey = string & { readonly __glyphKey: unique symbol };
 
 /** One glyph's placement. `x`/`y` are the pair a manipulation writes; everything else describes it. */
@@ -60,12 +34,7 @@ export interface GlyphPlacement {
   readonly bounds: LayoutBox;
 }
 
-/**
- * A run of glyphs addressed as one unit, because that is what a reader sees move.
- *
- * A caller staggering a reveal by word should not have to derive word membership from clusters,
- * which is what the previous surface forced.
- */
+/** A run of glyphs addressed as one unit — a word or line, whichever a reader perceives moving together. */
 export interface GlyphRun {
   readonly kind: 'word' | 'line';
   readonly index: number;
@@ -92,14 +61,7 @@ export interface GlyphLine extends GlyphRun {
   readonly lineHeight: number;
 }
 
-/**
- * A caret position, resolved to a cluster rather than to a UTF-16 index.
- *
- * Cluster-first is the whole point: one JavaScript character is not one caret stop. A ligature is
- * one glyph over several characters, a combining mark is several characters at one position, and
- * under bidi the character after an offset can be drawn to its left. A caret that indexes characters
- * cannot express any of those.
- */
+/** Caret position resolved to a cluster, not a UTF-16 index — a ligature spans multiple characters, a combining mark shares one position, and bidi can draw the next character to the left. */
 export interface GlyphCaret {
   /** UTF-16 offset of the cluster boundary the caret sits at. */
   readonly offset: number;
@@ -111,42 +73,17 @@ export interface GlyphCaret {
   readonly rect: LayoutBox;
 }
 
-/**
- * Internal read-only view of one paragraph's committed renderer records, addressable as glyphs,
- * words, and lines in one stated coordinate space. Public mutation happens only on the detached
- * `Glyphs` object returned by the Three adapter.
- *
- * Every array here is internally consistent by construction. There are no parallel columns for a
- * caller to keep aligned.
- */
+/** Read-only view of one paragraph's committed records, addressable as glyphs/words/lines in one coordinate space; every array is internally consistent by construction. Mutation happens only via the detached `Glyphs` object. */
 export interface GlyphPlacements {
   /** Every position and box below is in this space. No value in this snapshot is from another. */
   readonly space: GlyphSpace;
-  /**
-   * The committed layout these placements describe.
-   *
-   * Applying a snapshot taken before a reflow would move whichever records inherited its
-   * identities, so the layout rides along and the write compares it rather than trusting the caller
-   * to have noticed.
-   */
+  /** The committed layout these placements describe — rides along so a write against a stale (already-reflowed) snapshot is caught by comparison, not trusted to the caller. */
   readonly layout: GlyphLayoutInspection;
   readonly glyphs: readonly GlyphPlacement[];
   /** Runs of non-whitespace glyphs, split at every line boundary. See `wordsOf` for the exact rule. */
   readonly words: readonly GlyphRun[];
   readonly lines: readonly GlyphLine[];
-  /**
-   * Glyphs with no retained render record, so `x`/`y` hold the shaped origin and a write to them
-   * cannot land.
-   *
-   * The ordinary case is a glyph the font gives no outline for — a space is in here for almost every
-   * paragraph — because the render plan carries no record for something it never draws. Those
-   * glyphs still exist in the measure, still hold their place in the advance, and still belong to a
-   * word and a line; they simply cannot be moved independently of the glyphs around them.
-   *
-   * It is reported rather than hidden because the previous surface substituted a shaped-space value
-   * into its displayed array and said nothing, so a caller could not tell a moved glyph from an
-   * unmovable one.
-   */
+  /** Glyphs with no retained render record — typically ones the font gives no outline for, like spaces — so `x`/`y` hold the shaped origin and a write to them cannot land. */
   readonly incomplete: readonly number[];
   /** Nearest cluster boundary to a point, in this snapshot's space. */
   caretAt(x: number, y: number): GlyphCaret;
@@ -156,13 +93,7 @@ export interface GlyphPlacements {
 
 const EMPTY_BOX: LayoutBox = Object.freeze({ x: 0, y: 0, width: 0, height: 0 });
 
-/**
- * Whitespace that separates one animated word from the next.
- *
- * This is a presentation rule, not the engine's cluster grid, so it is stated here in full rather
- * than deferred to a segmenter whose Unicode version follows the host. A script that writes without
- * spaces yields one word per line; a caller wanting per-character motion there uses `glyphs`.
- */
+/** Presentation word-boundary rule (not the engine's cluster grid) — stated in full rather than deferred to a host segmenter. Scripts without spaces yield one word per line; use `glyphs` for per-character motion there. */
 function isWordSeparator(code: number): boolean {
   return (
     code === 0x20 ||
@@ -200,13 +131,7 @@ function unionBox(left: LayoutBox | undefined, right: LayoutBox): LayoutBox {
   );
 }
 
-/**
- * Builds the placement snapshot for one committed layout.
- *
- * `displayedX`/`displayedY` carry the drawn origins read from the retained records, and `incomplete`
- * names the glyphs whose record was missing. The caller supplies both together so the snapshot can
- * state its own completeness instead of leaving a hole the reader cannot see.
- */
+/** Builds the placement snapshot for one committed layout. `displayedX`/`displayedY` are drawn origins from retained records; `incomplete` names glyphs whose record was missing. */
 export function createGlyphPlacements(
   layout: GlyphLayoutInspection,
   text: string,
@@ -388,14 +313,7 @@ function clusterEndsOf(layout: GlyphLayoutInspection, textLength: number): Reado
   return ends;
 }
 
-/**
- * Groups glyphs into words: maximal runs of glyphs whose source cluster is not whitespace, never
- * crossing a line boundary.
- *
- * Grouping runs over the glyph order rather than the text order so the result stays contiguous under
- * bidi, where one word's glyphs are adjacent on screen even when its characters are not adjacent in
- * visual reading order across the paragraph.
- */
+/** Groups glyphs into words (maximal non-whitespace runs, never crossing a line) by glyph order, not text order — keeps a word's glyphs screen-contiguous under bidi. */
 function wordsOf(
   layout: GlyphLayoutInspection,
   text: string,
@@ -452,13 +370,7 @@ function caretRect(line: GlyphLine, x: number): LayoutBox {
   return box(x, line.baseline - line.ascent, 0, line.lineHeight);
 }
 
-/**
- * Resolves a point to the nearest cluster boundary.
- *
- * The comparison is against each glyph's leading and trailing edges rather than its centre alone, so
- * a right-to-left glyph resolves to the boundary that is logically before it even though that edge
- * is drawn on its right. That is the property a character-indexed hit test cannot have.
- */
+/** Resolves a point to the nearest cluster boundary using each glyph's leading/trailing edges, not its centre — an RTL glyph resolves to its logically-preceding boundary even though that edge draws on its right. */
 function caretAt(
   lines: readonly GlyphLine[],
   clusterEnds: ReadonlyMap<number, number>,
@@ -500,14 +412,7 @@ function caretAt(
   return Object.freeze({ offset: best.offset, line: line.index, leading: best.leading, rect: caretRect(line, best.x) });
 }
 
-/**
- * Rectangles covering the clusters whose offsets fall in `[start, end)`, one per line touched.
- *
- * A rectangle spans the union of the matching glyphs' advance boxes on that line and the full height
- * of the line box, matching what `Range.getClientRects()` returns for text: a selection highlight is
- * a layout-box artefact, not an ink one. A bidi line whose selected characters are drawn in two
- * separate places yields two rectangles for that line rather than one covering the gap.
- */
+/** Rectangles covering clusters in `[start, end)`, one per touched line — union of glyph advance boxes at full line height, matching `Range.getClientRects()`. A bidi line split by the selection yields two rectangles, not one spanning the gap. */
 function selectionRects(
   lines: readonly GlyphLine[],
   clusterEnds: ReadonlyMap<number, number>,

--- a/packages/glyph/src/internal/create-engine.ts
+++ b/packages/glyph/src/internal/create-engine.ts
@@ -63,10 +63,7 @@ export interface CreateEngineOptions<Bindings extends GlyphBindingSet, Boundary>
   readonly transformInput: (binding: HandleTransformBinding) => Bindings['transformInput'];
 }
 
-/**
- * Creates the retained mapper/binder for one publication root. Integrations provide only
- * their config schema; raw plan access, resource transactions, and identity settlement stay here.
- */
+/** Creates the retained mapper/binder for one publication root. Integrations provide only their config schema; plan access, resource transactions, and identity settlement stay here. */
 export function createEngine<Bindings extends GlyphBindingSet, Boundary>(
   options: CreateEngineOptions<Bindings, Boundary>,
 ): GlyphDisplayListProjector<Bindings> {

--- a/packages/glyph/src/internal/dev.ts
+++ b/packages/glyph/src/internal/dev.ts
@@ -1,27 +1,3 @@
-/**
- * Development-only diagnostics.
- *
- * Guidance that helps someone integrating the library — a lease that outlived its
- * paragraph, a teardown stage that failed and was stepped over — is worth saying loudly
- * while they are building, and worth nothing in a shipped bundle. Every consumer pays for
- * the message strings otherwise, and the engine already has a mechanism for conditions
- * that must hold in production: an ordinary `throw`.
- *
- * `DEV` is written as the ecosystem-standard `process.env.NODE_ENV` comparison because
- * every bundler replaces it with a literal. The comparison then folds to `false` and each
- * `if (DEV)` block is eliminated along with the strings inside it. The library itself
- * deliberately ships the guard unfolded: a library build cannot know which mode the
- * consuming application will build in, so the consumer's bundler decides.
- *
- * Use it for guidance only:
- *
- * ```ts
- * if (DEV) console.warn('a Text still holds a lease on this font');   // stripped
- * if (capacity <= 0) throw new RangeError('capacity must be positive'); // always
- * ```
- *
- * The package-size harness measures the production graph and asserts that no
- * development-only text survives it, so a diagnostic that leaks into shipped bytes fails
- * the build rather than going unnoticed.
- */
+/** Dev-only diagnostics gate — keep the literal `process.env.NODE_ENV !== 'production'` comparison so
+ * bundlers dead-code-eliminate `if (DEV)` blocks; use for guidance only, real invariants still `throw`. */
 export const DEV: boolean = process.env.NODE_ENV !== 'production';

--- a/packages/glyph/src/internal/font-artifact-reader.ts
+++ b/packages/glyph/src/internal/font-artifact-reader.ts
@@ -28,12 +28,7 @@ export class RuntimeFontArtifactError extends GlyphError<'artifact-invalid'> {
   }
 }
 
-/**
- * Locate the trusted package extension and its three shaping views.
- *
- * Bake and CI own schema validation. Runtime work is limited to the GLB envelope,
- * extension/version identity, and byte ranges required for safe typed-array views.
- */
+/** Locates the trusted package extension and its three shaping views. Bake and CI own schema validation; runtime is limited to the GLB envelope, extension/version identity, and byte ranges for safe typed-array views. */
 export function readRuntimeFontArtifact(bytes: Uint8Array): RuntimeFontArtifact {
   const parsed = readGlb(bytes);
   requireExtensionName(parsed.document.extensionsUsed, 'extensionsUsed');

--- a/packages/glyph/src/internal/font-binding.ts
+++ b/packages/glyph/src/internal/font-binding.ts
@@ -24,11 +24,7 @@ export interface FontBindingFieldTable {
   readonly names?: readonly string[];
 }
 
-/**
- * Order a binding table by the schema's declared field names. The same name
- * list drives the codec program's input table, so a missing, extra, or
- * misspelled reader is a compile error instead of a silently shifted column.
- */
+/** Orders a binding table by the schema's declared field names — the same list drives the codec program's input table, so a missing/extra/misspelled reader is a compile error, not a shifted column. */
 export function schemaFieldTable<const Names extends readonly string[]>(
   names: Names,
   rows: number,

--- a/packages/glyph/src/internal/frame-wire.ts
+++ b/packages/glyph/src/internal/frame-wire.ts
@@ -114,12 +114,7 @@ export interface PlannerConstraint {
   readonly spaceBefore?: number;
   /** Block-axis space added after the paragraph's final line. */
   readonly spaceAfter?: number;
-  /**
-   * Justification bounds on each word space as multiples of its natural
-   * advance. Leave unset for the unclamped distribution; when set, minimum is
-   * in (0, 1] and maximum is at least 1. Deficit beyond the maximum spills
-   * into letter-space expansion, capped per inter-cluster gap.
-   */
+  /** Justification bounds on each word space as multiples of its natural advance: min in (0, 1], max ≥ 1. Deficit beyond max spills into capped letter-space expansion. */
   readonly justify?: {
     readonly minWordSpaceRatio?: number;
     readonly maxWordSpaceRatio?: number;

--- a/packages/glyph/src/internal/glyph-plan-target.ts
+++ b/packages/glyph/src/internal/glyph-plan-target.ts
@@ -43,10 +43,7 @@ export interface GlyphPlanTarget<Bindings extends GlyphBindingSet, Result> exten
   dispose(): void;
 }
 
-/**
- * Creates the shared decode, bind, prepare, commit, and cleanup boundary for one publication root.
- * The returned target owns the configured renderer, optional built-in renderer, and command binder.
- */
+/** Creates the shared decode/bind/prepare/commit/cleanup boundary for one publication root; the returned target owns the configured renderer, optional built-in renderer, and command binder. */
 export function createGlyphPlanTarget<Bindings extends GlyphBindingSet, Result, Boundary, CodecValue extends Codec>(
   options: CreateGlyphPlanTargetOptions<Bindings, Result, Boundary, CodecValue>,
 ): GlyphPlanTarget<Bindings, Result> {

--- a/packages/glyph/src/internal/graphemes.ts
+++ b/packages/glyph/src/internal/graphemes.ts
@@ -1,19 +1,6 @@
 import { graphemeSegments } from 'unicode-segmenter/grapheme';
 
-/**
- * Extended grapheme cluster boundaries, in UTF-16 code units.
- *
- * The engine's own contract is one style per extended grapheme cluster (`cluster_state.rs`,
- * `build`), and the shaper segments UAX #29 in Rust through `unicode-segmentation`. These are two
- * implementations of one specification, pinned to the same Unicode version by the version contract,
- * not one authority and one copy. Callers that must agree with the engine's cluster grid before a
- * frame reaches it — span alignment above all — read their boundaries here rather than from
- * `Intl.Segmenter`, whose Unicode version follows the host ICU and can therefore place a boundary
- * this package's own tables do not.
- *
- * This lives apart from `unicode.ts` so a consumer that needs only cluster boundaries does not pull
- * in line breaking and the generated script tables with them.
- */
+/** Extended grapheme cluster boundaries (UTF-16 units), pinned to the same Unicode version as the Rust shaper's `cluster_state.rs` segmenter. Use this, not `Intl.Segmenter`, wherever boundaries must agree with the engine's grid — host ICU versions drift. */
 export function findGraphemeBoundaries(text: string): Uint32Array {
   assertWellFormed(text);
   // A grapheme is never shorter than one code unit, so the text length bounds the boundary count and the result is
@@ -39,34 +26,8 @@ export function assertWellFormed(text: string): void {
 /** The two offsets any styled range carries, whatever else it states. */
 export type ClusterAlignableRange = Readonly<{ start: number; end: number }>;
 
-/**
- * Resolve every range boundary onto the cluster grid `clusterBoundaries` describes.
- *
- * Each boundary moves forward to the end of the cluster containing it, which states one rule: a
- * cluster takes the style of its BASE, and the marks that attach to that base follow it. Moving a
- * start forward excludes the cluster it fell inside; moving an end forward includes it; both
- * outcomes hand the cluster to whatever styles its first scalar.
- *
- * Forward is a policy, not an arithmetic necessity — moving both boundaries backward preserves
- * ordering and adjacency equally well. It is chosen because backward resolution takes style away
- * from a base the caller styled and never edited, handing the cluster to a mark that attached to
- * it, and because a mark typed at the tail of a styled cluster is far more often meant to join that
- * style than to end it. Both boundaries move the SAME direction so that two ranges meeting at one
- * offset still meet afterwards; mixing directions would manufacture an overlap out of an adjacency.
- *
- * A range whose text is entirely claimed by an earlier cluster collapses to an empty range at that
- * boundary and is KEPT. Dropping it would delete a caller's style with nothing left in the array to
- * show for it, and would shift every later index out from under a caller reading `Text.spans` back
- * to compare it against what it authored. An empty range states nothing and is not compiled into an
- * engine style.
- *
- * Offsets outside `[0, textLength]` are left exactly as they are. Range validity is a separate
- * obligation with its own owner, and silently clamping an out-of-range offset would turn a caller's
- * arithmetic bug into a plausible-looking style.
- *
- * The input array is returned by identity when no boundary moves, so a caller can test whether
- * anything was resolved with `===`.
- */
+/** Moves boundaries forward to their cluster's end (the base takes the style); both ends move the
+ *  same direction so adjacent ranges stay adjacent. A collapsed-to-empty range is KEPT — dropping it would delete a caller's style and shift later indices. */
 export function alignRangesToClusters<Range extends ClusterAlignableRange>(
   ranges: readonly Range[],
   clusterBoundaries: Uint32Array,
@@ -90,33 +51,7 @@ export function alignRangesToClusters<Range extends ClusterAlignableRange>(
   return aligned ?? ranges;
 }
 
-/**
- * Resolve every boundary in `ranges` onto the cluster grid of `text`, segmenting it once.
- *
- * This is the single implementation of D-265 — a cluster takes the style of its BASE — and every
- * caller in the package reaches the rule through here rather than restating it:
- *
- * - `compose` (`txt`/`span`) and `flattenText` (React `<Text>`) are two implementations of ONE
- *   compiler. The document a caller authors is a tree with no offsets in it; each compiler derives
- *   a span boundary at a concatenation JOIN, taking `start` from the length before a fragment's
- *   text is appended and `end` from the length after. Concatenation can fuse the tail of one
- *   fragment with the head of the next into a single extended grapheme cluster — `txt` + a
- *   fragment opening with a combining mark is the one-character case — and the join then names an
- *   offset that is not a boundary of the text the compiler just produced. Resolving here, over the
- *   finished text, moves each such join forward onto the cluster the earlier fragment's base owns,
- *   so a tree can no longer compile to a paragraph the engine refuses.
- * - `alignSpansToClusters` is the public backstop for the untyped `spans` array, where the offsets
- *   are the caller's own arithmetic rather than anything the package derived.
- *
- * Resolving the WHOLE compiled array, once, is what makes nesting correct: a fragment composed on
- * its own carries boundaries resolved against its own cluster grid, and embedding it shifts that
- * grid at both edges. Two regional indicators are the case neither `left` nor `right` can settle
- * alone — the combined grid holds a boundary interior to neither fragment.
- *
- * Text that is not well-formed UTF-16 has no cluster grid and is the engine's to reject; its
- * ranges are returned untouched so the presence of a range cannot decide whether a lone surrogate
- * is accepted. The argument array is returned by identity when no boundary moves.
- */
+/** Segments `text` once and resolves every range boundary onto its cluster grid — the D-265 rule every span-boundary caller (`compose`, `flattenText`, `alignSpansToClusters`) shares rather than restates. Resolving the whole array together is what makes nesting correct; malformed UTF-16 has no grid and ranges pass through untouched. */
 export function resolveRangesToClusters<Range extends ClusterAlignableRange>(
   text: string,
   ranges: readonly Range[],
@@ -125,10 +60,7 @@ export function resolveRangesToClusters<Range extends ClusterAlignableRange>(
   return alignRangesToClusters(ranges, findGraphemeBoundaries(text));
 }
 
-/**
- * The end of the cluster containing `offset`, or `offset` itself when it is already a boundary or
- * lies outside the text the boundaries describe.
- */
+/** End of the cluster containing `offset`, or `offset` itself when it is already a boundary or lies outside the text's range. */
 function clusterEndAtOrAfter(clusterBoundaries: Uint32Array, offset: number): number {
   const textLength = clusterBoundaries[clusterBoundaries.length - 1] ?? 0;
   if (!Number.isSafeInteger(offset) || offset <= 0 || offset >= textLength) return offset;

--- a/packages/glyph/src/internal/handle-state.ts
+++ b/packages/glyph/src/internal/handle-state.ts
@@ -106,10 +106,7 @@ export type HandleEngineFontBinder = <Format extends RasterFormatMetadata>(
   font: Font<Format>,
 ) => HandleEngineFontBinding<Format>;
 
-/**
- * One borrowed A/B render-plan publication. Its bytes point into Wasm memory and expire when
- * this transport answers any later call. Configured renderers consume publications synchronously.
- */
+/** One borrowed A/B render-plan publication; `bytes` point into Wasm memory and expire on the transport's next call. Renderers must consume it synchronously. */
 export interface PlanPublication {
   readonly bytes: Uint8Array;
   readonly memoryBuffer: ArrayBuffer;
@@ -128,13 +125,7 @@ export interface PlanPublication {
   readonly drawCount: number;
 }
 
-/**
- * The paragraph and style a rejected frame names, read out of the result header.
- *
- * Both are the identifiers the request used, so a handle maps them to what it authored.
- * Zero means the status names none: an engine-internal invariant, a capacity watermark, or a
- * planner-level conflict attributes nothing.
- */
+/** Paragraph/style a rejected frame names, from the result header — both are request-authored ids; zero means the status names none (engine-internal, capacity, or planner-level fault). */
 const NO_FAULT: GlyphEngineFault = Object.freeze({ paragraphId: 0, styleId: 0 });
 
 interface EngineRegistrationOwners {
@@ -1320,13 +1311,7 @@ export class PlanTransport {
     this.#stagedUpdate = undefined;
   }
 
-  /**
-   * Answers one paragraph-scoped synchronous measurement without publishing. The
-   * result rides the inactive output slot under a handle-state lease: its bytes stay readable
-   * only until the next call into the same Wasm module. Engine revisions, the
-   * publication generation, and the renderer fence are untouched, so the following
-   * ordinary frame proceeds from pre-measure state.
-   */
+  /** Answers one paragraph-scoped synchronous measurement without publishing. Result bytes ride the inactive output slot and stay readable only until the next call into this Wasm module; engine revisions, publication generation, and renderer fence are untouched. */
   measureParagraph(request: Uint8Array, paragraphId: ParagraphId): PlanPublication {
     this.#assertActive();
     if (!(request instanceof Uint8Array) || request.byteLength === 0) {

--- a/packages/glyph/src/internal/layout-query-view.ts
+++ b/packages/glyph/src/internal/layout-query-view.ts
@@ -2,12 +2,7 @@ import { textShaperAbi } from '../generated/text-shaper-abi.js';
 import type { LayoutBox, GlyphLayoutInspection, ParagraphLayoutSummary, ParagraphLineMetrics } from '../layout.js';
 import type { PlanPublication } from './handle-state.js';
 
-/**
- * Reads the ink box off one semantic record, or reports its absence.
- *
- * Absence is carried by a flag bit on the paragraph record rather than by a sentinel extent,
- * because a zero-extent ink box is a legitimate answer — a paragraph of spaces has one.
- */
+/** Reads the ink box off one semantic record, or reports its absence via a flag bit — not a sentinel extent, since a zero-extent ink box (a paragraph of spaces) is a legitimate answer. */
 function inkBoundsOf(view: SemanticViewReader, record: number, measured: boolean): LayoutBox | undefined {
   if (!measured) return undefined;
   const layout = textShaperAbi.layouts.engineSemanticView;

--- a/packages/glyph/src/internal/runtime-bake-protocol.ts
+++ b/packages/glyph/src/internal/runtime-bake-protocol.ts
@@ -8,14 +8,7 @@ export type RuntimeBakeUnicodeRange = {
   readonly end: number;
 };
 
-/**
- * The raster kinds the runtime bake Worker embeds bakers for. This set is the
- * single routing authority: the host puts only these kinds into a Worker font
- * bake, and every other technique bakes host-side through the baker its own
- * declaration names (`technique.runtimeBaker`). The Worker's kind switch is
- * the realization of this set; its rejection of anything else guards protocol
- * violations, not routing.
- */
+/** Raster kinds the runtime bake Worker embeds bakers for — the single routing authority. Every other technique bakes host-side via its own `technique.runtimeBaker`. */
 export const workerRasterKinds: readonly string[] = Object.freeze(['bitmap', 'msdf', 'slug']);
 
 export type RuntimeBakeRaster = {

--- a/packages/glyph/src/internal/span-cascade.ts
+++ b/packages/glyph/src/internal/span-cascade.ts
@@ -1,13 +1,4 @@
-/**
- * The authoring half of the span cascade.
- *
- * A span states only the properties it changes, so a span stating a colour keeps the
- * font, size, outline, and shadow of the scope enclosing it. The fold itself belongs to
- * the engine: `cascadeOrder` is the authored array index and Rust resolves each offset by
- * `(root, cascade_order)`, so overlap is last-wins and needs no host-side resolution.
- * What the host still owns is separating a property a caller stated from one they left
- * absent, because an explicit `undefined` must not shadow an enclosing value.
- */
+/** Authoring half of the span cascade — a span states only what it changes. The fold is the engine's (last-wins by `cascadeOrder`); the host's job is separating a stated property from an absent one so explicit `undefined` never shadows an enclosing value. */
 
 /** A source that may hold an explicit `undefined` for any property it does not state. */
 export type StatedSource<Properties extends object> = {

--- a/packages/glyph/src/internal/typed-command-tree.ts
+++ b/packages/glyph/src/internal/typed-command-tree.ts
@@ -207,10 +207,7 @@ const primitiveLayout = textShaperAbi.layouts.enginePrimitive;
 const drawLayout = textShaperAbi.layouts.engineDraw;
 const retirementLayout = textShaperAbi.layouts.engineRetirement;
 
-/**
- * Retains only opaque JS identities. All command scalars and ranges stay in the trusted Rust
- * publication and are read lazily through the borrowed tables below.
- */
+/** Retains only opaque JS identities — command scalars and ranges stay in the trusted Rust publication, read lazily through the borrowed tables below. */
 export class TypedCommandTreeMapper {
   readonly #sources = new WeakMap<BorrowedTypedCommandTree, TypedSourceState>();
   readonly #resources = new Map<string, TypedResource>();

--- a/packages/glyph/src/layout.ts
+++ b/packages/glyph/src/layout.ts
@@ -1,10 +1,7 @@
 import type { FontHandle } from './identity.js';
 import { textShaperAbi } from './generated/text-shaper-abi.js';
 
-/**
- * Axis-aligned box in paragraph-local units: origin at the paragraph box's top-left corner,
- * positive X right, positive Y down. Every box this module publishes is in that one space.
- */
+/** Axis-aligned box in paragraph-local units: origin top-left, +X right, +Y down — every box this module publishes is in that space. */
 export interface LayoutBox {
   readonly x: number;
   readonly y: number;
@@ -12,18 +9,7 @@ export interface LayoutBox {
   readonly height: number;
 }
 
-/**
- * Named bits of `GlyphLayout.glyphFlags`.
- *
- * These are the shaper's own flags, carried through the engine unchanged, so a consumer reading a
- * bit is reading HarfRust's answer rather than a pmndrs re-derivation. `produced` is the union of
- * every bit this engine can set: a bit outside it is always zero, so testing against `produced`
- * distinguishes "the shaper said no" from "the engine never asked".
- *
- * `SAFE_TO_INSERT_TATWEEL` has no name here on purpose. Producing it needs a shaping buffer flag
- * this engine does not set, so the bit is unconditionally zero and a name would invite a consumer
- * to branch on a fact that is never reported.
- */
+/** Named bits of `GlyphLayout.glyphFlags` — HarfRust's own flags, carried through unchanged. Test against `produced` (union of settable bits) to tell "shaper said no" from "engine never asked"; unproducible bits (e.g. `SAFE_TO_INSERT_TATWEEL`) have no name here. */
 export const glyphFlags: {
   /** A line break before this glyph may change how the surrounding text shapes. */
   readonly unsafeToBreak: number;
@@ -33,13 +19,7 @@ export const glyphFlags: {
   readonly produced: number;
 } = textShaperAbi.engine.glyphFlags;
 
-/**
- * Vertical metrics of one line box, or of a whole paragraph, around its baseline.
- *
- * `ascent + descent === lineHeight` exactly, and the box top is `baseline - ascent`. Half-leading is
- * already distributed into `ascent` and `descent`, so these are box metrics rather than raw font
- * metrics — which is what a caller aligning to a baseline, a cap height, or an x height needs.
- */
+/** Vertical metrics of a line or paragraph around its baseline: `ascent + descent === lineHeight` exactly, box top = `baseline - ascent`. Half-leading is already distributed into ascent/descent. */
 export interface BaselineMetrics {
   /** Distance from the top edge of the box down to the baseline. */
   readonly ascent: number;
@@ -49,17 +29,7 @@ export interface BaselineMetrics {
   readonly lineHeight: number;
 }
 
-/**
- * Allocation-light paragraph metrics for intrinsic sizing and host layout.
- * It deliberately contains no per-glyph arrays.
- *
- * Two extents are published and they are not interchangeable. `contentWidth`/`contentHeight` are
- * *advance* extents: the space the text claims, which is the correct number for a flex or grid host
- * because CSS box measure is advance-based. `inkBounds` is the *ink* extent: the union of the glyphs'
- * outlines, which is the correct number for centring something visually, because italics, accents,
- * and swashes overhang their advances. Using one where the other belongs is a silent visual error,
- * so both ship under names that cannot be confused.
- */
+/** Allocation-light paragraph metrics; no per-glyph arrays. `contentWidth`/`contentHeight` are *advance* extents (CSS box measure); `inkBounds` is the *ink* extent (glyph outlines) — using one where the other belongs is a silent visual error. */
 export interface ParagraphMeasurement extends BaselineMetrics {
   /** Whole-paragraph baseline metrics use `firstBaseline` as their reference baseline. */
   readonly ascent: number;
@@ -77,15 +47,7 @@ export interface ParagraphMeasurement extends BaselineMetrics {
   readonly firstBaseline: number;
   /** Distance from the paragraph box's top edge to the last baseline. */
   readonly lastBaseline: number;
-  /**
-   * Union of every positioned glyph's ink box.
-   *
-   * `undefined` means this query did not position glyphs, so no ink was measured. It never means
-   * "the ink is empty": a paragraph that positioned zero glyphs reports a zero-extent box, not
-   * `undefined`. The absent case is stated rather than substituted with the advance box, because a
-   * caller centring on the advance box when it asked for ink is exactly the defect this pair exists
-   * to remove.
-   */
+  /** Union of every positioned glyph's ink box. `undefined` means glyphs were not positioned by this query — never that the ink is empty (a zero-glyph paragraph reports a zero-extent box). */
   readonly inkBounds: LayoutBox | undefined;
   readonly overflowed: boolean;
 }
@@ -108,11 +70,7 @@ export interface ParagraphLineMetrics extends BaselineMetrics {
   readonly inkBounds: LayoutBox | undefined;
 }
 
-/**
- * Bounded aggregate inspection of one retained layout. Unlike `GlyphLayout`, this contains no
- * per-glyph arrays and is suitable for positioning UI, telemetry, and missing-glyph admission
- * checks.
- */
+/** Bounded aggregate inspection of one retained layout. Unlike `GlyphLayout`, this has no per-glyph arrays — suitable for positioning UI, telemetry, and missing-glyph admission checks. */
 export interface ParagraphLayoutSummary extends ParagraphMeasurement, ParagraphIntrinsicWidths {
   /** Positioned glyphs retained by layout, including non-rendering glyphs such as spaces. */
   readonly glyphCount: number;
@@ -123,35 +81,13 @@ export interface ParagraphLayoutSummary extends ParagraphMeasurement, ParagraphI
   readonly lines: readonly ParagraphLineMetrics[];
 }
 
-/**
- * Content-only inline extents published beside every paragraph measurement.
- *
- * Both widths are intrinsic: they do not depend on the constraints a host is currently
- * probing, and they ride the same measurement pass that produced the rest of the summary
- * -- no second query at zero width is required. `maxContentWidth` is the widest run between
- * forced breaks under the constraint's wrap policy, trailing spaces trimmed the way line
- * ends trim them. `minContentWidth` is the widest run that remains when soft breaks are
- * also taken: after word spaces under `'word'` wrap, before every safe boundary under
- * `'character'`, and the whole segment under `'none'`. Column splits, line caps, and
- * overflow clipping do not participate, because those are box policies rather than
- * content properties.
- */
+/** Intrinsic (constraint-independent) inline extents from the same measurement pass. `maxContentWidth` is the widest run between forced breaks; `minContentWidth` is the widest run after soft breaks too. Column splits and clipping don't participate. */
 export interface ParagraphIntrinsicWidths {
   readonly minContentWidth: number;
   readonly maxContentWidth: number;
 }
 
-/**
- * Positioned glyph output in paragraph-local coordinates. The origin is the
- * paragraph box's top-left corner; positive X is right and positive Y is down.
- *
- * **`glyphCount` is the single authority for the per-glyph columns.** Every `Uint16Array`,
- * `Uint32Array`, and `Float32Array` below has exactly `glyphCount` entries, and every line column
- * has exactly `lineCount`. The reader is the only producer and slices each column to that length,
- * so a caller indexes with `glyphCount` and never re-derives a length from one column or checks the
- * columns against each other. The one real consumer of the previous shape hand-wrote a parallel
- * length assertion over six of these arrays; that assertion is now the reader's obligation.
- */
+/** Positioned glyph output in paragraph-local coordinates (origin top-left, +X right, +Y down). `glyphCount` is the single authority for every per-glyph column's length (`lineCount` for line columns) — the reader is the only producer, so a caller never re-derives or cross-checks lengths. */
 export interface GlyphLayout extends ParagraphMeasurement {
   readonly fontHandles: Uint32Array;
   readonly glyphFontSlots: Uint16Array;
@@ -163,10 +99,7 @@ export interface GlyphLayout extends ParagraphMeasurement {
   readonly glyphFontSizes: Float32Array;
   readonly x: Float32Array;
   readonly y: Float32Array;
-  /**
-   * Shaped advance per glyph: the distance the pen moves, which is neither the ink width nor the
-   * font size. A caret between two glyphs and a selection rectangle are built from this.
-   */
+  /** Shaped advance per glyph: the distance the pen moves — neither ink width nor font size. Carets and selection rectangles are built from this. */
   readonly glyphAdvances: Float32Array;
   /** Ink box per glyph, in the paragraph space `x`/`y` use. A glyph with no outline reports zero extents at its own origin. */
   readonly glyphInkX: Float32Array;
@@ -183,15 +116,7 @@ export interface GlyphLayout extends ParagraphMeasurement {
   readonly lineAdvances: Float32Array;
 }
 
-/**
- * One positioned paragraph: the measurement view plus every per-glyph and per-line column,
- * with stable identities for directed augmentation.
- *
- * This is what an explicit `Text.glyphs()` query copies out of Wasm.
- * It is a second query after `measure()`, not a bigger copy of it: asking for these columns
- * makes the engine emit a record per glyph, which a caller probing sizes never wants to pay
- * for. See `measure()` and `Text.measure()` for the split.
- */
+/** One positioned paragraph: measurement plus every per-glyph/line column, with stable identities — what `Text.glyphs()` copies from Wasm. A second query after `measure()`, not a bigger copy: per-glyph records cost more than a size probe wants to pay. See `measure()`/`Text.measure()`. */
 export interface GlyphLayoutInspection extends GlyphLayout, ParagraphLayoutSummary, ParagraphIntrinsicWidths {
   readonly glyphStableIds: Uint32Array;
 }

--- a/packages/glyph/src/node/cli.ts
+++ b/packages/glyph/src/node/cli.ts
@@ -615,13 +615,7 @@ async function directRasterPlans(options: DirectBakeArguments): Promise<DirectRa
   return { plans, resolved: await Promise.all(resolutions) };
 }
 
-/**
- * `em-size=32,pixel-range=6` — the technique's own settings, in the technique's
- * own terms.
- *
- * Atlas cost scales with the square of the em size, so a face set at small sizes
- * pays several times over for the default of 64 and has no way to say so.
- */
+/** Parses `em-size=32,pixel-range=6` — technique-specific settings. Atlas cost scales with the square of em size, so small-size faces can override the size-64 default. */
 function parseMsdfOptions(value: string): MsdfOptions {
   const options: { emSize?: number; pixelRange?: number } = {};
   for (const entry of value.split(',')) {

--- a/packages/glyph/src/paint.ts
+++ b/packages/glyph/src/paint.ts
@@ -15,10 +15,7 @@ export interface ResolvedPaint {
   };
 }
 
-/**
- * Core-owned paint attribution parallel to a GlyphLayout's glyph arrays.
- * Raster modules own how these resolved values enter their instance buffers.
- */
+/** Paint attribution parallel to a GlyphLayout's glyph arrays; raster modules map these into their own instance buffers. */
 export interface GlyphPaint {
   readonly paintIndices: Uint16Array;
   readonly palette: readonly ResolvedPaint[];

--- a/packages/glyph/src/raster-coverage.ts
+++ b/packages/glyph/src/raster-coverage.ts
@@ -12,10 +12,7 @@ export type RasterUnicodeRange = {
   readonly end: number;
 };
 
-/**
- * Bounded seeds for a sparse raster artifact. Seeds select nominal font-local glyph IDs only;
- * they do not request source subsetting, glyph remapping, or transitive shaping closure.
- */
+/** Bounded seeds for a sparse raster artifact; selects nominal font-local glyph IDs only, not source subsetting or shaping closure. */
 export type RasterCoverage = {
   readonly unicodeRanges?: readonly RasterUnicodeRange[];
   readonly text?: string;

--- a/packages/glyph/src/raster/bitmap.ts
+++ b/packages/glyph/src/raster/bitmap.ts
@@ -55,11 +55,7 @@ export interface BitmapData {
   readonly coverage?: Uint8Array;
 }
 
-/**
- * Reports the physical strike this technique selects for a logical CSS size and raster pixel ratio. Applications that
- * display or assert density behaviour must read the selection from here rather than reimplementing it, so a reported
- * strike can never diverge from the strike actually rendered.
- */
+/** Ppem of the strike selected for a CSS size and raster pixel ratio; read from here rather than reimplementing selection. */
 export function selectBitmapStrikePpem(
   strikes: readonly { readonly ppem: number }[],
   cssFontSize: number,
@@ -109,11 +105,7 @@ const BITMAP_UV_SIZE_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.bitmap/uv-size
 const BITMAP_COLOR_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.bitmap/color');
 const BITMAP_PAGE_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.bitmap/page');
 
-/**
- * The authoritative physical shape of the Bitmap format: binding field order matches
- * the strike tables the binding compiler emits; buffer ids and lanes are the contract
- * every codec program and shader realization derives from.
- */
+/** Authoritative physical shape of the Bitmap format; field order must match the binding compiler's strike tables — the contract every codec/shader realization derives from. */
 export const bitmapSchema: TechniqueSchema<
   {
     readonly origin: {

--- a/packages/glyph/src/raster/msdf.ts
+++ b/packages/glyph/src/raster/msdf.ts
@@ -97,9 +97,7 @@ const MSDF_COLOR_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.msdf/color');
 const MSDF_EFFECT_COLOR_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.msdf/effect-color');
 const MSDF_PAGE_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.msdf/page');
 
-/**
- * The authoritative physical shape of the MSDF technique.
- */
+/** The authoritative physical shape of the MSDF technique. */
 export const msdfSchema: TechniqueSchema<
   {
     readonly rect: {

--- a/packages/glyph/src/raster/slug.ts
+++ b/packages/glyph/src/raster/slug.ts
@@ -94,9 +94,7 @@ const SLUG_INVERSE_FONT_SIZE_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.slug/i
 const SLUG_TABLE_STARTS_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.slug/table-starts');
 const SLUG_BAND_COUNTS_BUFFER_ID: CodecBufferId = id.buffer('pmndrs.slug/band-counts');
 
-/**
- * The authoritative physical shape of the Slug format.
- */
+/** The authoritative physical shape of the Slug format. */
 export const slugSchema: TechniqueSchema<
   {
     readonly rect: {

--- a/packages/glyph/src/react.ts
+++ b/packages/glyph/src/react.ts
@@ -1077,16 +1077,7 @@ function createMountedHookFontStore(resource: ReactFontFaceResource): MountedHoo
   };
 }
 
-/**
- * Compile one `<Text>` element tree into the `(text, spans)` pair the engine consumes.
- *
- * The tree states no offsets. Every boundary below is derived at a concatenation JOIN -- `start` is
- * the length before a child's text is appended, `end` the length after -- and concatenation can
- * fuse the tail of one child with the head of the next into a single extended grapheme cluster,
- * naming an offset that is not a boundary of the text just produced. `resolveRangesToClusters`
- * settles those joins against the finished text under the one rule `compose` uses on the
- * `txt`/`span` tree: the fused cluster takes the style of its base, which is the earlier child's.
- */
+/** Boundaries are JOIN offsets in the concatenated text; when a JOIN fuses a grapheme cluster across children, `resolveRangesToClusters` gives the fused cluster the earlier child's style. */
 function flattenText(
   children: R3fTextChild<RasterFormatMetadata> | undefined,
   context: GlyphReactContext,

--- a/packages/glyph/src/shaders/tsl/bitmap-shader.ts
+++ b/packages/glyph/src/shaders/tsl/bitmap-shader.ts
@@ -4,10 +4,7 @@ import type { Node, Texture } from 'three/webgpu';
 // Upstream types this export as an unparameterized `Node`; it is always vec4. Narrow once, not per use.
 const modelViewProjection = TSL.modelViewProjection as Node<'vec4'>;
 
-/**
- * One glyph instance's canonical Bitmap fields, already resolved to nodes. Core owns what each field means; how a
- * program addresses it — storage buffers, instanced attributes, or a texture — stays the program's own choice.
- */
+/** One glyph instance's canonical Bitmap fields, resolved to nodes; Core owns field meaning, the program owns how it's addressed (buffer, attribute, or texture). */
 export interface TslBitmapInstanceNodes {
   /** Paragraph-local glyph origin, with y measured downward. */
   readonly origin: Node<'vec2'>;
@@ -37,11 +34,7 @@ export interface TslBitmapShaderOptions {
 /** Everything the canonical Bitmap graph produces, so a program can consume a stage or compose over its final output. */
 export interface TslBitmapShaderOutput {
   readonly position: Node<'vec3'>;
-  /**
-   * Clip-space vertex position selected by the shader options. Pixel snapping is opt-in because it preserves strike
-   * sharpness at rest but quantizes animated motion. A program must assign this to `material.vertexNode` to inherit the
-   * selected placement.
-   */
+  /** Clip-space vertex position selected by the shader options; assign to `material.vertexNode`. Pixel snapping is opt-in — sharp at rest, but quantizes animated motion. */
   readonly clipPosition: Node<'vec4'>;
   /** Atlas coordinate the page is sampled at, in the page's own top-down texel space. */
   readonly atlasUv: Node<'vec2'>;
@@ -51,14 +44,7 @@ export interface TslBitmapShaderOutput {
   readonly opacity: Node<'float'>;
 }
 
-/**
- * Builds the canonical Bitmap node graph. This is the exact graph the command-buffer executor renders, so a program that
- * composes over the returned nodes inherits the technique's coverage sampling and pixel snapping instead of
- * reimplementing them.
- *
- * The graph reads `positionLocal` and `uv()` from the technique's unit quad: both must span `[0, 1]` with the origin at
- * the glyph's upper-left corner. A program supplying different geometry owns that correspondence.
- */
+/** Builds the canonical Bitmap graph the executor renders; composing over it inherits coverage sampling and snapping. Reads `positionLocal`/`uv()` from a `[0, 1]` unit quad, origin at upper-left — different geometry must preserve that correspondence. */
 export function bitmapShader(
   instance: TslBitmapInstanceNodes,
   resources: TslBitmapShaderResources,
@@ -83,11 +69,7 @@ export function bitmapShader(
   };
 }
 
-/**
- * Rounds the projected quad to whole physical pixels. Snapping in clip space rather than paragraph space keeps the
- * paragraph transform, camera, and device pixel ratio out of the technique: whatever chain produced the clip position,
- * its device-space landing is what has to sit on the grid the atlas was baked for.
- */
+/** Rounds the projected quad to whole physical pixels in clip space (not paragraph space), so it works regardless of transform/camera/DPR — matching the grid the atlas was baked for. */
 function pixelSnappedClipPosition(): Node<'vec4'> {
   const clip = modelViewProjection;
   return TSL.vec4(

--- a/packages/glyph/src/shaders/tsl/decoration-shader.ts
+++ b/packages/glyph/src/shaders/tsl/decoration-shader.ts
@@ -16,18 +16,7 @@ export interface TslDecorationShaderOutput {
   readonly opacity: Node<'float'>;
 }
 
-/**
- * Builds the canonical decoration node graph: a solid quad covering the record's
- * rectangle, colored by the packed decoration paint. The graph reads `positionLocal`
- * from the decoration program's unit quad spanning `[0, 1]` with the origin at the upper-left
- * corner, matching the glyph raster programs. Only solid lines reach this graph: the public
- * boundary rejects other line styles, and `packed.y` retains the style bits for the
- * later patterned-paint implementation.
- *
- * The packed bytes are sRGB-encoded — the same wire encoding whose glyph counterpart
- * the Rust gather decodes through its sRGB-to-linear table — so the color channels pass
- * through the sRGB EOTF into the renderer's linear working space. Alpha stays linear.
- */
+/** `packed` is sRGB-encoded, matching the Rust gather's decode table — color passes through the sRGB EOTF into linear space, but alpha stays linear. `positionLocal` spans `[0, 1]` like the glyph raster programs. */
 export function decorationShader(instance: TslDecorationInstanceNodes): TslDecorationShaderOutput {
   const color = unpackSrgbRgba(instance.packed.x);
   return {

--- a/packages/glyph/src/shaders/tsl/index.ts
+++ b/packages/glyph/src/shaders/tsl/index.ts
@@ -1,10 +1,4 @@
-/**
- * The shader library: TSL node graphs for the Bitmap, MSDF, and Slug raster formats plus
- * the decoration program, importable without the Three scene integration. The graphs
- * build on `three/tsl` nodes; an integration that renders through a TSL-consuming
- * renderer reuses one canonical shading implementation per program instead of
- * reimplementing coverage math.
- */
+/** TSL shader library for Bitmap, MSDF, Slug, and decoration — importable without the Three integration; reuse this canonical implementation rather than reimplementing coverage math. */
 export {
   bitmapShader,
   type TslBitmapInstanceNodes,

--- a/packages/glyph/src/shaders/tsl/msdf-shader.ts
+++ b/packages/glyph/src/shaders/tsl/msdf-shader.ts
@@ -3,10 +3,7 @@ import type { Node, Texture } from 'three/webgpu';
 
 import { unpackSrgbRgba } from './packed-color.js';
 
-/**
- * One glyph instance's canonical MSDF fields, already resolved to nodes. The technique schema owns lane meaning and
- * scalar packing; the target owns GPU storage realization.
- */
+/** One glyph instance's canonical MSDF fields, resolved to nodes; the technique schema owns lane meaning/packing, the target owns GPU storage. */
 export interface TslMsdfInstanceNodes {
   /** Paragraph-local glyph origin, with y measured downward. */
   readonly origin: Node<'vec2'>;
@@ -39,13 +36,7 @@ export interface TslMsdfShaderResources {
   readonly pixelRange: number;
 }
 
-/**
- * Everything the canonical MSDF graph produces, so a program can consume a stage or compose over its final output.
- *
- * Unlike Bitmap this output publishes no `clipPosition`: a distance field reconstructs its edge from the screen-space
- * gradient, so it is correct at any subpixel placement and must keep the default projection rather than snap to the
- * physical pixel grid.
- */
+/** Unlike Bitmap, publishes no `clipPosition`: a distance field reconstructs its edge from the screen-space gradient, so it must keep the default projection rather than snap to the pixel grid. */
 export interface TslMsdfShaderOutput {
   readonly position: Node<'vec3'>;
   /** Unclamped atlas coordinate the glyph cell is sampled at. */
@@ -59,13 +50,7 @@ export interface TslMsdfShaderOutput {
   readonly opacity: Node<'float'>;
 }
 
-/**
- * Builds the canonical MSDF node graph. This is the exact graph the command-buffer executor renders, so a program that composes
- * over the returned nodes inherits the technique's median distance decode, screen-space range, and layer compositing.
- *
- * The graph reads `positionLocal` and `uv()` from the technique's unit quad: both must span `[0, 1]` with the origin at
- * the glyph's upper-left corner. A program supplying different geometry owns that correspondence.
- */
+/** Builds the canonical MSDF graph the executor renders; composing over it inherits median decode, screen-space range, and layer compositing. Reads `positionLocal`/`uv()` from a `[0, 1]` unit quad, origin at upper-left. */
 export function msdfShader(instance: TslMsdfInstanceNodes, resources: TslMsdfShaderResources): TslMsdfShaderOutput {
   const outlineColor = unpackSrgbRgba(instance.effectColor.x);
   const shadowColor = unpackSrgbRgba(instance.effectColor.y);

--- a/packages/glyph/src/shaders/tsl/slug/calc-root-code.ts
+++ b/packages/glyph/src/shaders/tsl/slug/calc-root-code.ts
@@ -1,15 +1,9 @@
-/**
- * Adapted from three-flatland Slug at 2935a89f (MIT).
- * See RESEARCH.md for repository provenance.
- */
+/** Adapted from three-flatland Slug at 2935a89f (MIT); see RESEARCH.md for provenance. */
 import type { Node } from 'three/webgpu';
 import { lessThan, uint } from 'three/tsl';
 import { uintBitAnd, uintBitOr, uintShiftLeft, uintShiftRight } from './internal/three-compat.js';
 
-/**
- * Calculate root eligibility from the signs of three control-point coordinates.
- * Bit 0 selects the first ordered root and bit 8 selects the second.
- */
+/** Root eligibility from the signs of three control-point coordinates; bit 0 selects the first ordered root, bit 8 the second. */
 export function calcRootCode(y1: Node<'float'>, y2: Node<'float'>, y3: Node<'float'>): Node<'uint'> {
   const negative1: Node<'bool'> = lessThan(y1, 0);
   const negative2: Node<'bool'> = lessThan(y2, 0);

--- a/packages/glyph/src/shaders/tsl/slug/internal/reference.ts
+++ b/packages/glyph/src/shaders/tsl/slug/internal/reference.ts
@@ -1,7 +1,4 @@
-/**
- * CPU reference math adapted from three-flatland Slug at 2935a89f
- * (MIT). It is independent of TSL and GPU texture behavior.
- */
+/** CPU reference math adapted from three-flatland Slug at 2935a89f (MIT); independent of TSL and GPU texture behavior. */
 
 export interface DecodedSlugHeader {
   readonly curveCount: number;

--- a/packages/glyph/src/shaders/tsl/slug/shader.ts
+++ b/packages/glyph/src/shaders/tsl/slug/shader.ts
@@ -3,10 +3,7 @@ import type { DataTexture, Node } from 'three/webgpu';
 
 import { slugDilate, slugDilateMatrix, slugRender, type SlugRenderOptions } from './primitives.js';
 
-/**
- * One glyph instance's canonical Slug fields, already resolved to nodes. The address and count fields locate the
- * glyph's band tables inside the shared page; core owns their meaning, and a program owns how it stores them.
- */
+/** One glyph instance's canonical Slug fields, resolved to nodes; core owns address/count field meaning, the program owns how it stores them. */
 export interface TslSlugInstanceNodes {
   /** Paragraph-local glyph origin, with y measured downward. */
   readonly origin: Node<'vec2'>;
@@ -48,10 +45,7 @@ export interface TslSlugFillRule {
   readonly thicken?: Node<'float'>;
 }
 
-/**
- * The GPU resources one Slug glyph batch binds. The clip-space rows and viewport drive the analytic half-pixel
- * dilation, so they must describe the same draw the returned position node feeds.
- */
+/** The GPU resources one Slug glyph batch binds; the clip-space rows/viewport drive analytic half-pixel dilation, so they must describe the same draw the returned position feeds. */
 interface TslSlugShaderResourceBase {
   readonly page: TslSlugPageResources;
   /** Drawing-buffer size in device pixels. */
@@ -76,12 +70,7 @@ interface TslSlugShaderMatrixResources extends TslSlugShaderResourceBase {
 
 export type TslSlugShaderResources = TslSlugShaderRowResources | TslSlugShaderMatrixResources;
 
-/**
- * Everything the canonical Slug graph produces, so a program can consume a stage or compose over its final output.
- *
- * Unlike Bitmap this output publishes no `clipPosition`: Slug integrates coverage analytically from outlines, so it is
- * correct at any subpixel placement and must keep the default projection rather than snap to the physical pixel grid.
- */
+/** Unlike Bitmap, publishes no `clipPosition`: Slug integrates coverage analytically from outlines, so it must keep the default projection rather than snap to the pixel grid. */
 export interface TslSlugShaderOutput {
   /** Dilated glyph-quad position. Reading it from a vertex node is what publishes `renderCoordinate`. */
   readonly position: Node<'vec3'>;
@@ -93,16 +82,7 @@ export interface TslSlugShaderOutput {
   readonly opacity: Node<'float'>;
 }
 
-/**
- * Builds the canonical Slug node graph. This is the exact graph the command-buffer executor renders, so a program that composes
- * over the returned nodes inherits the technique's band walk, quadratic solve, and antialiasing footprint.
- *
- * `position` and `coverage` are two halves of one graph: the vertex half writes the varying the fragment half
- * integrates over. A program that uses `coverage` must also drive its material position from `position`.
- *
- * The graph reads `positionLocal` from the technique's unit quad, which must span `[0, 1]` with the origin at the
- * glyph's upper-left corner. A program supplying different geometry owns that correspondence.
- */
+/** Builds the canonical Slug graph; composing over it inherits band walk, quadratic solve, and AA. `position`/`coverage` are two halves of one graph — using `coverage` requires driving material position from `position`. Reads `positionLocal` from a `[0, 1]` unit quad, origin upper-left. */
 export function slugShader(instance: TslSlugInstanceNodes, resources: TslSlugShaderResources): TslSlugShaderOutput {
   const renderCoordinate = TSL.varyingProperty('vec2', 'pmndrsSlugRenderCoordinate');
   const position = TSL.Fn(() => {

--- a/packages/glyph/src/shaders/tsl/slug/slug-band.ts
+++ b/packages/glyph/src/shaders/tsl/slug/slug-band.ts
@@ -1,8 +1,4 @@
-/**
- * Adapted from three-flatland Slug at 2935a89f (MIT).
- * The texture addressing is adapted to PMNDRS_font_slug V0's exact R32UI
- * header grid and R16UI glyph-local reference grid.
- */
+/** Adapted from three-flatland Slug at 2935a89f (MIT); texture addressing matches PMNDRS_font_slug V0's R32UI header grid and R16UI glyph-local reference grid. */
 import type { Node } from 'three/webgpu';
 import {
   If,

--- a/packages/glyph/src/shaders/tsl/slug/slug-render.ts
+++ b/packages/glyph/src/shaders/tsl/slug/slug-render.ts
@@ -1,8 +1,4 @@
-/**
- * Adapted from three-flatland Slug at 2935a89f (MIT).
- * The texture addressing is adapted to PMNDRS_font_slug V0's exact R32UI
- * header grid and R16UI glyph-local reference grid.
- */
+/** Adapted from three-flatland Slug at 2935a89f (MIT); texture addressing matches PMNDRS_font_slug V0's R32UI header grid and R16UI glyph-local reference grid. */
 import type { Node } from 'three/webgpu';
 import { add, div, float, max, mul, sub } from 'three/tsl';
 import { calcCoverage } from './calc-coverage.js';

--- a/packages/glyph/src/shaders/tsl/slug/solve-quadratic.ts
+++ b/packages/glyph/src/shaders/tsl/slug/solve-quadratic.ts
@@ -1,7 +1,4 @@
-/**
- * Adapted from three-flatland Slug at 866f77f9 (MIT), before the
- * experimental eac7d015 naive-solver trade-off (MIT). See RESEARCH.md.
- */
+/** Adapted from three-flatland Slug at 866f77f9 (MIT); see RESEARCH.md for provenance. */
 import type { Node } from 'three/webgpu';
 import {
   If,
@@ -19,10 +16,7 @@ import {
   vec2,
 } from 'three/tsl';
 
-/**
- * Two real roots of `a*t^2 - 2*b*t + c = 0`, ordered to match
- * `calcRootCode`'s winding convention.
- */
+/** Two real roots of `a*t^2 - 2*b*t + c = 0`, ordered to match `calcRootCode`'s winding convention. */
 function stableRoots(
   a: Node<'float'>,
   b: Node<'float'>,

--- a/packages/glyph/src/shaders/typegpu/bitmap-reference.ts
+++ b/packages/glyph/src/shaders/typegpu/bitmap-reference.ts
@@ -1,9 +1,4 @@
-/**
- * CPU reference math for the Bitmap technique, independent of TypeGPU and GPU texture
- * behavior. Every function mirrors one exported shader function of
- * `bitmap-shader.js` operation for operation, so a simulation of the shipped TypeGPU
- * functions can be pinned to these values exactly.
- */
+/** CPU reference math for the Bitmap technique, independent of TypeGPU/GPU texture behavior; each function mirrors one `bitmap-shader.js` function operation-for-operation, for exact pinning. */
 
 export type BitmapVec2 = readonly [number, number];
 export type BitmapVec3 = readonly [number, number, number];
@@ -23,11 +18,7 @@ export function referenceBitmapQuadPosition(
   return [origin[0] + quadPosition[0] * size[0], -(origin[1] + quadPosition[1] * size[1]), 0];
 }
 
-/**
- * CPU mirror of the projection step behind `projectClipPosition`, over an explicit
- * column-major matrix: `clip = mvp * vec4(position, 1)` with WGSL's column-times-
- * vector contraction.
- */
+/** CPU mirror of the projection behind `projectClipPosition` over an explicit column-major matrix: `clip = mvp * vec4(position, 1)` with WGSL's column-times-vector contraction. */
 export function referenceProjectClipPosition(mvp: readonly number[], position: BitmapVec3): BitmapVec4 {
   const x = position[0];
   const y = position[1];
@@ -41,10 +32,7 @@ export function referenceProjectClipPosition(mvp: readonly number[], position: B
   ];
 }
 
-/**
- * CPU mirror of `snapClipAxis`, including the final multiplication by clip w and the
- * reciprocal-multiply order of the emitted shader.
- */
+/** CPU mirror of `snapClipAxis`, including the final multiplication by clip w and the reciprocal-multiply order of the emitted shader. */
 export function referenceSnapClipAxis(clipAxis: number, clipW: number, physicalSize: number): number {
   const normalizedDevicePosition = clipAxis * (1 / clipW);
   const physicalPosition = (normalizedDevicePosition + 1) * (physicalSize * 0.5);
@@ -61,10 +49,7 @@ export function referenceSnappedClipPosition(clip: BitmapVec4, screenSize: Bitma
   ];
 }
 
-/**
- * CPU mirror of `bitmapPageCoverage`: clamp-to-edge, texel-grid scaling, floor, bound
- * clamping, exact texel fetch. Returns the linear texel index the fetch lands on.
- */
+/** CPU mirror of `bitmapPageCoverage`: clamp-to-edge, texel-grid scaling, floor, bound clamping, exact texel fetch. Returns the linear texel index. */
 export function referenceBitmapPageCoverage(dimensions: BitmapVec2, atlasUv: BitmapVec2): number {
   const clampedUv = [clamp(atlasUv[0], 0, 1), clamp(atlasUv[1], 0, 1)] as const;
   const texelCoord = [Math.floor(clampedUv[0] * dimensions[0]), Math.floor(clampedUv[1] * dimensions[1])] as const;

--- a/packages/glyph/src/shaders/typegpu/bitmap-shader.ts
+++ b/packages/glyph/src/shaders/typegpu/bitmap-shader.ts
@@ -8,10 +8,7 @@ import tgpu, {
 import * as d from 'typegpu/data';
 import * as std from 'typegpu/std';
 
-/**
- * One glyph instance's canonical Bitmap fields, as a typed GPU schema. Core owns what each field means; how a program
- * addresses it — storage buffers, instanced attributes, or a uniform — stays the program's own choice.
- */
+/** One glyph instance's canonical Bitmap fields, as a typed GPU schema; Core owns field meaning, the program owns how it's addressed (buffer, attribute, or uniform). */
 export const TypeGpuBitmapInstance: d.WgslStruct<{
   origin: d.Vec2f;
   size: d.Vec2f;
@@ -35,12 +32,7 @@ export const TypeGpuBitmapInstance: d.WgslStruct<{
 });
 export type TypeGpuBitmapInstance = d.InferGPU<typeof TypeGpuBitmapInstance>;
 
-/**
- * The GPU resource one Bitmap glyph batch binds: the single-channel coverage pages its strike binding selected. Pages
- * are uploaded in the atlas's own top-down row order, so any flipY-style host setting must stay disabled. Coverage is
- * read as exact clamped texels — the fetch the `/tsl` realization compiles to for data textures — so no sampler enters
- * the measure.
- */
+/** Single-channel coverage pages uploaded in the atlas's own top-down row order — flipY-style host settings must stay disabled; read as exact clamped texels, no sampler. */
 export const TypeGpuBitmapPageLayout: TgpuBindGroupLayout<{
   page: TgpuLayoutTexture<d.WgslTexture2dArray<d.F32>> & { visibility?: readonly ['fragment'] };
 }> = tgpu.bindGroupLayout({
@@ -64,15 +56,9 @@ export const TypeGpuBitmapVertexInput: d.WgslStruct<{
   modelViewProjection: d.Mat4x4f;
   screenSize: d.Vec2f;
 }> = d.struct({
-  /**
-   * Unit-quad coordinate spanning `[0, 1]` with the origin at the glyph's upper-left corner. This is the coordinate
-   * `/tsl` reads from `positionLocal`; a program supplying different geometry owns that correspondence.
-   */
+  /** Unit-quad coordinate spanning `[0, 1]`, origin at upper-left — the coordinate `/tsl` reads from `positionLocal`; different geometry must preserve that correspondence. */
   quadPosition: d.vec2f,
-  /**
-   * Unit-quad texture coordinate, the coordinate `/tsl` reads from `uv()`. Equals `quadPosition` on the technique's
-   * unit quad; both are carried because `/tsl` reads them independently.
-   */
+  /** Unit-quad texture coordinate, the coordinate `/tsl` reads from `uv()`; equals `quadPosition` but carried separately since `/tsl` reads them independently. */
   quadUv: d.vec2f,
   instance: TypeGpuBitmapInstance,
   /** Column-major model-view-projection, the same matrix chain a Three renderer would apply to `position`. */
@@ -82,12 +68,7 @@ export const TypeGpuBitmapVertexInput: d.WgslStruct<{
 });
 export type TypeGpuBitmapVertexInput = d.InferGPU<typeof TypeGpuBitmapVertexInput>;
 
-/**
- * Everything the canonical Bitmap vertex stage produces, so a program can consume a stage or compose over its output.
- *
- * Unlike `/tsl`, which leaves object-space `position` for the renderer's projection, a standalone vertex result carries
- * its clip-space placement directly: `clipPosition` is what a program assigns to `@builtin(position)`.
- */
+/** Unlike `/tsl`, which leaves object-space `position` for the renderer's projection, this carries clip-space placement directly: `clipPosition` is what a program assigns to `@builtin(position)`. */
 export const TypeGpuBitmapVertexOutput: d.WgslStruct<{
   position: d.Vec3f;
   clipPosition: d.Vec4f;
@@ -120,10 +101,7 @@ export const TypeGpuBitmapFragmentInput: d.WgslStruct<{
 });
 export type TypeGpuBitmapFragmentInput = d.InferGPU<typeof TypeGpuBitmapFragmentInput>;
 
-/**
- * Everything the canonical Bitmap fragment stage produces, so a program can consume the final result or compose over
- * its coverage before paint alpha.
- */
+/** Everything the canonical Bitmap fragment stage produces; a program can consume the final result or compose over coverage before paint alpha. */
 export const TypeGpuBitmapFragmentOutput: d.WgslStruct<{
   coverage: d.F32;
   color: d.Vec3f;
@@ -150,12 +128,7 @@ export function bitmapQuadPosition(origin: d.v2f, size: d.v2f, quadPosition: d.v
   return d.vec3f(origin.x + quadPosition.x * size.x, -(origin.y + quadPosition.y * size.y), 0);
 }
 
-/**
- * Rounds one projected clip-space axis onto whole physical pixels and returns the final clip value. Snapping in clip
- * space rather than paragraph space keeps the paragraph transform, camera, and device pixel ratio out of the technique:
- * whatever chain produced the clip position, its device-space landing is what has to sit on the grid the atlas was
- * baked for. The operation order — reciprocals included — matches the TSL realization's emitted shader exactly.
- */
+/** Rounds a clip-space axis onto whole physical pixels in clip space (not paragraph space), so any transform/camera/DPR lands on the atlas's baked grid; operation order matches the TSL realization exactly. */
 export function snapClipAxis(clipAxis: number, clipW: number, physicalSize: number): number {
   'use gpu';
 
@@ -171,11 +144,7 @@ export function projectClipPosition(modelViewProjection: d.m4x4f, position: d.v3
   return std.mul(modelViewProjection, d.vec4f(position.x, position.y, position.z, 1));
 }
 
-/**
- * The canonical Bitmap vertex stage: quad placement, atlas addressing, and paint passthrough under the default
- * projection. Pixel snapping is opt-in because it preserves strike sharpness at rest but quantizes animated motion; a
- * program that wants it binds `bitmapVertexSnapped` instead.
- */
+/** The canonical Bitmap vertex stage under the default projection; a program wanting pixel snapping (sharp at rest, quantizes animated motion) binds `bitmapVertexSnapped` instead. */
 export const bitmapVertex: TgpuFn<(input: typeof TypeGpuBitmapVertexInput) => typeof TypeGpuBitmapVertexOutput> =
   tgpu.fn(
     [TypeGpuBitmapVertexInput],
@@ -194,10 +163,7 @@ export const bitmapVertex: TgpuFn<(input: typeof TypeGpuBitmapVertexInput) => ty
     });
   });
 
-/**
- * The pixel-snapped Bitmap vertex stage: the same graph with the projected x/y axes rounded onto whole physical
- * pixels. Snapping preserves strike sharpness at rest but quantizes animated motion.
- */
+/** The pixel-snapped Bitmap vertex stage: same graph with projected x/y rounded onto whole physical pixels — sharp at rest, but quantizes animated motion. */
 export const bitmapVertexSnapped: TgpuFn<(input: typeof TypeGpuBitmapVertexInput) => typeof TypeGpuBitmapVertexOutput> =
   tgpu.fn(
     [TypeGpuBitmapVertexInput],
@@ -241,10 +207,7 @@ export function bitmapPaintCoverageOpacity(coverage: number, color: d.v4f): d.v2
   return d.vec2f(output.coverage, output.opacity);
 }
 
-/**
- * Coverage of one atlas coordinate: the coordinate is clamped into the page, scaled onto the texel grid, floored, and
- * clamped against the bounds — the same nearest-texel fetch the `/tsl` realization compiles to for data textures.
- */
+/** Coverage of one atlas coordinate: clamped into the page, scaled onto the texel grid, floored, bound-clamped — the same nearest-texel fetch the `/tsl` realization compiles to. */
 export function bitmapPageCoverage(page: d.texture2dArray<d.F32>, atlasUv: d.v2f, pageLayer: number): number {
   'use gpu';
 
@@ -271,16 +234,10 @@ function bitmapAccessorCoverage(atlasUv: d.v2f, pageLayer: number): number {
   return bitmapPageCoverage(bitmapPageAccessor.$, atlasUv, pageLayer);
 }
 
-/**
- * Override this slot when Bitmap coverage comes from a procedural function or a host-owned indirection rather than a
- * texture. Its default reads `bitmapPageAccessor`, so ordinary texture-backed hosts only replace the accessor.
- */
+/** Override for procedural or host-indirected coverage; the default reads `bitmapPageAccessor`. */
 export const bitmapCoverageSlot: TgpuSlot<BitmapCoverageSource> = tgpu.slot(bitmapAccessorCoverage);
 
-/**
- * The canonical Bitmap fragment stage: single-channel coverage fetched from the bound page array at the interpolated
- * atlas coordinate, then composed with the paint colour.
- */
+/** The canonical Bitmap fragment stage: single-channel coverage fetched from the bound page array, then composed with the paint colour. */
 export const bitmapFragment: TgpuFn<(input: typeof TypeGpuBitmapFragmentInput) => typeof TypeGpuBitmapFragmentOutput> =
   tgpu.fn(
     [TypeGpuBitmapFragmentInput],

--- a/packages/glyph/src/text-properties.ts
+++ b/packages/glyph/src/text-properties.ts
@@ -6,12 +6,7 @@ import type { RasterFormatMetadata } from './config/raster-format.js';
 
 export interface GlyphBufferCapacity {
   readonly size: number;
-  /**
-   * `grow` resizes to what the content needs, `chunk` resizes in multiples of `size`, and `fixed`
-   * rejects an update whose glyph requirement exceeds `size` and keeps the last complete revision
-   * visible. The requirement is a text-length upper bound computed before shaping, so a caller can
-   * size content against the cap rather than discovering it after the fact.
-   */
+  /** `grow` resizes to fit; `chunk` resizes in multiples of `size`; `fixed` rejects an update exceeding `size`, keeping the last complete revision visible. */
   readonly policy: 'grow' | 'chunk' | 'fixed';
 }
 
@@ -56,13 +51,7 @@ export interface ParagraphLayout {
   readonly spaceBefore?: number;
   /** Block-axis space carried in measurements after the paragraph's final line. */
   readonly spaceAfter?: number;
-  /**
-   * Justification bounds on each word space as multiples of its natural
-   * advance: `minWordSpaceRatio` in (0, 1] permits shrinking, and
-   * `maxWordSpaceRatio` (at least 1) caps expansion before the remaining
-   * deficit spills into per-gap letter-space expansion. Unset sides stay
-   * unbounded.
-   */
+  /** Word-space bounds as multiples of natural advance: `minWordSpaceRatio` in (0, 1] permits shrinking, `maxWordSpaceRatio` (>=1) caps expansion before spilling into letter-space expansion. */
   readonly justify?: {
     readonly minWordSpaceRatio?: number;
     readonly maxWordSpaceRatio?: number;
@@ -70,12 +59,7 @@ export interface ParagraphLayout {
   };
   /** Whether the final and hard-broken lines also justify. Defaults to 'auto'. */
   readonly lastLine?: 'auto' | 'justify';
-  /**
-   * Flow the paragraph through side-by-side ordered columns inside an exact
-   * constrained width. Text fills each column in order without balancing, so
-   * the final column may run short. Requires an exact `width`; `gap` is the
-   * inline space between adjacent columns in paragraph-local units.
-   */
+  /** Flows text through ordered columns inside an exact `width`, filling in order without balancing (final column may run short); `gap` is inline space between columns. */
   readonly columns?: { readonly count: number; readonly gap?: number };
 }
 
@@ -102,12 +86,7 @@ export interface TextStyle {
   readonly shadow?: { readonly color: ColorInput; readonly offset: readonly [number, number] };
 }
 
-/**
- * Text decoration lines for a styled range. Geometry comes from the font's baked
- * underline and strikeout metrics; `thickness` and `offset` override in paragraph-local units
- * when nonzero. Only `solid` lines are implemented: requesting another line style is
- * rejected at the boundary rather than silently rendered as solid.
- */
+/** Decoration geometry comes from the font's baked underline/strikeout metrics; `thickness`/`offset` override when nonzero. Only `solid` style is implemented — others are rejected. */
 export interface TextDecorationStyle {
   readonly underline?: boolean;
   readonly overline?: boolean;

--- a/packages/glyph/src/three/codec.ts
+++ b/packages/glyph/src/three/codec.ts
@@ -52,10 +52,7 @@ export const TRANSFORM_BUFFER_ID: CodecBufferId = threeSystemBuffers.transformIn
 
 export const STABLE_GLYPH_BUFFER_ID: CodecBufferId = threeSystemBuffers.stableGlyphId.id;
 
-/**
- * Decoration is a reserved technique of the Three Codec rather than a raster
- * technique: rows are resource-free and fill the gather lanes directly.
- */
+/** Decoration is a reserved technique of the Three Codec, not a raster technique: rows are resource-free and fill the gather lanes directly. */
 export const decorationSchema: TechniqueSchema<
   {
     readonly rect: {
@@ -175,13 +172,7 @@ export function threeCodecCapabilitySet(): CodecCapabilitySet {
   };
 }
 
-/**
- * Resource-free decoration quads. Decoration rows fill the gather lanes directly —
- * f32 lanes 0-3 carry the rectangle and u32 lanes carry transform, stable identity,
- * color, then flags — so the semantic handles below address gather lanes by
- * position, not per-glyph meaning: the "inlineOrigin" lane is the rect's inline
- * start, and the paint arrives through the binding's packed u32 pair.
- */
+/** Decoration rows fill gather lanes by position, not per-glyph meaning: e.g. the "inlineOrigin" lane here holds the rect's inline start, not an inline origin. */
 function decorationProgram(
   techniqueId: CodecTechniqueId,
   programId: CodecProgramId,

--- a/packages/glyph/src/three/command-buffer-renderer.ts
+++ b/packages/glyph/src/three/command-buffer-renderer.ts
@@ -142,17 +142,7 @@ export class ThreeCommandBufferRenderer implements GlyphRenderer<ThreeBindings, 
     return this.#decodeRendererCommit(view);
   }
 
-  /**
-   * Reads where each glyph is drawn, in paragraph glyph-origin space, and names what it could not read.
-   *
-   * The retained lane is NOT in glyph-origin space, and which space it is in is the technique's own
-   * business: Slug and MSDF pack the ink box's top-left corner, and Bitmap stores the origin plus the
-   * baked strike's raster bearing, which is a third space that no measure value can reconstruct. What
-   * every technique does share is that `targetX`/`targetY` is that same lane's value with the glyph
-   * at rest — the position the layout put it. So the displacement from rest, `value - target`, is in
-   * glyph-origin space for all of them, and adding it to the shaped origin converts without the
-   * renderer knowing anything about the technique's packing at all.
-   */
+  /** Each technique packs the retained lane in a different, non-glyph-origin space, but `value - target` is always the displacement in glyph-origin space, so adding it to shapedX/Y converts without knowing the packing. */
   snapshotGlyphOrigins(
     stableIds: Uint32Array,
     shapedX: Float32Array,

--- a/packages/glyph/src/three/frame-error.ts
+++ b/packages/glyph/src/three/frame-error.ts
@@ -8,24 +8,13 @@ import { GlyphError } from '../glyph-error.js';
 import type { RasterFormatMetadata } from '../config/raster-format.js';
 import type { Text, TextSpan } from './text.js';
 
-/**
- * The authored input a rejected frame names.
- *
- * The engine reports a paragraph handle and a style id, both allocated by this layer; neither is
- * meaningful to a consumer. They are resolved here into the objects the consumer actually wrote:
- * the `Text` and, when one span owns the cause, that span together with its index in `Text.spans`.
- */
+/** The authored input a rejected frame names, resolved from the engine's internal handle/style id onto the `Text` (and span+index, when a span owns the cause) the consumer wrote. */
 export type TextFrameSubject<Format extends RasterFormatMetadata = RasterFormatMetadata> =
   | Readonly<{ kind: 'span'; text: Text<Format>; index: number; span: TextSpan<Format> }>
   | Readonly<{ kind: 'paragraph'; text: Text<Format> }>
   | Readonly<{ kind: 'unattributed' }>;
 
-/**
- * Why the engine refused the frame, in terms a consumer can branch on.
- *
- * `engine` is the residual: a status the engine does not classify further, including every internal
- * invariant violation. Treat it as a defect report rather than something to correct in the input.
- */
+/** Why the engine refused the frame, branchable by `cause`; `engine` is the residual for unclassified internal invariant violations — a defect report, not an input to fix. */
 export type TextFrameRejection<Format extends RasterFormatMetadata = RasterFormatMetadata> =
   /** A span's `[start, end)` is inverted, reaches past the text, or splits a UTF-16 surrogate pair. */
   | Readonly<{ cause: 'span-range'; subject: TextFrameSubject<Format> }>
@@ -44,12 +33,7 @@ export type TextFrameRejection<Format extends RasterFormatMetadata = RasterForma
   /** A status the engine does not classify as caller-actionable. */
   | Readonly<{ cause: 'engine' }>;
 
-/**
- * A frame the text engine refused, raised with the cause resolved onto the caller's own objects.
- *
- * Branch on `rejection.cause`; `status` is the raw engine status the rejection was decoded from and
- * exists for reporting, not for classification.
- */
+/** A frame the engine refused, with cause resolved onto the caller's own objects. Branch on `rejection.cause`; `status` is raw and for reporting only, not classification. */
 export class TextFrameError extends GlyphError<'frame-rejected'> {
   readonly rejection: TextFrameRejection;
   readonly status: number;
@@ -75,12 +59,7 @@ const CAUSE_BY_CODE: ReadonlyMap<GlyphEngineStatusCode, TextFrameRejection['caus
   ['result-too-large', 'capacity' as const],
 ]);
 
-/**
- * Re-raises an engine status as a typed rejection.
- *
- * The status alone decides the cause; nothing is recovered from the underlying message. Errors that
- * are not engine statuses pass through untouched, because they already name their own cause.
- */
+/** Re-raises an engine status as a typed rejection; the status code alone decides the cause. Non-engine-status errors pass through untouched. */
 export function textFrameError(error: unknown, resolve: TextFrameSubjectResolver): unknown {
   if (!(error instanceof GlyphEngineStatusError)) return error;
   const details = glyphEngineStatusErrorDetails(error);

--- a/packages/glyph/src/three/glyph-measurement.ts
+++ b/packages/glyph/src/three/glyph-measurement.ts
@@ -15,15 +15,7 @@ export interface GlyphAnchor {
 /** The coordinate system used by a retained renderer geometry source. */
 export type ThreeGlyphGeometryCoordinates = 'glyph-local' | 'unit-square' | 'em';
 
-/**
- * Geometry data available to a Three adapter when a technique supplies a mesh.
- *
- * `metric-quad` is already in Text-local Three coordinates. `supplied` is the
- * immutable source mesh in the technique's declared coordinates; the technique
- * shader owns how those coordinates are scaled or otherwise transformed. This
- * distinction keeps a physics adapter from mistaking a renderer source mesh for
- * a collision guarantee while still making the exact retained shape available.
- */
+/** `metric-quad` is already in Text-local Three coordinates; `supplied` is the technique's immutable source mesh in its own declared coordinates — not a collision guarantee. */
 export interface ThreeGlyphGeometrySource {
   readonly kind: 'metric-quad' | 'supplied';
   readonly geometryKind?: 'quad' | 'hull' | 'custom';

--- a/packages/glyph/src/three/glyphs.ts
+++ b/packages/glyph/src/three/glyphs.ts
@@ -14,14 +14,7 @@ interface DetachedTextSource extends THREE.Object3D {
   readonly pixelSnapping: boolean;
 }
 
-/**
- * Converts an instance matrix from world space into one `Glyphs` object's local space without
- * allocating or recomputing its inverse.
- *
- * @param glyphsMatrixWorldInverse - Precomputed inverse of the owning `Glyphs` object's current `matrixWorld`.
- * @param matrixWorld - Instance transform expressed in world space.
- * @param target - Matrix that receives the local transform; it may alias `matrixWorld`.
- */
+/** Converts an instance matrix from world into one `Glyphs` object's local space using a precomputed inverse (no allocation/recompute); `target` may alias `matrixWorld`. */
 export function worldToLocalMatrix(
   glyphsMatrixWorldInverse: THREE.Matrix4,
   matrixWorld: THREE.Matrix4,
@@ -31,13 +24,7 @@ export function worldToLocalMatrix(
   return target.copy(glyphsMatrixWorldInverse).multiply(matrixWorld);
 }
 
-/**
- * Converts an instance matrix from `Glyphs`-local space into world space.
- *
- * @param glyphsMatrixWorld - Current `matrixWorld` of the `Glyphs` object that owns the instance.
- * @param matrixLocal - Instance transform expressed in the owning `Glyphs` object's local space.
- * @param target - Matrix that receives the world transform; it may alias `matrixLocal`.
- */
+/** Converts an instance matrix from `Glyphs`-local space into world space using the owner's current `matrixWorld`; `target` may alias `matrixLocal`. */
 export function localToWorldMatrix(
   glyphsMatrixWorld: THREE.Matrix4,
   matrixLocal: THREE.Matrix4,
@@ -99,15 +86,7 @@ interface DetachedGlyphRecordAddress {
   readonly index: number;
 }
 
-/**
- * A detached render-plan branch produced by `Text.breakApart()`.
- *
- * The planner has already compacted the selected glyph records into a complete publication. This
- * object imports that publication into the normal Three command-buffer renderer, retaining the same
- * atlas/resource relationships and compatible instancing without making child Text objects.
- * Per-glyph matrices are an additional Three-side instance attribute; the live paragraph never
- * receives them and continues to shape normally.
- */
+/** A detached render-plan branch from `Text.breakApart()`: imports the planner's compacted publication into the normal renderer without child Text objects; per-glyph matrices are Three-side only and never reach the live paragraph. */
 export class Glyphs extends THREE.Object3D {
   readonly #target: ThreeCommandBufferRenderer;
   readonly #copy: GlyphCopy<void>;
@@ -263,13 +242,7 @@ export class Glyphs extends THREE.Object3D {
     markStorageAttributeUpdated(storage.transforms, offset, 16);
   }
 
-  /**
-   * Writes a full affine instance transform expressed in world space.
-   *
-   * This single-record convenience updates the detached root's ancestor chain. Bulk callers should
-   * update that chain once, invert `matrixWorld` once, convert with `worldToLocalMatrix()`, and call
-   * `setMatrixAt()` per glyph.
-   */
+  /** Writes a world-space transform; this per-call convenience updates the ancestor chain and inverts `matrixWorld` each time — bulk callers should do that once and call `setMatrixAt()` per glyph. */
   setWorldMatrixAt(index: number, matrixWorld: THREE.Matrix4): void {
     this.#assertActive();
     this.updateWorldMatrix(true, false, true);

--- a/packages/glyph/src/three/text.ts
+++ b/packages/glyph/src/three/text.ts
@@ -807,10 +807,7 @@ export class Text<Format extends RasterFormatMetadata> extends THREE.Object3D {
     this.#boundingBoxCurrent = false;
   }
 
-  /**
-   * Measure current desired text without scene attachment or matrix traversal.
-   * A cache miss may synchronously incur font and measure lookup work in the text engine.
-   */
+  /** Measures current desired text without scene attachment or matrix traversal; a cache miss may synchronously incur font/measure lookup work. */
   measure(): ParagraphLayoutSummary {
     this.#assertActive();
     const text = this;
@@ -819,10 +816,7 @@ export class Text<Format extends RasterFormatMetadata> extends THREE.Object3D {
     return measurement;
   }
 
-  /**
-   * Return caller-owned positioned glyph and line columns without requiring a rendered frame.
-   * A cache miss may synchronously incur glyph lookup and positioning work; every call copies the columns.
-   */
+  /** Returns caller-owned positioned glyph and line columns without requiring a rendered frame; a cache miss may incur lookup work, and every call copies the columns. */
   glyphs(): GlyphLayoutInspection {
     this.#assertActive();
     const text = this;

--- a/packages/glyph/tests/integration/engine-sequence-property.test.mjs
+++ b/packages/glyph/tests/integration/engine-sequence-property.test.mjs
@@ -1,17 +1,4 @@
-/**
- * Sequence-level property gate for the retained text engine.
- *
- * Single-step tests fix one input and assert one output. The defects this engine has
- * actually shipped were pairings instead: a state reachable only after a particular
- * ORDER of edits, measures, and publishes. This harness drives randomized-but-seeded
- * interactive sequences through the public Three surface and asserts, after every step,
- * that valid input never fails to publish and that committed metrics never disagree with
- * themselves.
- *
- * Determinism is a requirement, not a convenience: the generator is a seeded PRNG with a
- * fixed seed list, so a failure names the seed and step that reproduce it exactly. There
- * is no wall-clock input, no Math.random, and no retry.
- */
+/** Property gate: seeded PRNG drives randomized interactive sequences through Three's public surface and asserts every step publishes valid, self-consistent metrics. Deterministic — fixed seed list, no Math.random, no retry. */
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
@@ -34,11 +21,7 @@ const FONT_FIXTURES = {
   cjk: 'noto-sans-cjk-showcase-bitmap-16.font.glb',
 };
 
-/**
- * Seed corpus: the authored Advanced-shaping timeline, which drives text, width,
- * direction, language, and features together and is the sequence that found the
- * ligature and style-payload defects in the live app.
- */
+/** Seed corpus: authored cases pairing text with direction, language, and features, replayed to reproduce shipped ligature and style-payload defects. */
 const SEEDED_CASES = [
   {
     id: 'latin-features',
@@ -182,11 +165,6 @@ class Subject {
   }
 }
 
-/**
- * The operation alphabet. Each entry mutates the subject's intended inputs; the runner
- * applies them and publishes. Weights favour the edit shapes that compose into the
- * pairings the engine has historically mishandled.
- */
 const OPERATIONS = [
   {
     name: 'append-text',

--- a/packages/glyph/tests/integration/react-lease-lifecycle.test.mjs
+++ b/packages/glyph/tests/integration/react-lease-lifecycle.test.mjs
@@ -1,19 +1,4 @@
-/**
- * React adapter lease accounting.
- *
- * The adapter holds no disposal code of its own: react-three-fiber's reconciler owns it,
- * calling `disposeOnIdle(child.object)` from `removeChild` unless `dispose={null}` opts
- * out. Two properties of that implementation make lease accounting worth asserting rather
- * than assuming. It defers disposal to idle priority, so a paragraph outlives its unmount
- * and can be disposed after the runtime an application tore down; and it swallows disposal
- * errors in a `try`/`catch`, so a throw there is invisible in React while being fatal in
- * plain Three. This fixture sets `IS_REACT_ACT_ENVIRONMENT`, which makes r3f dispose
- * synchronously — so these assertions observe the settled state directly.
- *
- * StrictMode double-invokes component bodies and, in development, mounts, unmounts, and
- * remounts. A paragraph lease taken per mount and released per unmount must therefore
- * balance across the doubled lifecycle, or every StrictMode application would leak.
- */
+/** r3f's reconciler owns disposal via idle-deferred, error-swallowing `disposeOnIdle`; `IS_REACT_ACT_ENVIRONMENT` forces it synchronous here so assertions see settled state, and StrictMode's doubled mount/unmount means leases must balance across it. */
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test, { after } from 'node:test';
@@ -36,9 +21,8 @@ await glyph.init();
 const r3fHandle = glyph.handle('three:react-lease-tests', ThreeConfig);
 after(() => r3fHandle.dispose());
 
-// Three's WebGPU renderer drives its animation loop through a host context that node does
-// not provide. These tests assert lifecycle accounting, never rendering, so a minimal
-// scheduler is enough to let the renderer construct and tear down.
+// Three's WebGPU renderer needs a host context node lacks; a minimal scheduler lets it
+// construct and tear down without actually rendering.
 globalThis.self ??= globalThis;
 // A no-op scheduler: the renderer may start its loop, but nothing is ever driven, so the
 // process stays quiescent and exits. These tests assert lifecycle accounting, never frames.

--- a/packages/glyph/tests/integration/shaper-registration.test.mjs
+++ b/packages/glyph/tests/integration/shaper-registration.test.mjs
@@ -580,13 +580,7 @@ function align(value, alignment) {
   return Math.ceil(value / alignment) * alignment;
 }
 
-/**
- * Roadmap 11.17 layer 1: the paragraph-scoped synchronous measure entry runs
- * preparation and measurement for one paragraph, writes the semantic table into
- * the inactive result slot without publishing, and leaves committed state
- * untouched — no revision advance, no publication-generation bump, and no
- * checkpoint hazard for the next real frame.
- */
+/** measureParagraph writes its semantic table to the inactive result slot without publishing — no revision advance, no publication-generation bump. */
 test('measure_paragraph answers synchronously without publishing or burning revisions', async () => {
   const [interArtifact, shaperWasm, abi] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/rendering/inter-bitmap-16.font.glb', import.meta.url)),
@@ -769,13 +763,7 @@ test('measure_paragraph answers synchronously without publishing or burning revi
   assert.equal(fn.disposeRoot(29), abi.status.ok);
 });
 
-/**
- * Roadmap 11.17 layer 3: the committing frame compares its per-paragraph inputs
- * against the retained speculative transaction and, on a fingerprint hit, adopts the
- * transaction's pending state together with its reserved glyph identities — the
- * stable ids a query reported stay valid in the committed frame instead of being
- * rolled back and re-allocated.
- */
+/** On a fingerprint hit, the committing frame adopts the retained speculative transaction's pending state and reserved glyph ids rather than rolling them back. */
 test('the committing frame adopts the speculative transaction and its reserved glyph identities', async () => {
   const [interArtifact, shaperWasm, abi] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/rendering/inter-bitmap-16.font.glb', import.meta.url)),
@@ -893,15 +881,7 @@ test('the committing frame adopts the speculative transaction and its reserved g
   assert.equal(fn.disposeRoot(29), abi.status.ok);
 });
 
-/**
- * Measurement-only queries skip the per-glyph positioning tail (the
- * measurement derives at line level from flow and clusters), and the
- * committing frame runs exactly the missing tail when it adopts such a
- * transaction. The proof is end-state equality: a planner that measured
- * several widths before committing must publish a semantic table
- * byte-identical to a control planner that committed the same frame
- * without ever measuring.
- */
+/** Measurement-only queries skip per-glyph positioning (derived at line level instead); committing then runs exactly that missing tail, proved by byte-identical output vs. a never-measured control. */
 test('measurement-only queries leave the committing frame byte-identical to a never-measured control', async () => {
   const [interArtifact, shaperWasm, abi] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/rendering/inter-bitmap-16.font.glb', import.meta.url)),
@@ -1023,12 +1003,7 @@ test('measurement-only queries leave the committing frame byte-identical to a ne
   assert.equal(remeasured.status, abi.status.ok, 'measurement-only re-query over a positioned transaction');
 });
 
-/**
- * The geometry-only resize short-circuit: a width change that composes the
- * exact committed lines adopts committed positioning and publishes nothing,
- * and a width change that moves breaks still relayouts fully afterward —
- * the committed state must answer both correctly in sequence.
- */
+/** A width change that preserves committed line breaks adopts committed positioning and publishes nothing; one that moves breaks still relayouts fully. */
 test('resize equivalence adopts committed positioning and still relayouts on break changes', async () => {
   const [interArtifact, shaperWasm, abi] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/rendering/inter-bitmap-16.font.glb', import.meta.url)),
@@ -1140,17 +1115,7 @@ test('resize equivalence adopts committed positioning and still relayouts on bre
   assert.equal(fn.disposeRoot(41), abi.status.ok);
 });
 
-/**
- * Integer layout-units slice 5: the packaged artifact's measured f32 extents
- * are pinned EXACTLY at several widths. Every stage between text and extent
- * runs on the F16.16 rounding contract (`layout_units.rs`), whose integer
- * arithmetic and IEEE f64 scaling are deterministic across native and Wasm
- * builds and across hosts; the linux CI runner reproducing these exact
- * values is the cross-build half of the bit-exactness evidence, alongside
- * the composed conformance hashes it already reproduces. A change in any
- * pinned value is a layout-contract change and must be re-derived
- * deliberately, never absorbed.
- */
+/** f32 extents are pinned exactly per the F16.16 integer rounding contract (layout_units.rs), deterministic across native/Wasm and hosts. A pinned-value change is a layout-contract change — re-derive deliberately, never absorb. */
 test('measured f32 extents reproduce exactly at every pinned width', async () => {
   const [interArtifact, shaperWasm, abi] = await Promise.all([
     readFile(new URL('../../../../apps/benchmarks/fixtures/rendering/inter-bitmap-16.font.glb', import.meta.url)),

--- a/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
+++ b/packages/glyph/tests/integration/text-mutation-gpu-lanes.test.mjs
@@ -1,26 +1,4 @@
-/**
- * Incremental text mutation, verified through to the GPU.
- *
- * Every lane this engine already tested -- `layout`, `glyphs`, glyph ids, glyph
- * origins, draw counts, `instanceCount` -- reads the ENGINE. The packed instanced attributes are
- * what the GPU actually samples, and nothing asserted them. An incremental edit that leaves one
- * record slot holding its pre-edit occupant therefore passes every engine-side check while
- * rendering the wrong glyph, which is exactly the defect this file exists to catch.
- *
- * This file owns the Latin corpus and the three raster formats. The differential oracle it
- * asserts lives in `../support/text-mutation-lanes.mjs`, shared with the script-topology and span
- * files so the invariant cannot drift between them.
- *
- * Sequences are seeded and fixed. A failure names the case and step that reproduce it, with no
- * wall-clock input and no `Math.random`.
- *
- * NOT COVERED: the stable-indirect allocation policy. `ThreeTextEngineCoordinator` registers the
- * Three Codec with `threeCodecBytes`'s default `'ordered'` allocation mode and
- * `ThreeTextEngineCoordinatorOptions` exposes only `transformMode`, so no first-party path
- * reachable from `Text`/`TextGroup` selects `'stable'`. Covering it needs either a coordinator
- * option or a host-level test that drives internal handle state directly, as
- * `three-engine-coordinator.test.mjs` does.
- */
+/** Verifies edits reach the GPU-sampled packed instanced attributes, not just engine state (`layout`/`glyphs`/counts) — an edit can pass those while rendering the wrong glyph. Shared oracle lives in `../support/text-mutation-lanes.mjs`; sequences are seeded and deterministic. */
 import test, { after } from 'node:test';
 
 import { bitmap } from '@pmndrs/glyph/raster/bitmap';
@@ -59,13 +37,7 @@ const TECHNIQUES = {
 const fonts = createFontCache(TECHNIQUES);
 after(() => fonts.dispose());
 
-/**
- * Author one paragraph's content.
- *
- * Spans are derived from the text rather than fixed, so an edited node and a node freshly built
- * with the same text always carry identical authored style -- the comparison stays a test of the
- * incremental path, not of two different documents.
- */
+/** Spans derive from the text (not fixed), so an edited node and a freshly built one share identical authored style — keeping the comparison a test of the incremental path only. */
 function paragraph(text, { bounds = constraints, position, rasterPixelRatio, styled = false } = {}) {
   return {
     position,
@@ -106,20 +78,7 @@ const EDIT_CLASSES = [
   ['collapse to one character', 'ACTIVATE', 'A'],
 ];
 
-/**
- * A three-node group with per-span colours and sizes and per-node raster pixel ratios.
- *
- * One paragraph in uniform white at one size leaves the foreground, `fontSize`, and
- * `transformIndex` lanes constant, so a slot corrupted in exactly those lanes reads back correct
- * by accident. Distinct positions, sizes, and colours make each of those lanes carry a value that
- * identifies its own slot.
- *
- * `rasterPixelRatio` is not itself a packed lane -- no first-party codec program
- * reads it -- but it is one of the two resource-selection inputs, so varying it per node drives
- * the gather's selection-change branch, the one that widens a narrow change mask to every input.
- * It cannot select a DIFFERENT resource here: these fixtures bake one strike and one page each,
- * and requesting more strikes needs retained source bytes the fixtures do not carry.
- */
+/** Distinct position/size/color per node means every packed lane carries a value identifying its own slot, so slot corruption can't read back correct by accident. `rasterPixelRatio` also varies per node — not a packed lane itself, but a resource-selection input that exercises the gather's selection-change branch. */
 function styledScene(texts) {
   return texts.map((text, index) =>
     paragraph(text, {

--- a/packages/glyph/tests/integration/text-mutation-known-defects.test.mjs
+++ b/packages/glyph/tests/integration/text-mutation-known-defects.test.mjs
@@ -1,43 +1,4 @@
-/**
- * Minimal reproductions of three defects found while extending incremental-mutation coverage.
- *
- * Each one is the smallest input that exhibits a defect the differential/packed-lane oracle or the
- * script corpora uncovered, reduced to the public `Text`/`TextGroup` surface and one baked fixture.
- * They are pinned here rather than inside the coverage files so that a red run names the defect
- * instead of naming a corpus, and so that fixing one turns exactly one test green. All three are
- * now fixed, and each pins its fix: reverting the fix turns exactly the case below red again.
- *
- * None of these is the defect fixed by `fix(glyph): rebuild only a slot whose retained identity
- * moved`. That fix holds: the Latin gate and every non-bidi script case pass with it and fail
- * without it.
- *
- *   1. A GLYPH DISAPPEARS FROM THE GPU BUFFER. FIXED.
- *      Deleting a leading left-to-right island, together with its separating space, from a
- *      right-to-left paragraph inside a `TextGroup` left a LATER, UNEDITED paragraph with one
- *      fewer instanced record than it has committed glyphs. The engine still reported every glyph;
- *      the GPU was handed one fewer. Nothing engine-side could see this, which is exactly why the
- *      packed lanes are worth asserting. The retained gather recorded only a selection bit per
- *      source glyph, never the identity that bit belonged to, so a deleted space let an unchanged
- *      glyph read a neighbour's row and skip its own record.
- *
- *   2. A LEGAL TEXT CHANGE MANUFACTURED A PARAGRAPH THE ENGINE REFUSES TO PUBLISH. FIXED.
- *      The engine requires every extended grapheme cluster to resolve to exactly one style. `Text`
- *      did not hold that on its `spans` input: adding a combining scalar at a legal, cluster-
- *      aligned span boundary moved that boundary into the middle of the cluster the change just
- *      created, and the paragraph stopped publishing with an opaque numeric engine status. `Text`
- *      now resolves every span boundary onto the cluster grid before a frame is built (D-265); the
- *      surface around this one case is covered by `text-mutation-span-alignment.test.mjs`. The
- *      original reproduction went through `replaceText`, which has since been removed along with
- *      the rest of the offset-taking edit surface; the case is restated on the `set` that remains.
- *
- *   3. A SPACE FOLLOWED BY A COMBINING MARK WAS REJECTED OUTRIGHT. FIXED.
- *      UAX #14 LB9 does NOT attach a combining mark to a preceding SPACE, so it yields a break
- *      opportunity between them; UAX #29 GB9 attaches it unconditionally, so the two are one
- *      grapheme cluster. The break opportunity therefore falls strictly inside a cluster, and the
- *      engine rejected the whole frame instead of ignoring an opportunity it cannot take. The same
- *      text after any base the two standards agree on -- a letter, a hyphen, a tab, U+00A0 -- is
- *      accepted, which isolates the disagreement as the cause.
- */
+/** Minimal regression pins for three fixed defects the packed-lane oracle and script corpora found; each test is the smallest repro, and reverting its fix turns exactly that test red. */
 import assert from 'node:assert/strict';
 import test, { after } from 'node:test';
 
@@ -63,13 +24,7 @@ const authored = (text, style, spans = []) => ({
   properties: { constraints, layout, spans, style: [style, paint], text },
 });
 
-/**
- * Committed glyphs against records actually handed to the GPU, per paragraph and in total.
- *
- * Totals alone would catch the loss but not attribute it. A group batches its paragraphs into one
- * draw, so the GPU side cannot name which paragraph lost a record -- the per-paragraph committed
- * counts are the attribution, and they must sum to the records the group actually hands over.
- */
+/** Committed glyphs vs. GPU-handed records, per paragraph and in total. Per-paragraph counts attribute a loss that a batched single-draw total cannot pin to one paragraph. */
 function drawn(mounted) {
   const scene = lanes(mounted);
   const glyphs = scene.paragraphs.map((entry) => entry.glyphCount);

--- a/packages/glyph/tests/integration/text-mutation-script-topology.test.mjs
+++ b/packages/glyph/tests/integration/text-mutation-script-topology.test.mjs
@@ -1,48 +1,4 @@
-/**
- * Incremental text mutation where the SHAPING-RUN TOPOLOGY changes, verified through to the GPU.
- *
- * `text-mutation-gpu-lanes.test.mjs` drives the same differential oracle over Latin text, where a
- * grapheme, a scalar, and a glyph are almost always the same thing. The defect class this file
- * exists for is the one where they are not: the engine computes a glyph's semantic change mask in
- * IDENTITY space, against that glyph's own previous record slot, while the gather that consumes the
- * mask walks SLOT space. The two agree only while a slot keeps its occupant. Every mechanism that
- * moves an occupant between slots is a script mechanism:
- *
- *   - bidi reordering, where an edit anywhere on a mixed-direction line renumbers visual order;
- *   - ligature absorption, where one glyph swallows or releases a whole grapheme cluster;
- *   - Devanagari cluster reordering, where a pre-base matra typed at the TAIL of a cluster renders
- *     at its HEAD, so a tail insertion displaces a glyph that precedes it;
- *   - conjunct formation and splitting, where a single virama changes the glyph count of a cluster.
- *
- * `engine-sequence-property.test.mjs` already drives randomized edits over these same fixtures, and
- * never saw the defect, because its oracle is engine-only: it asks whether `layout` agrees
- * with `layout`. Both read the engine, and both were correct. This file points the
- * differential/packed-lane oracle -- construction from scratch, compared bit-for-bit including the
- * instanced attributes the GPU samples -- at the same fixture classes.
- *
- * Every corpus string here is a substring of the authored Advanced-shaping corpus in
- * `apps/benchmarks/src/workloads/advanced-shaping/scene.ts`, which the conformance target already
- * shapes against these exact baked fixtures with `missingGlyphCount === 0`. `assertShaped` re-proves
- * that here, so a green run cannot be a green blank.
- *
- * Sequences are seeded and fixed. A failure names the case, the edit, and the step that reproduce
- * it, with no wall-clock input and no `Math.random`.
- *
- * NOT COVERED, deliberately:
- *
- *   - Multi-scalar grapheme clusters in the Japanese corpus. Every unit in the authored CJK text is
- *     a single precomposed scalar, and combining voiced-sound marks (U+3099/U+309A) are not in the
- *     `noto-sans-cjk-showcase` subset, so a CJK edit cannot land strictly inside a grapheme cluster.
- *     Mid-cluster editing is covered instead by the scalar-boundary sequences over Devanagari and
- *     Arabic, whose clusters really are multi-scalar.
- *   - Devanagari and CJK through the Slug and MSDF packing policies. Slug lane coverage of
- *     topology change is carried by the three Amiri cases, which cover bidi reorder and ligature
- *     absorption; adding two more baked fixtures per script would multiply bake cost without
- *     reaching a different code path, since the packing policy is chosen per technique and not per
- *     script.
- *   - The stable-indirect allocation policy, for the reason documented in
- *     `text-mutation-gpu-lanes.test.mjs`: no first-party path from `Text`/`TextGroup` selects it.
- */
+/** Extends `text-mutation-gpu-lanes.test.mjs`'s differential/packed-lane oracle to scripts where slot reassignment (bidi reorder, ligature absorption, cluster reordering, conjunct formation) can desync the engine's identity-space change mask from the gather's slot-space read. Seeded and deterministic. */
 import assert from 'node:assert/strict';
 import test, { after } from 'node:test';
 
@@ -91,19 +47,7 @@ const clippedFlow = {
 };
 const paint = { color: '#ffffff' };
 
-/**
- * Author one paragraph.
- *
- * Style carries the case's direction, language, and features, because those are shaping inputs and
- * a run-topology case means nothing under the wrong ones. Features are dropped for empty text: the
- * engine validates an unbounded feature as a non-empty UTF-16 range over the paragraph, which an
- * empty paragraph cannot satisfy, and the shipped Advanced-shaping target drops them for the same
- * reason.
- *
- * Spans are derived from the text rather than fixed, so an edited node and a node freshly built
- * with the same text always carry identical authored style -- the comparison stays a test of the
- * incremental path, not of two different documents.
- */
+/** Style carries the case's direction/language/features (a topology case means nothing under the wrong ones); features are dropped for empty text since the engine rejects a feature range over an empty paragraph. Spans derive from the text so an edited and freshly built node share identical authored style. */
 function paragraph(shaping, text, { flow = wrappingFlow, position, rasterPixelRatio, styled = false } = {}) {
   return {
     position,
@@ -126,19 +70,7 @@ function paragraph(shaping, text, { flow = wrappingFlow, position, rasterPixelRa
   };
 }
 
-/**
- * Two leading runs in different colours and sizes; the remainder keeps the paragraph defaults.
- *
- * Boundaries are code-unit thirds SNAPPED OUTWARD TO GRAPHEME BOUNDARIES. The engine requires every
- * grapheme cluster to resolve to exactly one style and rejects the frame otherwise
- * (`cluster_state.rs`, `build`), which the roadmap records as validating span boundaries against
- * extended grapheme clusters. On Latin text a third almost always lands on a boundary already; on
- * these scripts it almost never does, so an unsnapped third would make every styled case fail as an
- * invalid request instead of testing the incremental path.
- *
- * A boundary inside a LIGATURE is not snapped and does not need to be: styling splits the shaping
- * run, the ligature simply does not form, and `latin-ligature` covers that on purpose.
- */
+/** Boundaries snap outward to grapheme boundaries because the engine rejects any frame whose span splits a cluster (`cluster_state.rs`, `build`); unlike Latin, these scripts rarely land a code-unit third on one already. A boundary inside a ligature is left unsnapped on purpose — the run just splits. */
 function spansFor(text) {
   const boundaries = [...findGraphemeBoundaries(text)];
   const snap = (offset) => boundaries.find((boundary) => boundary >= offset) ?? text.length;
@@ -151,13 +83,7 @@ function spansFor(text) {
   ];
 }
 
-/**
- * The script cases.
- *
- * `alphabet` is the pool a seeded sequence may splice in. Every entry is drawn from the same
- * authored corpus as the case's edits, so a randomized sequence can never wander outside the baked
- * fixture's coverage and turn a topology assertion into a `.notdef` assertion.
- */
+/** `alphabet` is the pool a seeded splice may draw from; every entry comes from the same authored corpus as the case's edits, so a randomized sequence can't wander outside the baked fixture and turn this into a `.notdef` assertion. */
 const CASES = [
   {
     id: 'arabic-joining',
@@ -310,15 +236,7 @@ const CASES = [
   },
 ];
 
-/**
- * A three-node group with per-span colours and sizes and per-node raster pixel ratios.
- *
- * One paragraph in uniform white at one size leaves the foreground, `fontSize`, and
- * `transformIndex` lanes constant, so a slot corrupted in exactly those lanes reads back correct by
- * accident. Distinct positions, sizes, and colours make each of those lanes carry a value that
- * identifies its own slot. The edit lands on the middle node, so the nodes around it must keep
- * their own lanes while the record run under them shifts.
- */
+/** Distinct position/size/color per node means every packed lane carries an identifying value, so slot corruption can't read back correct by accident. The edit lands on the middle node, so surrounding nodes must keep their lanes while the record run under them shifts. */
 function styledScene(shaping, texts) {
   return texts.map((text, index) =>
     paragraph(shaping, text, {
@@ -462,17 +380,7 @@ function spliceEdit(text, units, random) {
   return admissible(next === text ? text.slice(0, Math.max(0, text.length - 1)) : next);
 }
 
-/**
- * Trim a generated string down to one the engine will accept.
- *
- * EXCLUDED, and pinned separately: text where UAX #14 offers a line-break opportunity strictly
- * inside a UAX #29 grapheme cluster -- a SPACE followed by a combining mark is the reachable case,
- * because LB9 does not attach a mark to a preceding SPACE while GB9 does. The engine rejects that
- * whole frame rather than ignoring the opportunity, which
- * `text-mutation-known-defects.test.mjs` case 3 reproduces minimally. Splicing at scalar boundaries
- * generates it constantly, and letting it through would leave these sequences reporting a defect
- * they are not for instead of testing the packed lanes they are for.
- */
+/** Excludes text where a UAX #14 break point falls inside a UAX #29 cluster (space + combining mark, LB9 vs GB9) — that's `text-mutation-known-defects.test.mjs` case 3's defect, not this file's, and scalar splicing generates it constantly. */
 function admissible(text) {
   for (let candidate = text; candidate.length > 0; candidate = candidate.slice(0, -1)) {
     const clusters = [...findGraphemeBoundaries(candidate)];
@@ -484,13 +392,7 @@ function admissible(text) {
   return '';
 }
 
-/**
- * The offsets a splice may land on.
- *
- * Scalar sequences use every scalar boundary, so a cluster can be cut. Grapheme sequences use only
- * grapheme boundaries, so it cannot. A surrogate pair is never split either way: scalar boundaries
- * are taken from the string's own code-point iterator, not from its code-unit indices.
- */
+/** Scalar sequences use every scalar boundary (so a cluster can be cut); grapheme sequences use only grapheme boundaries. Either way a surrogate pair is never split, since scalar boundaries come from the code-point iterator. */
 function boundaryOffsets(text, units) {
   const graphemes = units.some((unit) => [...unit].length > 1 || unit.length > 1);
   if (!graphemes) return [...scalarOffsets(text)];
@@ -510,14 +412,7 @@ function graphemeUnits(source) {
   return [...GRAPHEMES.segment(source)].map((entry) => entry.segment);
 }
 
-/**
- * The oracle's negative control.
- *
- * Everything above is an assertion that two scenes agree. If `assertMatchesFreshBuild` could not
- * SEE a difference, every one of those assertions would pass on a corrupt buffer and this whole
- * file would be decorative. Corrupting one float in one packed lane -- the smallest defect the
- * mechanism under test can produce -- must make it fail, per lane, so no lane is silently exempt.
- */
+/** Negative control: proves `assertMatchesFreshBuild` can see a difference. Without this, every assertion above could pass against a corrupt buffer. Corrupting one float in one packed lane must fail, per lane. */
 test('the differential oracle fails when a single packed float is corrupted', { timeout }, async () => {
   const shaping = CASES.find((entry) => entry.id === 'indic-reordering');
   const font = await fonts.load('devanagari');

--- a/packages/glyph/tests/integration/three-raster-program-registration.test.mjs
+++ b/packages/glyph/tests/integration/three-raster-program-registration.test.mjs
@@ -1,19 +1,4 @@
-/**
- * When a Three raster codec may still be registered.
- *
- * The registry is module-global, and a `GlyphEngine`'s Three coordinator reads it exactly
- * once, at construction. Nothing re-reads it. A registration after that point was a perfectly legal
- * call that applied to nothing: the technique was in the map, invisible to every engine already
- * built, and the loss surfaced far away and much later as a missing technique when a font using it
- * was bound. A doc comment saying "register early" is not enforcement.
- *
- * The rule this pins: a technique no live engine could ever see is refused at registration,
- * naming itself, and becomes registrable again once no engine holds a snapshot.
- *
- * This file owns its own engine and coordinator because the assertions are about the module-global
- * registry's lifecycle, and it leaves a program in that registry -- which is safe only because the
- * test runner gives each file its own process.
- */
+/** A registration after any live engine's construction-time registry snapshot is refused, naming itself, and becomes legal again once no engine holds one. Leaves state in the module-global registry — safe only because the test runner isolates each file to its own process. */
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';

--- a/packages/glyph/tests/integration/three-v1.test.mjs
+++ b/packages/glyph/tests/integration/three-v1.test.mjs
@@ -2260,12 +2260,7 @@ test('one Three root grows aggregate glyph storage without reserving one aggrega
   fontDomain.dispose();
 });
 
-/**
- * Roadmap 11.17 layer 4: layout under a geometry-only change routes to the
- * paragraph-scoped synchronous engine query — no full planner updates, no
- * publication flips, no revision burn — and the following ordinary frame adopts the
- * speculative work without a checkpoint rebuild.
- */
+/** A geometry-only constraint change routes to the paragraph-scoped synchronous engine query — no full planner update, no publication flip — and the next ordinary frame adopts the speculative work without a checkpoint rebuild. */
 test('repeated layout under changing constraints stays on the paragraph query path', async (t) => {
   const abi = textShaperAbi;
   const three = await createThreeTestHandle(t);
@@ -2319,11 +2314,8 @@ test('repeated layout under changing constraints stays on the paragraph query pa
 });
 
 test('a standard ligature that absorbs a grapheme publishes and keeps typing', async (t) => {
-  // A ligature reports one glyph at the first grapheme of the pair, so the trailing
-  // grapheme's cluster owns no glyph. It still belongs to the shaped run and positioning
-  // still derives a scale for it, so the cluster arena must record the owning font's
-  // units-per-em for it as well. Amiri applies `liga` to Latin f-pairs; Inter as baked
-  // does not, which is why every existing Latin fixture missed this.
+  // A ligature's absorbed grapheme owns no glyph, but the cluster arena still records the
+  // owning font's units-per-em for it. Amiri applies `liga` to Latin f-pairs; Inter as baked does not.
   const three = await createThreeTestHandle(t);
   const fontDomain = createThreeFontDomain();
   const font = await fontDomain.loadFont({ baked: dataUrl(await readFile(amiriFontUrl)) }, bitmap({ strikes: [16] }));

--- a/packages/glyph/tests/package/codec-program-provenance.test.mjs
+++ b/packages/glyph/tests/package/codec-program-provenance.test.mjs
@@ -7,11 +7,7 @@ import { id } from '../../dist/config/codec.js';
 const OPTIONS = { scope: 'glyph', bindingF32: ['bearingX'] };
 const BUFFER = { id: id.buffer('test.codec-provenance/position'), scalar: 'f32', lanes: ['x', 'y'] };
 
-/**
- * A value loaded from one program's input table means nothing inside another
- * program: the input index it carries would silently read a different field.
- * Only scope-free constants may cross builders.
- */
+/** A value from one program's input table means nothing in another — its input index could silently read a different field. Only scope-free constants may cross builders. */
 test('storing another scope’s value throws instead of misreading inputs', () => {
   const first = codecProgram(OPTIONS);
   const second = codecProgram(OPTIONS);

--- a/packages/glyph/tests/package/entry-point-boundaries.test.mjs
+++ b/packages/glyph/tests/package/entry-point-boundaries.test.mjs
@@ -1,22 +1,4 @@
-/**
- * Where a name lives, and why.
- *
- * The package publishes one application vocabulary, renderer subpaths, and leaf integration helpers.
- * A name has exactly one home, so a reader never has to guess which subpath to import it from:
- *
- *   `.`        what text IS -- fonts, authoring, layout and measurement types, raster formats,
- *              paint. Every consumer speaks it, whether they render with Three.js or drive the
- *              engine themselves.
- *   `.`        also carries the types applications can encounter through GlyphConfig and handles.
- *   `./config/*` carries renderer-neutral construction helpers for integration authors without
- *              charging every application for the complete integration DSL.
- *   `./three`  the Three.js integration -- `ThreeConfig`, `Text`, `TextGroup`, materials.
- *
- * An integration may re-export a root name ONLY when that name appears in one of its own
- * signatures, because a caller should be able to name what `layout()` returns without
- * reaching for a second subpath. Re-exporting anything else duplicates the vocabulary and makes the
- * import site a coin toss.
- */
+/** A name has exactly one home: `.` for the application vocabulary, `./config/*` for renderer-neutral integration helpers, `./three` for the Three.js integration. An integration re-exports a root name only when it appears in its own signatures. */
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';

--- a/packages/glyph/tests/package/schema-authority.test.mjs
+++ b/packages/glyph/tests/package/schema-authority.test.mjs
@@ -5,12 +5,7 @@ import test from 'node:test';
 
 const sourceRoot = new URL('../../src/', import.meta.url).pathname;
 
-/**
- * The technique schema is the only witness to buffer identity. Nobody else may
- * hold a literal buffer id: not executor lookups, not attribute-name strings,
- * not parallel const tables. Schema declarations (raster formats and the
- * Three codec's own buffers) are the sanctioned definition sites.
- */
+/** The technique schema is the sole witness to buffer identity — no executor lookup, attribute-name string, or parallel const table may hold a literal buffer id outside these sanctioned declaration sites. */
 const DEFINITION_SITES = new Set(['raster/bitmap.ts', 'raster/msdf.ts', 'raster/slug.ts', 'three/codec.ts']);
 
 test('buffer ids appear only inside schema declarations', async () => {

--- a/packages/glyph/tests/package/typegpu-bitmap-parity.test.mjs
+++ b/packages/glyph/tests/package/typegpu-bitmap-parity.test.mjs
@@ -26,20 +26,7 @@ import {
   referenceSnapClipAxis,
 } from '../../dist/shaders/typegpu/bitmap-reference.js';
 
-/**
- * Bitmap authority across the `/three/typegpu` adapter and `/typegpu` implementation.
- *
- * The two sides cannot execute against each other without a GPU, so the pin stands on
- * extractions and mirrors instead of prose:
- *
- * 1. The device-free TSL extraction compiles the canonical `/three/typegpu` graph to the WGSL a
- *    WebGPU run executes, and the shipped TypeGPU stages resolve to WGSL through the
- *    metadata the build embeds. Each source is extracted here, at test time, from built
- *    artifacts. The TSL program must call the same TypeGPU helpers as the direct
- *    stages rather than carrying a second native implementation.
- * 2. Every CPU-callable shader function is compared against its CPU reference mirror,
- *    so the mirrors cannot silently drift from what ships.
- */
+/** No GPU means parity is pinned via extraction, not execution: `/three/typegpu` must call the shipped TypeGPU helpers, and every CPU-callable shader function must match its reference mirror. */
 
 /** Collapse shader text so formulas can be matched whitespace-insensitively. */
 function flatten(source) {

--- a/packages/glyph/tests/support/extract-bitmap-tsl-shader.mjs
+++ b/packages/glyph/tests/support/extract-bitmap-tsl-shader.mjs
@@ -3,22 +3,7 @@ import * as THREE from 'three/webgpu';
 
 import { bitmapShader } from '../../dist/three/typegpu.js';
 
-/**
- * Compiles the canonical TSL Bitmap material to shader source without a GPU device.
- *
- * Node builds are pure text generation, so a real renderer over an offscreen canvas
- * stand-in reaches the generated WGSL that a hardware WebGPU run would execute. The
- * instance nodes are plain per-vertex attributes and the coverage page is an unsigned
- * byte data array — the same resource kinds the command-buffer executor binds — so the
- * extracted source is the authoritative statement of what `/three/typegpu` produces for Bitmap.
- *
- * `renderer.hasFeature` is stubbed because it is the only builder input that requires
- * an adapter; Bitmap reads its pages through data-texture texel loads, so no optional
- * filtering feature can change the generated source.
- *
- * @param {{ pixelSnapping: boolean }} options Variant selector for the clip placement.
- * @returns {{ vertex: string, fragment: string }} Generated WGSL per stage.
- */
+/** Compiles `/three/typegpu` Bitmap to WGSL without a GPU device. `renderer.hasFeature` is stubbed because data-texture texel loads do not depend on optional filtering. */
 export function extractBitmapTslShader({ pixelSnapping }) {
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0, 0, 1, 0], 3));

--- a/packages/glyph/tests/support/text-mutation-lanes.mjs
+++ b/packages/glyph/tests/support/text-mutation-lanes.mjs
@@ -1,20 +1,4 @@
-/**
- * Differential harness for incremental mutation, read through to the GPU.
- *
- * The oracle is construction from scratch. A node edited into some content may not differ, in any
- * lane, from a node built with that content: same glyphs, same layout, same packed bytes. That
- * invariant needs no knowledge of what each buffer means, so it holds as techniques and packing
- * policies change, and it is the only oracle that sees a record slot left holding its pre-edit
- * occupant -- every engine-side lane reads correct while the GPU samples the wrong glyph.
- *
- * Both sides of every comparison are produced by the same packing code from the same authored
- * inputs, so every lane is compared bit-for-bit. Rounding here would hide exactly the corruption
- * this harness exists to detect: a stale slot whose retained bytes happen to be close to the
- * correct ones.
- *
- * This module owns the oracle and the scene plumbing. Each test file owns its own corpus, fixture
- * set, and authoring helpers, so the invariant cannot drift between the files that assert it.
- */
+/** Differential harness: an edited node must be indistinguishable, lane for lane and bit for bit, from one built fresh from the same content — no rounding, since that would hide a stale slot whose retained bytes are merely close. This module owns the oracle and scene plumbing; each test file owns its own corpus. */
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { gunzipSync } from 'node:zlib';
@@ -39,12 +23,7 @@ let nextMountedHandle = 1;
 
 await glyph.init();
 
-/**
- * One immutable font per fixture, for the lifetime of a test file.
- *
- * Every mount is a scene built on top of them, so loading per test would retain dozens of runtimes
- * and re-bake identical rasters for no additional coverage.
- */
+/** One immutable font per fixture, cached for the file's lifetime — loading per test would retain dozens of runtimes and re-bake identical rasters for no added coverage. */
 export function createFontCache(specs) {
   const loaded = new Map();
   return {
@@ -120,14 +99,7 @@ function structuralProperties(properties) {
   return { ...rest, text: txt(strings, ...values) };
 }
 
-/**
- * Read every lane a scene exposes, engine-side and GPU-side.
- *
- * Every draw in a group shares one retained buffer per codec lane and addresses its own run
- * through `pmndrsGlyphRunStart`, so a lane must be read from `start` rather than from the head of
- * the array. Only the run's own `instanceCount` records are read: capacity beyond it is allowed to
- * hold anything, and asserting it would fail on legal slack rather than on a defect.
- */
+/** Every draw shares one retained buffer per lane, addressing its own run via `pmndrsGlyphRunStart` — read from `start`, not the array head. Only `instanceCount` records are read; capacity beyond it may hold anything. */
 export function lanes(mounted) {
   const draws = [];
   mounted.scene.traverse((object) => {
@@ -183,15 +155,7 @@ export function lanes(mounted) {
   };
 }
 
-/**
- * Assert an edited scene is indistinguishable from one built with the same content.
- *
- * Stable ids are compared separately and only for length: identity is expected to differ, because
- * retaining a glyph across an edit is the point of the incremental path. That exemption covers the
- * packed identity lane too -- it carries the same allocation-order ids -- so that lane is instead
- * held to a local invariant, resolved through `identityPositions` below. Every other lane, packed
- * bytes included, must agree exactly with the fresh build.
- */
+/** Stable/packed identity lanes are exempt from direct fresh-build comparison — retaining a glyph's identity across an edit is the point — and are instead held to the local invariant in `identityPositions` below. Every other lane must match exactly. */
 export function assertMatchesFreshBuild(font, mounted, paragraphs, context) {
   const fresh = mount(font, paragraphs);
   try {
@@ -265,20 +229,7 @@ function assertTransformBindings(scene, draw, where) {
   }
 }
 
-/**
- * Where each of a draw's slots sits in the scene's own committed identity list.
- *
- * The identity lane cannot be compared to the fresh build's values -- retaining a glyph across an
- * edit is the point of the incremental path, so the numbers legitimately differ -- and it cannot be
- * compared to a positional slice of the committed list either: a glyph that renders nothing, a
- * space above all, is committed with an identity but occupies no record slot, so the k-th slot is
- * not the k-th committed glyph. Resolving each slot's identity back to its INDEX in the committed
- * list removes both problems. The resulting index list says which committed glyphs this draw
- * renders and in what order, which is directly comparable between the two builds.
- *
- * A slot holding its pre-edit occupant fails this either way: if that identity was freed it
- * resolves to nothing, and if it was handed to another glyph it resolves to the wrong index.
- */
+/** Resolves each slot's identity to its index in the scene's own committed identity list — directly comparable between builds despite identities differing across edits, and unaffected by non-rendering glyphs (e.g. a space) that consume an identity but no record slot. */
 function identityPositions(scene, draw, where) {
   const identities = draw.attributes[IDENTITY_LANE];
   assert.equal(


### PR DESCRIPTION
## What

Every comment longer than two lines across `packages/` and `apps/` was summarised, checked against the code beside it, and then condensed to at most two lines — or removed when it recorded a decision, a changelog, or a story rather than a fact about the adjacent code.

## Scope

| | |
|---|---|
| Files changed | 168 |
| Comments processed | 342 (331 found by AST span, plus 11 consecutive-`//` groups the span scan misses) |
| Remaining comments over two lines | **0** across `packages/` and `apps/` |
| Net | 356 insertions, 2,563 deletions |

## Proof the change is inert

Stripping every AST comment span from all 168 changed files leaves their code **byte-identical to `de89cf70`**. Independently, `release:size:check` reports an **identical `sha256` for every JavaScript artifact** — `browser-core`, `three-runtime-js`, `glyph-config-js`, `tsl-subpath-js` and the rest all unchanged. Comments do not survive the build, so no shipped byte moved.

Full suite: **937 tests, 937 pass, 0 fail** — identical to the pre-sweep baseline.

## What was kept

Per [the standard](.agents/docs/engineering/code-style.md#L145), a comment earns its place for non-obvious ownership, safety, protocol, performance, or mathematical invariants. Those were condensed, never dropped. Also preserved deliberately:

- **MIT license attribution** on the Slug-derived shaders (`tsl/slug-shaders/*`). The rule says delete attribution; these function as provenance notices, so they were kept.
- **Golden-value provenance** in tests — a pinned constant with no recorded origin is unmaintainable.
- **Measurement invariants** in the benchmark harness — warmup counts, settle predicates, sample validity.
- All directive pragmas verbatim, including `@vitest-environment`, whose loss would silently change a test environment.

`/* @workflow { … } */` blocks are machine-parsed metadata backing `pnpm scripts`, not prose. They are normalised onto one line with every JSON field preserved verbatim; all **80** workflows still resolve, and `Usage` / `Requires` / `Writes` / `Source` still render.

## One false claim corrected

`apps/benchmarks/src/benchmark/scenarios.ts` described "one natural measurement plus twenty-five constrained probes" (26) where the assertion checks `!== 24`. Tracing every `calls.measure` increment through `uikit-layout-fixture.ts` and `paragraph-contracts.ts:231-246` gives 1 natural + 3 explicit probes + 20 repeated `atMost` = **24**. Replaced with the verified count.

A second false claim was removed rather than corrected: `engine-sequence-property.test.mjs` claimed weighted operation selection, but `pick()` is uniform (`values[Math.floor(random() * values.length)]`) and `OPERATIONS` has no duplicate entries — no weighting mechanism exists.

## Known gap

`ast-grep --kind comment` emits each `//` line as its own node, so a multi-line `//` block never trips a span-based length filter. Consecutive-`//` runs were therefore swept by an explicit grouping pass. Anyone repeating this sweep needs that second pass; the AST method alone silently misses them.

## Not addressed

Two test headers in `text-mutation-gpu-lanes` and `text-mutation-script-topology` carried a "NOT COVERED: stable-indirect allocation policy" disclosure that did not fit the two-line cap. That is real coverage-gap knowledge and now lives only in git history — it likely deserves an issue rather than a comment.
